### PR TITLE
Render system settings dynamically

### DIFF
--- a/src/pages/SystemSetting/index.tsx
+++ b/src/pages/SystemSetting/index.tsx
@@ -9,17 +9,13 @@ import {
   Modal,
   Row,
   Select,
-  Space,
-  Tag,
   Tooltip,
   message,
 } from 'antd'
 import {
-  MailOutlined,
   ReloadOutlined,
   SaveOutlined,
   SendOutlined,
-  UserAddOutlined,
 } from '@ant-design/icons'
 import {
   SECRET_MASK,
@@ -31,88 +27,21 @@ import {
 } from '../../api/system-setting'
 
 type BoolFormValue = '' | '0' | '1'
+type SettingFormValue = string | number | null | undefined
 
-interface SystemSettingFormValues {
-  register_off: BoolFormValue
-  register_only_china: BoolFormValue
-  register_username_on: BoolFormValue
-  register_email_on: BoolFormValue
-  support_email: string
-  support_email_smtp: string
-  support_email_pwd: string
-}
+type SystemSettingFormValues = Record<string, SettingFormValue>
 
 interface TestEmailFormValues {
   to: string
 }
 
-interface BoolSettingDef {
-  name: keyof SystemSettingFormValues
-  category: 'register'
-  key: 'off' | 'only_china' | 'username_on' | 'email_on'
-  label: string
-  description: string
-  onLabel: string
-  offLabel: string
-}
-
-const boolSettings: BoolSettingDef[] = [
-  {
-    name: 'register_off',
-    category: 'register',
-    key: 'off',
-    label: '注册入口',
-    description: '是否关闭注册',
-    onLabel: '关闭注册',
-    offLabel: '允许注册',
-  },
-  {
-    name: 'register_only_china',
-    category: 'register',
-    key: 'only_china',
-    label: '手机号范围',
-    description: '仅中国手机号可以注册',
-    onLabel: '仅中国手机号',
-    offLabel: '不限制地区',
-  },
-  {
-    name: 'register_username_on',
-    category: 'register',
-    key: 'username_on',
-    label: '用户名注册',
-    description: '是否开启用户名注册',
-    onLabel: '开启',
-    offLabel: '关闭',
-  },
-  {
-    name: 'register_email_on',
-    category: 'register',
-    key: 'email_on',
-    label: '邮箱注册/登录',
-    description: '是否开启邮箱注册/登录',
-    onLabel: '开启',
-    offLabel: '关闭',
-  },
-]
-
 const settingMapKey = (category: string, key: string) => `${category}.${key}`
+const settingFormName = (category: string, key: string) => settingMapKey(category, key)
 
-const initialValues: SystemSettingFormValues = {
-  register_off: '',
-  register_only_china: '',
-  register_username_on: '',
-  register_email_on: '',
-  support_email: '',
-  support_email_smtp: '',
-  support_email_pwd: '',
-}
-
-function getValue(items: SystemSettingItem[], category: string, key: string) {
-  return items.find((item) => item.category === category && item.key === key)?.value ?? ''
-}
-
-function getSetting(items: SystemSettingItem[], category: string, key: string) {
-  return items.find((item) => item.category === category && item.key === key)
+const categoryTitles: Record<string, string> = {
+  login: '登录配置',
+  register: '注册配置',
+  support: '邮件服务',
 }
 
 function normaliseBoolValue(value: string): BoolFormValue {
@@ -121,55 +50,92 @@ function normaliseBoolValue(value: string): BoolFormValue {
   return ''
 }
 
-function boolText(value: string | undefined, item: BoolSettingDef) {
+function boolText(value: string | undefined) {
   const normalised = normaliseBoolValue(value ?? '')
-  if (normalised === '1') return item.onLabel
-  if (normalised === '0') return item.offLabel
+  if (normalised === '1') return '是'
+  if (normalised === '0') return '否'
   return '未配置'
 }
 
-function boolDefaultLabel(def: BoolSettingDef, item?: SystemSettingItem) {
-  return item?.effective_value ? `跟随默认配置（当前：${boolText(item.effective_value, def)}）` : '跟随默认配置'
+function formValueToString(value: SettingFormValue) {
+  if (value === null || value === undefined) return ''
+  return String(value)
 }
 
-function stringExtra(description: string, item?: SystemSettingItem) {
-  if (!item?.effective_value) return description
-  const source = item.configured ? 'DB 配置' : '默认配置'
-  return `${description}。当前生效：${item.effective_value}（${source}）`
+function valuesToPayload(values: SystemSettingFormValues, items: SystemSettingItem[]): SystemSettingUpdateItem[] {
+  return items.map((item) => {
+    const value = formValueToString(values[settingFormName(item.category, item.key)])
+    const keepEncryptedValue = item.value_type === 'encrypted' && !value && (item.configured || item.value === SECRET_MASK)
+
+    return {
+      category: item.category,
+      key: item.key,
+      value: keepEncryptedValue ? SECRET_MASK : value,
+    }
+  })
 }
 
-function encryptedExtra(description: string, item?: SystemSettingItem) {
-  if (!item?.effective_value) return description
-  const source = item.configured ? 'DB 配置' : '默认配置'
-  return `${description}。当前生效：已配置（${source}）`
+function valuesFromSettings(items: SystemSettingItem[]): SystemSettingFormValues {
+  return items.reduce<SystemSettingFormValues>((values, item) => {
+    const fieldName = settingFormName(item.category, item.key)
+    values[fieldName] = item.value_type === 'encrypted' ? '' : item.value ?? ''
+    if (item.value_type === 'bool') {
+      values[fieldName] = normaliseBoolValue(formValueToString(values[fieldName]))
+    }
+    return values
+  }, {})
 }
 
-function valuesToPayload(values: SystemSettingFormValues, keepExistingPassword: boolean): SystemSettingUpdateItem[] {
-  const payload: SystemSettingUpdateItem[] = boolSettings.map((item) => ({
-    category: item.category,
-    key: item.key,
-    value: values[item.name] || '',
-  }))
+function categoryTitle(category: string) {
+  return categoryTitles[category] || `${category} 配置`
+}
 
-  payload.push(
-    {
-      category: 'support',
-      key: 'email',
-      value: values.support_email ?? '',
-    },
-    {
-      category: 'support',
-      key: 'email_smtp',
-      value: values.support_email_smtp ?? '',
-    },
-    {
-      category: 'support',
-      key: 'email_pwd',
-      value: values.support_email_pwd || (keepExistingPassword ? SECRET_MASK : ''),
-    },
-  )
+function settingSource(item: SystemSettingItem) {
+  return item.configured ? 'DB 配置' : '默认配置'
+}
 
-  return payload
+function genericSettingExtra(item: SystemSettingItem) {
+  const identity = settingMapKey(item.category, item.key)
+  if (!item.effective_value) return identity
+  if (item.value_type === 'encrypted') return `${identity}。当前生效：已配置（${settingSource(item)}）`
+  if (item.value_type === 'bool') {
+    return `${identity}。当前生效：${boolText(item.effective_value)}（${settingSource(item)}）`
+  }
+  return `${identity}。当前生效：${item.effective_value}（${settingSource(item)}）`
+}
+
+function genericBoolDefaultLabel(item: SystemSettingItem) {
+  return item.effective_value ? `跟随默认配置（当前：${boolText(item.effective_value)}）` : '跟随默认配置'
+}
+
+function settingLabel(item: SystemSettingItem) {
+  return item.description || item.key
+}
+
+function renderSettingInput(item: SystemSettingItem) {
+  if (item.value_type === 'bool') {
+    return (
+      <Select
+        options={[
+          { value: '', label: genericBoolDefaultLabel(item) },
+          { value: '1', label: '是' },
+          { value: '0', label: '否' },
+        ]}
+      />
+    )
+  }
+
+  if (item.value_type === 'encrypted') {
+    return (
+      <Input.Password
+        allowClear
+        autoComplete="new-password"
+        placeholder={item.configured ? '留空保留现有值' : '留空跟随默认配置'}
+      />
+    )
+  }
+
+  return <Input allowClear type={item.value_type === 'int' ? 'number' : undefined} />
 }
 
 export default function SystemSetting() {
@@ -180,24 +146,17 @@ export default function SystemSetting() {
   const [testing, setTesting] = useState(false)
   const [testModalOpen, setTestModalOpen] = useState(false)
   const [settings, setSettings] = useState<SystemSettingItem[]>([])
-  const [hasStoredPassword, setHasStoredPassword] = useState(false)
-  const [hasEffectivePassword, setHasEffectivePassword] = useState(false)
   const [dirty, setDirty] = useState(false)
 
-  const settingDescriptions = useMemo(() => {
-    const map = new Map<string, string>()
+  const settingGroups = useMemo(() => {
+    const groups = new Map<string, SystemSettingItem[]>()
     settings.forEach((item) => {
-      map.set(settingMapKey(item.category, item.key), item.description)
+      const group = groups.get(item.category) || []
+      group.push(item)
+      groups.set(item.category, group)
     })
-    return map
-  }, [settings])
 
-  const settingByKey = useMemo(() => {
-    const map = new Map<string, SystemSettingItem>()
-    settings.forEach((item) => {
-      map.set(settingMapKey(item.category, item.key), item)
-    })
-    return map
+    return Array.from(groups.entries())
   }, [settings])
 
   const fetchSettings = async () => {
@@ -205,22 +164,8 @@ export default function SystemSetting() {
     try {
       const data = await getSystemSettings()
       const items = data.items || []
-      const passwordSetting = getSetting(items, 'support', 'email_pwd')
-      const storedPassword =
-        passwordSetting?.configured === true || getValue(items, 'support', 'email_pwd') === SECRET_MASK
-      const effectivePassword = passwordSetting?.effective_value === SECRET_MASK
       setSettings(items)
-      setHasStoredPassword(storedPassword)
-      setHasEffectivePassword(effectivePassword)
-      form.setFieldsValue({
-        register_off: normaliseBoolValue(getValue(items, 'register', 'off')),
-        register_only_china: normaliseBoolValue(getValue(items, 'register', 'only_china')),
-        register_username_on: normaliseBoolValue(getValue(items, 'register', 'username_on')),
-        register_email_on: normaliseBoolValue(getValue(items, 'register', 'email_on')),
-        support_email: getValue(items, 'support', 'email'),
-        support_email_smtp: getValue(items, 'support', 'email_smtp'),
-        support_email_pwd: '',
-      })
+      form.setFieldsValue(valuesFromSettings(items))
       setDirty(false)
     } catch (error) {
       message.error('获取系统配置失败: ' + (error as Error).message)
@@ -237,7 +182,7 @@ export default function SystemSetting() {
     const values = await form.validateFields()
     setSaving(true)
     try {
-      await updateSystemSettings(valuesToPayload(values, hasStoredPassword))
+      await updateSystemSettings(valuesToPayload(values, settings))
       message.success('配置已保存')
       await fetchSettings()
     } catch (error) {
@@ -265,7 +210,7 @@ export default function SystemSetting() {
   return (
     <div>
       <h1 className="page-title">系统配置</h1>
-      <p className="page-subtitle">注册策略与邮件服务配置</p>
+      <p className="page-subtitle">登录、注册策略与邮件服务配置</p>
 
       <div className="toolbar">
         <Button icon={<ReloadOutlined />} onClick={fetchSettings} loading={loading}>
@@ -289,84 +234,26 @@ export default function SystemSetting() {
       <Form
         form={form}
         layout="vertical"
-        initialValues={initialValues}
+        initialValues={{}}
         onValuesChange={() => setDirty(true)}
       >
         <Row gutter={[16, 16]}>
-          <Col xs={24} lg={12}>
-            <Card title="注册配置" loading={loading} extra={<UserAddOutlined style={{ color: 'var(--a-text-tertiary)' }} />}>
-              {boolSettings.map((item) => (
-                <Form.Item
-                  key={item.name}
-                  name={item.name}
-                  label={item.label}
-                  extra={settingDescriptions.get(settingMapKey(item.category, item.key)) || item.description}
-                >
-                  <Select
-                    options={[
-                      {
-                        value: '',
-                        label: boolDefaultLabel(item, settingByKey.get(settingMapKey(item.category, item.key))),
-                      },
-                      { value: '1', label: item.onLabel },
-                      { value: '0', label: item.offLabel },
-                    ]}
-                  />
-                </Form.Item>
-              ))}
-            </Card>
-          </Col>
-
-          <Col xs={24} lg={12}>
-            <Card title="邮件服务" loading={loading} extra={<MailOutlined style={{ color: 'var(--a-text-tertiary)' }} />}>
-              <Form.Item
-                name="support_email"
-                label="技术支持邮箱"
-                extra={stringExtra(
-                  settingDescriptions.get('support.email') || '技术支持邮箱（发件人）',
-                  settingByKey.get('support.email'),
-                )}
-                rules={[{ type: 'email', message: '请输入有效的邮箱地址' }]}
-              >
-                <Input allowClear placeholder="support@example.com" />
-              </Form.Item>
-
-              <Form.Item
-                name="support_email_smtp"
-                label="SMTP 服务器"
-                extra={stringExtra(
-                  settingDescriptions.get('support.email_smtp') || 'SMTP 服务器 host:port',
-                  settingByKey.get('support.email_smtp'),
-                )}
-              >
-                <Input allowClear placeholder="smtp.example.com:587" />
-              </Form.Item>
-
-              <Form.Item
-                name="support_email_pwd"
-                label={
-                  <Space size={8}>
-                    <span>SMTP 密码</span>
-                    {hasStoredPassword ? (
-                      <Tag color="processing">DB 已配置</Tag>
-                    ) : hasEffectivePassword ? (
-                      <Tag color="default">默认已配置</Tag>
-                    ) : null}
-                  </Space>
-                }
-                extra={encryptedExtra(
-                  settingDescriptions.get('support.email_pwd') || 'SMTP 密码（加密存储）',
-                  settingByKey.get('support.email_pwd'),
-                )}
-              >
-                <Input.Password
-                  allowClear
-                  autoComplete="new-password"
-                  placeholder={hasStoredPassword ? '留空保留现有密码' : '留空跟随默认配置'}
-                />
-              </Form.Item>
-            </Card>
-          </Col>
+          {settingGroups.map(([category, items]) => (
+            <Col xs={24} lg={12} key={category}>
+              <Card title={categoryTitle(category)} loading={loading}>
+                {items.map((item) => (
+                  <Form.Item
+                    key={settingMapKey(item.category, item.key)}
+                    name={settingFormName(item.category, item.key)}
+                    label={settingLabel(item)}
+                    extra={genericSettingExtra(item)}
+                  >
+                    {renderSettingInput(item)}
+                  </Form.Item>
+                ))}
+              </Card>
+            </Col>
+          ))}
         </Row>
       </Form>
 


### PR DESCRIPTION
## Summary
- Render system settings by category from API items instead of hard-coded register/support fields
- Add generic controls for bool, string, int, and encrypted setting types
- Preserve encrypted settings when the field is left blank during save

## Testing
- npm run build