### PR TITLE
ci(octo-ci-status): drop unused run_id input from caller

### DIFF
--- a/.github/workflows/octo-ci-status.yml
+++ b/.github/workflows/octo-ci-status.yml
@@ -13,7 +13,6 @@ jobs:
       repo_name: ${{ github.event.workflow_run.repository.name }}
       workflow_name: ${{ github.event.workflow_run.name }}
       conclusion: ${{ github.event.workflow_run.conclusion }}
-      run_id: ${{ github.event.workflow_run.id }}
       run_url: ${{ github.event.workflow_run.html_url }}
       project_group_id: "a48e308c2ead4d9dbcdc30fff0f01eaf"
     secrets:


### PR DESCRIPTION
## Drop unused `run_id` input from caller

The `run_id` input is declared in the reusable workflow `Mininglamp-OSS/.github/.github/workflows/octo-ci-status.yml` but is never read in any of the steps (only `REPO_NAME`, `WORKFLOW_NAME`, `CONCLUSION`, `RUN_URL`, `PROJECT_GROUP_ID` are consumed). This PR removes the unused caller-side argument.

### What changed
- Removed `run_id: ${{ github.event.workflow_run.id }}` from the `with:` block in `.github/workflows/octo-ci-status.yml`

### Dependency & merge order

This PR is **paired with** [`Mininglamp-OSS/.github` PR #1](https://github.com/Mininglamp-OSS/.github/pull/1), which changes the reusable workflow declaration from `required: true` to `required: false`.

**⚠️ Merge order required:**
1. Merge `Mininglamp-OSS/.github` PR #1 first (makes `run_id` optional in the reusable workflow)
2. Then merge this PR (octo-admin #5) and the sibling [octo-server #14](https://github.com/Mininglamp-OSS/octo-server/pull/14)

Merging this PR before `.github` PR #1 will break `Octo CI Status` notifications on `octo-admin/main` with a "Required input run_id not supplied" error.

### Review checklist
- [x] Reusable workflow (`Mininglamp-OSS/.github` PR #1) updates `run_id` to `required: false` before this merges
- [x] No other workflow in `octo-admin/.github/workflows/` calls the same reusable workflow
- [x] All other required inputs (`repo_name`, `workflow_name`, `conclusion`, `run_url`, `project_group_id`) and `OCTO_BOT_TOKEN` secret are unchanged