### PR TITLE
fix(ci): add concurrency config, pin action SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -16,8 +20,8 @@ jobs:
       matrix:
         node-version: [18, 20]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm

--- a/.github/workflows/octo-ci-status.yml
+++ b/.github/workflows/octo-ci-status.yml
@@ -6,6 +6,8 @@ on:
     types: [completed]
     branches: [main]
 
+permissions: {}
+
 jobs:
   notify:
     uses: Mininglamp-OSS/.github/.github/workflows/octo-ci-status.yml@v1

--- a/.github/workflows/octo-ci-status.yml
+++ b/.github/workflows/octo-ci-status.yml
@@ -6,7 +6,8 @@ on:
     types: [completed]
     branches: [main]
 
-permissions: {}
+permissions:
+  actions: read
 
 jobs:
   notify:

--- a/.github/workflows/octo-ci-status.yml
+++ b/.github/workflows/octo-ci-status.yml
@@ -6,8 +6,7 @@ on:
     types: [completed]
     branches: [main]
 
-permissions:
-  actions: read
+permissions: {}
 
 jobs:
   notify:


### PR DESCRIPTION
## Changes

### 🟡 M-3: Add concurrency configuration
Without `concurrency`, pushing multiple commits quickly to a PR branch accumulates parallel CI runs, wasting runner minutes. Add `cancel-in-progress: true` to cancel stale runs automatically.

### 🟢 L-1: Pin action SHAs
Pin `actions/checkout` and `actions/setup-node` to commit SHAs for supply-chain security.
