### PR TITLE
ci: improve GitHub Actions workflows for octo-admin

### DIFF
--- a/.github/workflows/octo-ci-status.yml
+++ b/.github/workflows/octo-ci-status.yml
@@ -16,5 +16,6 @@ jobs:
       run_id: ${{ github.event.workflow_run.id }}
       run_url: ${{ github.event.workflow_run.html_url }}
       project_group_id: "a48e308c2ead4d9dbcdc30fff0f01eaf"
+      workflow_id: ${{ github.event.workflow_run.workflow_id }}
     secrets:
       OCTO_BOT_TOKEN: ${{ secrets.OCTO_BOT_TOKEN }}

--- a/.github/workflows/pr-merged-done.yml
+++ b/.github/workflows/pr-merged-done.yml
@@ -17,6 +17,8 @@ on:
   pull_request_target:
     types: [closed]
 
+permissions: {}  # GITHUB_TOKEN not used; PROJECT_TOKEN is passed explicitly
+
 jobs:
   move-to-done:
     if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == github.event.repository.default_branch


### PR DESCRIPTION
## Changes

### C: Add `workflow_id` to `octo-ci-status.yml`

Added `workflow_id: ${{ github.event.workflow_run.workflow_id }}` to the `with` block in `octo-ci-status.yml` so the CI status notification includes the workflow identifier.

### D: Add `permissions: {}` to `pr-merged-done.yml`

Adds explicit `permissions: {}` block between `on:` and `jobs:` to clarify that `GITHUB_TOKEN` is not used; only `PROJECT_TOKEN` is passed explicitly.