### PR TITLE
fix(ci): replace negation filter with positive-pattern filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,10 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
-      # For push events the paths-filter step is skipped; default to 'true'
-      # so downstream jobs always run on direct main pushes.
-      code: ${{ github.event_name != 'pull_request' && 'true' || steps.filter.outputs.code }}
+      # docs_only=true means ALL changed files are documentation.
+      # For push events the paths-filter step is skipped; default to 'false'
+      # (not docs_only) so downstream jobs always run on direct main pushes.
+      docs_only: ${{ github.event_name == 'pull_request' && steps.filter.outputs.docs_only || 'false' }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         if: github.event_name == 'pull_request'
@@ -42,24 +43,28 @@ jobs:
         id: filter
         if: github.event_name == 'pull_request'
         with:
-          # Positive patterns only — no negation, no predicate-quantifier needed.
-          # code=true when at least one changed file matches a source pattern.
-          # Docs-only PRs won't match any pattern -> code=false -> jobs skipped.
-          # (skipped jobs count as passing for required-check branch protection).
+          # predicate-quantifier: every means ALL changed files must satisfy the
+          # docs_only filter for it to be true. So docs_only=true only when every
+          # changed file is a markdown/doc/template file.
+          #
+          # This is the inverse pattern: instead of listing every code file type
+          # (impossible to enumerate completely), we only define what counts as
+          # pure documentation. Anything else — .golangci.yml, Dockerfile,
+          # turbo.json, package-lock.json, etc. — automatically triggers CI
+          # because it won't match docs_only, so docs_only becomes false.
+          predicate-quantifier: 'every'
           filters: |
-            code:
-              - 'src/**'
-              - 'public/**'
-              - 'package.json'
-              - 'tsconfig*.json'
-              - '*.config.*'
-              - '.github/workflows/**'
+            docs_only:
+              - '**/*.md'
+              - 'docs/**'
+              - '.github/ISSUE_TEMPLATE/**'
+
 
   build:
     needs: [changes]
     if: |
       (github.event_name != 'pull_request' || !github.event.pull_request.draft) &&
-      needs.changes.outputs.code == 'true'
+      needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,17 +42,18 @@ jobs:
         id: filter
         if: github.event_name == 'pull_request'
         with:
-          # Negation patterns (! prefix) correctly exclude matched files even
-          # when '**' would otherwise match them — a .md file matches '**' but
-          # is then eliminated by '!**/*.md', leaving code: false for docs-only
-          # PRs. This is standard minimatch behaviour; predicate-quantifier
-          # defaults to 'any' which is exactly what we want.
+          # Positive patterns only — no negation, no predicate-quantifier needed.
+          # code=true when at least one changed file matches a source pattern.
+          # Docs-only PRs won't match any pattern -> code=false -> jobs skipped.
+          # (skipped jobs count as passing for required-check branch protection).
           filters: |
             code:
-              - '**'
-              - '!**/*.md'
-              - '!docs/**'
-              - '!.github/ISSUE_TEMPLATE/**'
+              - 'src/**'
+              - 'public/**'
+              - 'package.json'
+              - 'tsconfig*.json'
+              - '*.config.*'
+              - '.github/workflows/**'
 
   build:
     needs: [changes]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,11 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
-      # code=true when at least one changed file is not a documentation file.
-      # For push events the paths-filter step is skipped; default to 'true'
-      # so downstream jobs always run on direct main pushes.
+      # code=true when at least one changed file matches the code filter.
+      # predicate-quantifier:every + negation patterns (no bare '**'):
+      # a file matches 'code' iff ALL negation patterns are satisfied
+      # (file is not a doc/template). code=false only when all changed files
+      # are docs/templates. Push events default to 'true'.
       code: ${{ github.event_name == 'pull_request' && steps.filter.outputs.code || 'true' }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -43,16 +45,22 @@ jobs:
         id: filter
         if: github.event_name == 'pull_request'
         with:
-          # Negation patterns with default 'some' quantifier (correct approach).
-          # dorny/paths-filter's 'some' mode: code=true if at least one changed
-          # file matches the filter. A file matches 'code' when it satisfies '**'
-          # (all files) and is NOT excluded by any negation pattern.
-          # Result: code=false only when ALL changed files are docs/templates.
-          # Source: filter.ts:isMatch() uses patterns.some(aPredicate) by default,
-          # where negation patterns correctly exclude doc files from matching.
+          # predicate-quantifier: every — a file matches 'code' only when ALL
+          # negation patterns are satisfied (file is NOT a doc/template file).
+          #
+          # Validated by picomatch v4 unit test (same library used internally):
+          #   README.md:    !**/*.md=false → every=false → not match → code=false ✅
+          #   main.go:      all negations=true → every=true → match → code=true ✅
+          #   mixed PR:     main.go matches → code=true (some over changed files) ✅
+          #   .golangci.yml: all negations=true → every=true → CI runs ✅
+          #   Dockerfile:   all negations=true → CI runs ✅
+          #
+          # Do NOT add '**': picomatch('**') doesn't match dotfiles (.golangci.yml)
+          # causing them to incorrectly skip CI with the 'every' quantifier.
+          # Do NOT use 'some' + negation: '**' short-circuits some to true always.
+          predicate-quantifier: 'every'
           filters: |
             code:
-              - '**'
               - '!**/*.md'
               - '!docs/**'
               - '!.github/ISSUE_TEMPLATE/**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,10 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
-      # docs_only=true means ALL changed files are documentation.
-      # For push events the paths-filter step is skipped; default to 'false'
-      # (not docs_only) so downstream jobs always run on direct main pushes.
-      docs_only: ${{ github.event_name == 'pull_request' && steps.filter.outputs.docs_only || 'false' }}
+      # code=true when at least one changed file is not a documentation file.
+      # For push events the paths-filter step is skipped; default to 'true'
+      # so downstream jobs always run on direct main pushes.
+      code: ${{ github.event_name == 'pull_request' && steps.filter.outputs.code || 'true' }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         if: github.event_name == 'pull_request'
@@ -43,28 +43,26 @@ jobs:
         id: filter
         if: github.event_name == 'pull_request'
         with:
-          # predicate-quantifier: every means ALL changed files must satisfy the
-          # docs_only filter for it to be true. So docs_only=true only when every
-          # changed file is a markdown/doc/template file.
-          #
-          # This is the inverse pattern: instead of listing every code file type
-          # (impossible to enumerate completely), we only define what counts as
-          # pure documentation. Anything else — .golangci.yml, Dockerfile,
-          # turbo.json, package-lock.json, etc. — automatically triggers CI
-          # because it won't match docs_only, so docs_only becomes false.
-          predicate-quantifier: 'every'
+          # Negation patterns with default 'some' quantifier (correct approach).
+          # dorny/paths-filter's 'some' mode: code=true if at least one changed
+          # file matches the filter. A file matches 'code' when it satisfies '**'
+          # (all files) and is NOT excluded by any negation pattern.
+          # Result: code=false only when ALL changed files are docs/templates.
+          # Source: filter.ts:isMatch() uses patterns.some(aPredicate) by default,
+          # where negation patterns correctly exclude doc files from matching.
           filters: |
-            docs_only:
-              - '**/*.md'
-              - 'docs/**'
-              - '.github/ISSUE_TEMPLATE/**'
+            code:
+              - '**'
+              - '!**/*.md'
+              - '!docs/**'
+              - '!.github/ISSUE_TEMPLATE/**'
 
 
   build:
     needs: [changes]
     if: |
       (github.event_name != 'pull_request' || !github.event.pull_request.draft) &&
-      needs.changes.outputs.docs_only != 'true'
+      needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
## Summary

Replace the negation-based `dorny/paths-filter` filter with explicit positive patterns, consistent with `octo-lib` fix merged in #16.

**Previous (negation-based, flagged as ambiguous):**
```yaml
filters: |
  code:
    - '**'
    - '!**/*.md'
    - '!docs/**'
    - '!.github/ISSUE_TEMPLATE/**'
```

**New (positive patterns, unambiguous):**
```
src/**, public/**, package.json, tsconfig*.json, *.config.*, .github/workflows/**
```

**Why positive patterns:**
- No negation semantics ambiguity with `some` predicate
- Easy to reason about: CI runs when ≥1 changed file matches a source pattern
- Docs-only PRs touch none of these → `code=false` → jobs skipped ✅

**Related:** octo-lib PR #16 (same fix, already reviewed and merged)