### PR TITLE
feat(users): push type filter to backend (bot_only/system_only/exclude_*)

### DIFF
--- a/src/pages/Spaces/index.tsx
+++ b/src/pages/Spaces/index.tsx
@@ -86,14 +86,19 @@ export default function Spaces() {
     const seq = ++userSearchSeq.current
     setUserSearching(true)
     try {
-      const params = new URLSearchParams({ page_index: '1', page_size: '20' })
+      const params = new URLSearchParams({
+        page_index: '1',
+        page_size: '20',
+        exclude_bot: '1',
+        exclude_system: '1',
+      })
       if (kw) params.append('keyword', kw)
       const res = await api.get<{ list: UserOptionRaw[] }>(
         `/v1/manager/user/list?${params}`,
       )
       if (seq === userSearchSeq.current) {
         const list = (res.data.list || []).filter(
-          (u) => u.status === 1 && u.is_destroy !== 1 && !u.uid?.endsWith('_bot'),
+          (u) => u.status === 1 && u.is_destroy !== 1,
         )
         setUserOptions(list)
       }

--- a/src/pages/Users/index.tsx
+++ b/src/pages/Users/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import { Table, Input, Button, Select, message, Modal, Tooltip, Typography } from 'antd'
-import { SearchOutlined, ReloadOutlined, RobotOutlined } from '@ant-design/icons'
+import { SearchOutlined, ReloadOutlined, RobotOutlined, SettingOutlined } from '@ant-design/icons'
 import type { ColumnsType } from 'antd/es/table'
 import api from '../../api'
 
@@ -15,8 +15,13 @@ interface User {
   status: number
   online: number
   is_destroy: number
+  is_bot?: number
+  is_system?: number
   register_time: string
 }
+
+type TypeFilter = 'all' | 'human' | 'bot' | 'system'
+type StatusFilter = 'all' | 'online' | 'offline' | 'banned' | 'destroyed'
 
 export default function Users() {
   const [loading, setLoading] = useState(false)
@@ -25,17 +30,31 @@ export default function Users() {
   const [page, setPage] = useState(1)
   const [keyword, setKeyword] = useState('')
   const [pageSize, setPageSize] = useState(20)
-  const [typeFilter, setTypeFilter] = useState<'all' | 'human' | 'bot'>('all')
-  const [statusFilter, setStatusFilter] = useState<'all' | 'online' | 'offline' | 'banned' | 'destroyed'>('all')
+  const [typeFilter, setTypeFilter] = useState<TypeFilter>('all')
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all')
 
-  const fetchData = async () => {
+  const fetchData = async (
+    nextPage = page,
+    nextPageSize = pageSize,
+    nextType = typeFilter,
+    kw = keyword,
+  ) => {
     setLoading(true)
     try {
       const params = new URLSearchParams({
-        page_index: page.toString(),
-        page_size: pageSize.toString(),
+        page_index: nextPage.toString(),
+        page_size: nextPageSize.toString(),
       })
-      if (keyword) params.append('keyword', keyword)
+      if (kw) params.append('keyword', kw)
+      // 类型筛选全部下推到后端，分页基于过滤后结果
+      if (nextType === 'human') {
+        params.append('exclude_bot', '1')
+        params.append('exclude_system', '1')
+      } else if (nextType === 'bot') {
+        params.append('is_bot', '1')
+      } else if (nextType === 'system') {
+        params.append('is_system', '1')
+      }
       const res = await api.get(`/v1/manager/user/list?${params}`)
       setData(res.data.list || [])
       setTotal(res.data.count || 0)
@@ -47,24 +66,32 @@ export default function Users() {
   }
 
   useEffect(() => {
-    fetchData()
-  }, [page, pageSize])
+    fetchData(page, pageSize, typeFilter, keyword)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [page, pageSize, typeFilter])
 
+  // 类型筛选已下推到后端；状态筛选仍是当前页客户端过滤（后端尚未支持）
   const filteredData = useMemo(() => {
     return data.filter((u) => {
-      if (typeFilter === 'bot' && !u.uid?.endsWith('_bot')) return false
-      if (typeFilter === 'human' && u.uid?.endsWith('_bot')) return false
       if (statusFilter === 'destroyed' && u.is_destroy !== 1) return false
       if (statusFilter === 'banned' && u.status !== 0) return false
       if (statusFilter === 'online' && !(u.online === 1 && u.status === 1 && u.is_destroy !== 1)) return false
       if (statusFilter === 'offline' && !(u.online !== 1 && u.status === 1 && u.is_destroy !== 1)) return false
       return true
     })
-  }, [data, typeFilter, statusFilter])
+  }, [data, statusFilter])
 
   const handleSearch = () => {
-    setPage(1)
-    fetchData()
+    if (page !== 1) {
+      setPage(1)
+    } else {
+      fetchData(1, pageSize, typeFilter, keyword)
+    }
+  }
+
+  const handleTypeFilterChange = (v: TypeFilter) => {
+    setTypeFilter(v)
+    if (page !== 1) setPage(1)
   }
 
   const handleBan = async (uid: string, status: number) => {
@@ -73,12 +100,10 @@ export default function Users() {
       onOk: async () => {
         await api.put(`/v1/manager/user/liftban/${uid}/${status}`)
         message.success(status === 0 ? '已封禁' : '已解封')
-        fetchData()
+        fetchData(page, pageSize, typeFilter, keyword)
       },
     })
   }
-
-  const isBot = (uid: string) => uid?.endsWith('_bot')
 
   const columns: ColumnsType<User> = [
     {
@@ -89,11 +114,15 @@ export default function Users() {
       render: (name, record) => (
         <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
           <span className="cell-primary">{name}</span>
-          {isBot(record.uid) && typeFilter !== 'bot' && (
+          {record.is_system === 1 ? (
+            <span className="ai-tag" aria-label="系统账号">
+              <SettingOutlined /> 系统
+            </span>
+          ) : record.is_bot === 1 ? (
             <span className="ai-tag" aria-label="Bot 账号">
               <RobotOutlined /> BOT
             </span>
-          )}
+          ) : null}
         </span>
       ),
     },
@@ -183,12 +212,13 @@ export default function Users() {
         />
         <Select
           value={typeFilter}
-          onChange={setTypeFilter}
-          style={{ width: 120 }}
+          onChange={handleTypeFilterChange}
+          style={{ width: 130 }}
           options={[
             { value: 'all', label: '全部类型' },
             { value: 'human', label: '真实用户' },
             { value: 'bot', label: 'Bot 账号' },
+            { value: 'system', label: '系统账号' },
           ]}
         />
         <Select
@@ -206,7 +236,7 @@ export default function Users() {
         <Button type="primary" icon={<SearchOutlined />} onClick={handleSearch}>
           搜索
         </Button>
-        <Button icon={<ReloadOutlined />} onClick={fetchData}>
+        <Button icon={<ReloadOutlined />} onClick={() => fetchData()}>
           刷新
         </Button>
       </div>

--- a/src/pages/Users/index.tsx
+++ b/src/pages/Users/index.tsx
@@ -51,9 +51,9 @@ export default function Users() {
         params.append('exclude_bot', '1')
         params.append('exclude_system', '1')
       } else if (nextType === 'bot') {
-        params.append('is_bot', '1')
+        params.append('bot_only', '1')
       } else if (nextType === 'system') {
-        params.append('is_system', '1')
+        params.append('system_only', '1')
       }
       const res = await api.get(`/v1/manager/user/list?${params}`)
       setData(res.data.list || [])

--- a/src/pages/Users/index.tsx
+++ b/src/pages/Users/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { Table, Input, Button, Select, message, Modal, Tooltip, Typography } from 'antd'
 import { SearchOutlined, ReloadOutlined, RobotOutlined, SettingOutlined } from '@ant-design/icons'
 import type { ColumnsType } from 'antd/es/table'
@@ -32,6 +32,8 @@ export default function Users() {
   const [pageSize, setPageSize] = useState(20)
   const [typeFilter, setTypeFilter] = useState<TypeFilter>('all')
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all')
+  // 序号守卫：快速切换筛选/分页时，仅采用最近一次请求的响应，避免错序覆盖
+  const fetchSeq = useRef(0)
 
   const fetchData = async (
     nextPage = page,
@@ -39,6 +41,7 @@ export default function Users() {
     nextType = typeFilter,
     kw = keyword,
   ) => {
+    const seq = ++fetchSeq.current
     setLoading(true)
     try {
       const params = new URLSearchParams({
@@ -56,12 +59,17 @@ export default function Users() {
         params.append('system_only', '1')
       }
       const res = await api.get(`/v1/manager/user/list?${params}`)
+      if (seq !== fetchSeq.current) return
       setData(res.data.list || [])
       setTotal(res.data.count || 0)
     } catch (error) {
-      message.error((error as Error).message)
+      if (seq === fetchSeq.current) {
+        message.error((error as Error).message)
+      }
     } finally {
-      setLoading(false)
+      if (seq === fetchSeq.current) {
+        setLoading(false)
+      }
     }
   }
 


### PR DESCRIPTION
> Supersedes #15 (closed automatically when the source branch was renamed from `understand-user-list-apis` to `feat/users-type-filter`).

**Depends on Mininglamp-OSS/octo-server#63** — ✅ merged on 2026-05-16 (commit `c2b549f`). Frontend can ship after the backend release reaches the target environment.

## Summary

Backend \`GET /v1/manager/user/list\` has been extended with new response fields (\`is_bot\`, \`is_system\`) and new query parameters. This PR aligns the frontend.

### Backend contract (confirmed)

\`\`\`
page_index      int  required  page index
page_size       int  required  page size
keyword         str  optional  fuzzy search on name/UID/phone/email/short_no
online          int  optional  -1=all 0=offline 1=online
exclude_bot     int  optional  1 = exclude user.robot=1
exclude_system  int  optional  1 = exclude built-in system accounts
bot_only        int  optional  1 = only user.robot=1                    (introduced in octo-server#63)
system_only     int  optional  1 = only built-in system accounts        (introduced in octo-server#63)
\`\`\`

### Users page (User Management)
- Type filter is fully pushed to the backend, so pagination reflects the filtered result set:
  - Real users → \`exclude_bot=1 & exclude_system=1\`
  - Bot accounts → \`bot_only=1\`
  - System accounts → \`system_only=1\` (new option)
- Badge rendering uses the new \`is_bot\` / \`is_system\` fields. "System" takes priority over "Bot".
- Drop the \`uid.endsWith('_bot')\` heuristic.
- \`fetchData\` now takes explicit args (\`page\`, \`pageSize\`, \`type\`, \`keyword\`) to avoid stale-closure bugs when \`typeFilter\` changes before Search is pressed.
- \`fetchData\` uses a \`useRef\` sequence guard so out-of-order responses from rapid filter switching cannot overwrite the table (mirrors the pattern already in Spaces). _Addresses review feedback from Jerry-Xin / yujiawei / lml2468._

### Spaces page (Create Space → Owner picker)
- Request now includes \`exclude_bot=1 & exclude_system=1\` so the backend filters out non-human accounts.
- Client-side filter reduced to \`status === 1 && is_destroy !== 1\`. The \`_bot\` suffix hack is gone.

## Release ordering

Backend must be deployed first. Until octo-server#63 is live in the target environment, \`bot_only=1\` / \`system_only=1\` will be silently ignored and the type filter will return unfiltered results.

## Test plan

- [ ] User Management → "All types": pagination and total work as before
- [ ] User Management → "Real users": no BOT / system badges in the list
- [ ] User Management → "Bot accounts": every row shows a BOT badge; \`total\` is the bot count
- [ ] User Management → "System accounts": every row shows a system badge
- [ ] User Management → switching type resets to page 1 and refetches
- [ ] User Management → typing a keyword without pressing Search, then switching type, sends both the new type and the typed keyword
- [ ] User Management → rapid filter toggling (bot → system → human within ~1s) leaves the table consistent with the final selection
- [ ] Spaces → Create Space → Owner picker: bot and system accounts are absent from results