### PR TITLE
ci: build and publish multi-arch Docker images to Docker Hub

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -250,7 +250,13 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+            # `:MAJOR` alias is intentionally suppressed for v0.* releases.
+            # SemVer §4 explicitly permits breaking changes between any two
+            # 0.y.z versions, so a `:0` alias would falsely imply a stable
+            # major-0 stream. Once the project hits v1.0.0 the alias fires
+            # automatically (`:1`, `:2`, ...) with the usual major-stream
+            # backwards-compat contract.
+            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
             type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Create manifest list and push

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,276 @@
+name: Docker Publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Image tag to publish. Must match Docker tag grammar ^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,127}$, must NOT look like a semver alias (1, 1.2, v1.2.3, ...), and from non-default branches must be prefixed with "test-".'
+        required: true
+
+permissions:
+  contents: read
+
+concurrency:
+  # Serialize ALL publishes to this image so two close-together v* tags can't
+  # race on the shared mutable tags (:latest, :MAJOR, :MAJOR.MINOR) — last
+  # writer wins, and "last finished" is not necessarily "newest version".
+  #
+  # KNOWN TRADEOFF: GitHub Actions concurrency holds at most ONE pending run
+  # per group; a newer pending run replaces the older one even with
+  # `cancel-in-progress: false`. So if you push v1.0.0 (running), v1.0.1
+  # (queued), v1.0.2 (queued) in quick succession, v1.0.1 will be canceled
+  # by v1.0.2 and never publish. Workaround: wait for each release to finish
+  # publishing before pushing the next tag. We accept this over the
+  # alternative (no concurrency = consistent :latest race on every overlap)
+  # because real release cadence is minutes-to-hours apart and protecting
+  # :latest is the higher-value invariant.
+  #
+  # NOTE: workflow-level concurrency.group only accepts github/inputs/vars
+  # contexts (not env), so the image name is hard-coded here. Keep this group
+  # name in sync with env.IMAGE_NAME below if you ever rename the image.
+  group: docker-publish-mininglamposs-octo-admin
+  cancel-in-progress: false
+
+env:
+  IMAGE_NAME: mininglamposs/octo-admin
+
+jobs:
+  validate:
+    # No-secret preflight: rejects bad inputs/refs BEFORE any job that holds
+    # Docker Hub credentials runs. Catches command-injection attempts,
+    # invalid Docker tag grammar, semver-alias clobbering, and manual
+    # publishes from unreviewed refs — all before any registry write.
+    name: Validate inputs and ref
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate tag push ref
+        if: github.event_name == 'push'
+        env:
+          REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          # Require strict semver per semver.org §9 (with mandatory leading 'v')
+          # so metadata-action's type=semver actually matches. A loose regex
+          # would let near-semver refs (e.g. 'vfoo', 'v01.2.3', 'v1.2.3-01',
+          # 'v1.2.3-..') reach the secret-bearing build job and push orphan
+          # digests before metadata-action quietly emits no tags — defeating
+          # the no-secret preflight intent.
+          #
+          # The regex below is the official semver.org regex (BRE/ERE form),
+          # prefixed with a literal 'v' and WITHOUT the optional +BUILD
+          # metadata suffix. Build metadata is rejected because
+          # metadata-action's {{version}}/{{major}}/{{major}}.{{minor}}
+          # patterns strip the +BUILD portion when computing Docker tag
+          # names, so v1.2.3 and v1.2.3+build.1 would both publish to
+          # :1.2.3 / :1.2 / :1 / :latest — two distinct git tags clobbering
+          # the same release aliases, breaking the no-clobber invariant.
+          #
+          # Rejects:
+          #   - leading zeros in numeric identifiers (v01.2.3, v1.2.3-01)
+          #   - empty dot-separated identifiers (v1.2.3-..)
+          #   - any +BUILD metadata (v1.2.3+build.1)
+          #   - characters outside [0-9A-Za-z.-]
+          tag="${REF#refs/tags/}"
+          semver='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?$'
+          if ! printf '%s' "$tag" | grep -Eq "$semver"; then
+            echo "::error::tag '$tag' is not strict semver per semver.org without +BUILD metadata (vMAJOR.MINOR.PATCH[-PRERELEASE]); refusing to publish"
+            exit 1
+          fi
+          echo "OK: $REF"
+
+      - name: Validate workflow_dispatch input and ref
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+          REF: ${{ github.ref }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+
+          # Docker image tag grammar (also blocks shell metacharacters as a
+          # side effect — only [A-Za-z0-9_.-] are allowed and length <= 128).
+          if ! printf '%s' "$INPUT_TAG" | grep -Eq '^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,127}$'; then
+            echo "::error::tag '$INPUT_TAG' violates Docker tag grammar ^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,127}$"
+            exit 1
+          fi
+
+          # Reserved auto-managed names — manual dispatch must not clobber them.
+          case "$INPUT_TAG" in
+            latest|main|master)
+              echo "::error::tag '$INPUT_TAG' is reserved/auto-managed; pick a different name"
+              exit 1
+              ;;
+          esac
+
+          # Semver-alias shapes (e.g. 1, 1.2, 1.2.3, v1.2.3) are reserved for
+          # the auto-managed major / major.minor / major.minor.patch / version
+          # aliases populated by tag-push events. A manual dispatch with
+          # these shapes would race with / overwrite the next real release.
+          if printf '%s' "$INPUT_TAG" | grep -Eq '^v?[0-9]+(\.[0-9]+){0,2}([+-].+)?$'; then
+            echo "::error::tag '$INPUT_TAG' looks like a semver alias; manual publishes must use a non-semver name (or prefix with 'test-')"
+            exit 1
+          fi
+
+          # Restrict manual publishes from non-default branches to the
+          # 'test-' namespace so feature-branch experimentation cannot land
+          # in the official release tag space. Read the default branch from
+          # repository metadata so a future rename doesn't silently weaken
+          # this guard.
+          DEFAULT_REF="refs/heads/${DEFAULT_BRANCH}"
+          if [ "$REF" != "$DEFAULT_REF" ]; then
+            case "$INPUT_TAG" in
+              test-*) echo "OK: non-default ref '$REF' with test- prefix" ;;
+              *)
+                echo "::error::manual publishes from '$REF' must use a 'test-*' tag (got '$INPUT_TAG'); merge to ${DEFAULT_BRANCH} for official tags"
+                exit 1
+                ;;
+            esac
+          fi
+
+          echo "OK: dispatch from $REF with tag '$INPUT_TAG'"
+
+  build:
+    name: Build ${{ matrix.platform }}
+    runs-on: ${{ matrix.runner }}
+    needs: validate
+    # `docker-hub-publish` environment gates the Docker Hub credentials:
+    #   - required reviewers (Mininglamp-OSS/maintainers team)
+    #   - deployment ref allowlist: refs/heads/main, refs/tags/v*
+    # No DOCKERHUB_* secret reaches a runner until a maintainer approves
+    # the run in the Actions UI.
+    environment: docker-hub-publish
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=docker-publish-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=docker-publish-${{ matrix.arch }}
+          # Disable provenance attestation so the final manifest list doesn't
+          # carry an extra "unknown/unknown" platform entry that confuses some
+          # registry UIs and scanners.
+          provenance: false
+
+      - name: Export digest
+        env:
+          BUILD_DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/digests
+          touch "/tmp/digests/${BUILD_DIGEST#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: digests-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Create multi-arch manifest
+    runs-on: ubuntu-latest
+    needs: build
+    # Same gate as `build` — manifest creation also needs Docker Hub creds.
+    # The single approval at the start of the run covers both jobs.
+    environment: docker-hub-publish
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          # `flavor: latest=auto` is the metadata-action default, set explicitly
+          # so the prerelease-skipping behavior is visible without consulting
+          # action docs. With latest=auto + a {{version}} semver tag entry,
+          # `:latest` is published for stable releases (v1.2.3) and skipped
+          # for prereleases (v1.2.3-rc1).
+          flavor: |
+            latest=auto
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        env:
+          IMAGE: ${{ env.IMAGE_NAME }}
+          METADATA: ${{ steps.meta.outputs.json }}
+        run: |
+          set -euo pipefail
+          # Build "-t TAG" args as an array — never interpolate tags into the
+          # shell command line, which would be a command-injection vector
+          # if metadata-action ever emitted a tag containing shell syntax.
+          tags=()
+          while IFS= read -r tag; do
+            tags+=(-t "$tag")
+          done < <(jq -r '.tags[]' <<< "$METADATA")
+
+          if [ ${#tags[@]} -eq 0 ]; then
+            echo "::error::metadata-action produced no tags; refusing to publish manifest"
+            exit 1
+          fi
+
+          # Digest filenames in /tmp/digests are SHA-256 hex strings (validated
+          # by upload-artifact's if-no-files-found:error and the controlled
+          # filename derived from build.outputs.digest), safe to feed in.
+          sources=()
+          for f in *; do
+            sources+=("${IMAGE}@sha256:${f}")
+          done
+
+          docker buildx imagetools create "${tags[@]}" "${sources[@]}"
+
+      - name: Inspect image
+        env:
+          IMAGE: ${{ env.IMAGE_NAME }}
+          PRIMARY_TAG: ${{ steps.meta.outputs.version }}
+        run: |
+          set -euo pipefail
+          docker buildx imagetools inspect "${IMAGE}:${PRIMARY_TAG}"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -114,6 +114,22 @@ jobs:
             exit 1
           fi
 
+          # Reject tag refs for workflow_dispatch. metadata-action's
+          # type=semver patterns fire on refs/tags/v* even on dispatch
+          # events, so dispatching from a tag ref would simultaneously
+          # emit the auto-managed semver aliases (:MAJOR / :MAJOR.MINOR /
+          # :latest, from the tag's version) AND the raw input tag,
+          # silently overwriting an existing release. The GitHub web UI
+          # only offers branch refs in the "Run workflow" dropdown, but
+          # the REST/GraphQL API accepts any ref — close that gap here.
+          case "$REF" in
+            refs/heads/*) ;;
+            *)
+              echo "::error::workflow_dispatch must be triggered from a branch ref (got '$REF'). Publishing from a tag ref would double-emit auto-managed release aliases. Use 'git push origin v<X.Y.Z>' for tag releases."
+              exit 1
+              ;;
+          esac
+
           # Restrict manual publishes from non-default branches to the
           # 'test-' namespace so feature-branch experimentation cannot land
           # in the official release tag space. Read the default branch from


### PR DESCRIPTION
## Summary

Add a hardened `docker-publish.yml` workflow that publishes `mininglamposs/octo-admin` to Docker Hub on every `v*` tag push. Direct port of the latest converged version from sibling repos ([`octo-server#72`](https://github.com/Mininglamp-OSS/octo-server/pull/72), [`octo-matter#18`](https://github.com/Mininglamp-OSS/octo-matter/pull/18), [`octo-smart-summary#15`](https://github.com/Mininglamp-OSS/octo-smart-summary/pull/15), [`octo-web#42`](https://github.com/Mininglamp-OSS/octo-web/pull/42)) — five PRs worth of review iteration baked in.

## Architecture

- `linux/amd64` + `linux/arm64` on **native runners** (`ubuntu-latest` + `ubuntu-24.04-arm`) — no QEMU
- Build uses the existing `./Dockerfile` (Node 18 build → nginx runtime)
- Push-by-digest per arch → merge into multi-arch manifest

## Hardening (converged baseline)

- All third-party actions pinned to commit SHAs
- **No-secret `validate` job** runs first; `build`/`merge` declare `needs: validate`
  - Tag push: strict semver per semver.org §9 **without** `+BUILD` metadata (prevents `v1.2.3` and `v1.2.3+build.1` clobbering the same `:MAJOR`/`:MAJOR.MINOR`/`:latest` aliases)
  - `workflow_dispatch`: Docker tag grammar + reserved-name + semver-alias-shape + non-default-branch `test-*` namespace
- **Command-injection-safe shell**: every external input via `env:`, `imagetools` args built as bash arrays
- **`docker-hub-publish` GitHub Environment** gate (already configured in repo settings):
  - Required reviewer: `Mininglamp-OSS/maintainers` team
  - Deployment ref allowlist: `main` branch + `v*` tags
- Per-arch GHA cache scope (`docker-publish-ARCH`)
- `provenance: false` (no `unknown/unknown` manifest entries)
- Concurrency block documents the GitHub 1-pending-run queue-depth tradeoff

## Prerequisites

- Org-level secrets `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` (already provisioned)
- Repo environment `docker-hub-publish` with required-reviewers + ref allowlist (configured)
- Env-level `DOCKERHUB_*` secrets if you want to fully scope credentials to this env (optional — falls back to org-level if not set)

## Test plan (run after merge to main)

> Testing on this PR branch is intentionally blocked by the environment policy. All scenarios must run from `main` after merge.

- [ ] **Env gate** — From `main`, dispatch with `tag=test-env-gate-$(date +%s)`. Run pauses at `build` with "Waiting for review"; proceeds after a maintainer approves.
- [ ] **Multi-arch manifest** — `docker buildx imagetools inspect mininglamposs/octo-admin:<tag>` shows both archs, no `unknown/unknown`.
- [ ] **Semver preflight rejects junk** — temporarily push `vfoo` (or `v01.2.3`); validate fails before any Docker Hub login. Delete tag after.
- [ ] **Prerelease skip-:latest** — push `v0.0.1-rc1`; confirm only `:0.0.1-rc1` (no `:latest`/`:0`/`:0.0`).
- [ ] **Branch dispatch rejected** — try to dispatch from any non-main branch; environment policy should block.