### PR TITLE
Fix app bot bind guide flow

### DIFF
--- a/src/pages/AppBots/CreateModal.tsx
+++ b/src/pages/AppBots/CreateModal.tsx
@@ -1,13 +1,20 @@
 import { useState } from 'react'
-import { Modal, Form, Input, Typography, message } from 'antd'
+import { Button, Form, Input, Modal, Space, Typography, message } from 'antd'
 import { CopyOutlined } from '@ant-design/icons'
 import { createAppBot, createSpaceAppBot, type AppBotCreateReq } from '../../api/app-bot'
+import { buildConnectGuide } from './connectGuide'
 
 interface Props {
   open: boolean
   spaceId?: string
   onClose: () => void
   onSuccess: () => void
+}
+
+interface CreatedBotInfo {
+  id: string
+  displayName: string
+  token: string
 }
 
 /** Copy text to clipboard with fallback */
@@ -29,12 +36,12 @@ async function copyToClipboard(text: string): Promise<void> {
 export default function CreateModal({ open, spaceId, onClose, onSuccess }: Props) {
   const [form] = Form.useForm<AppBotCreateReq>()
   const [loading, setLoading] = useState(false)
-  const [createdToken, setCreatedToken] = useState<string | null>(null)
+  const [createdBot, setCreatedBot] = useState<CreatedBotInfo | null>(null)
 
   const handleOk = async () => {
     // If token is showing, this is the "I've saved it" confirmation
-    if (createdToken) {
-      setCreatedToken(null)
+    if (createdBot) {
+      setCreatedBot(null)
       form.resetFields()
       onSuccess()
       return
@@ -45,8 +52,12 @@ export default function CreateModal({ open, spaceId, onClose, onSuccess }: Props
       const resp = spaceId
         ? await createSpaceAppBot(spaceId, values)
         : await createAppBot(values)
-      // Show token — user must explicitly dismiss
-      setCreatedToken(resp.token)
+      // Show token and bind guide together; user must explicitly dismiss.
+      setCreatedBot({
+        id: resp.id || values.id,
+        displayName: values.display_name,
+        token: resp.token,
+      })
     } catch (err) {
       if (err instanceof Error) message.error(err.message)
     } finally {
@@ -55,9 +66,9 @@ export default function CreateModal({ open, spaceId, onClose, onSuccess }: Props
   }
 
   const handleCancel = () => {
-    if (createdToken) {
+    if (createdBot) {
       // Already created, treat cancel as confirm
-      setCreatedToken(null)
+      setCreatedBot(null)
       form.resetFields()
       onSuccess()
       return
@@ -66,34 +77,62 @@ export default function CreateModal({ open, spaceId, onClose, onSuccess }: Props
   }
 
   const handleCopyToken = async () => {
-    if (!createdToken) return
+    if (!createdBot) return
     try {
-      await copyToClipboard(createdToken)
+      await copyToClipboard(createdBot.token)
       message.success('Token copied')
     } catch {
       message.error('复制失败')
     }
   }
 
+  const handleCopyGuide = async () => {
+    if (!createdBot) return
+    try {
+      await copyToClipboard(
+        buildConnectGuide({
+          displayName: createdBot.displayName,
+          botId: createdBot.id,
+          token: createdBot.token,
+        }),
+      )
+      message.success('连接指南已复制')
+    } catch {
+      message.error('复制失败')
+    }
+  }
+
+  const connectGuide = createdBot
+    ? buildConnectGuide({
+      displayName: createdBot.displayName,
+      botId: createdBot.id,
+      token: createdBot.token,
+    })
+    : ''
+
   return (
     <Modal
-      title={createdToken ? '✅ 创建成功 — 请保存 Token' : '创建应用 Bot'}
+      title={createdBot ? '创建成功 - 请保存 Token 并完成绑定' : '创建应用 Bot'}
       open={open}
       onOk={handleOk}
       onCancel={handleCancel}
-      okText={createdToken ? '已保存，关闭' : '确定'}
+      okText={createdBot ? '已保存，关闭' : '确定'}
       confirmLoading={loading}
       destroyOnClose
+      width={createdBot ? 680 : undefined}
     >
-      {createdToken ? (
+      {createdBot ? (
         <div>
           <Typography.Paragraph type="warning" style={{ marginBottom: 12 }}>
-            ℹ️ Token 仅在创建时显示一次，关闭后无法再次查看。请立即复制并安全保存。
+            Token 仅在创建时完整显示一次。请复制 Token，并将连接指南发给 OpenClaw 执行完成绑定。
           </Typography.Paragraph>
+          <Typography.Title level={5} style={{ marginTop: 0 }}>
+            API Token
+          </Typography.Title>
           <div
             style={{
               padding: '12px 16px',
-              background: '#f5f5f5',
+              background: 'var(--a-bg-tertiary, #f5f5f5)',
               borderRadius: 8,
               fontFamily: 'monospace',
               fontSize: 13,
@@ -101,41 +140,70 @@ export default function CreateModal({ open, spaceId, onClose, onSuccess }: Props
               marginBottom: 12,
             }}
           >
-            {createdToken}
+            {createdBot.token}
           </div>
-          <Typography.Link onClick={handleCopyToken}>
-            <CopyOutlined /> 点击复制 Token
-          </Typography.Link>
+          <Button size="small" icon={<CopyOutlined />} onClick={handleCopyToken}>
+            复制 Token
+          </Button>
+
+          <Typography.Title level={5} style={{ marginTop: 24 }}>
+            连接指南
+          </Typography.Title>
+          <Typography.Paragraph type="secondary" style={{ marginBottom: 12 }}>
+            将以下内容发给 OpenClaw 执行，即可将此 Bot 绑定到 Agent：
+          </Typography.Paragraph>
+          <div
+            style={{
+              padding: '12px 16px',
+              background: 'var(--a-bg-tertiary, #f5f5f5)',
+              borderRadius: 8,
+              fontFamily: 'monospace',
+              fontSize: 12,
+              lineHeight: 1.6,
+              wordBreak: 'break-all',
+              whiteSpace: 'pre-wrap',
+            }}
+          >
+            {connectGuide}
+          </div>
+          <Space style={{ marginTop: 12 }}>
+            <Button size="small" icon={<CopyOutlined />} onClick={handleCopyGuide}>
+              复制指南
+            </Button>
+          </Space>
+          <Typography.Paragraph type="secondary" style={{ marginTop: 8, fontSize: 12 }}>
+            如需绑定到其他 Agent，修改 --agent 参数即可。断开连接请在 BotFather 中发送 /disconnect。
+          </Typography.Paragraph>
         </div>
       ) : (
         <Form form={form} layout="vertical" autoComplete="off">
-        <Form.Item
-          name="id"
-          label="Bot ID"
-          rules={[
-            { required: true, message: '请输入 Bot ID' },
-            {
-              pattern: /^[a-z0-9][a-z0-9_-]{0,29}$/,
-              message: '小写字母/数字/下划线/短横，1-30 字符',
-            },
-          ]}
-          extra="唯一标识，创建后不可修改。如：octo-butler"
-        >
-          <Input placeholder="octo-butler" />
-        </Form.Item>
-        <Form.Item
-          name="display_name"
-          label="显示名称"
-          rules={[{ required: true, message: '请输入显示名称' }]}
-        >
-          <Input placeholder="Octo 管家" maxLength={100} />
-        </Form.Item>
-        <Form.Item name="description" label="描述">
-          <Input.TextArea placeholder="智能工作助手，支持..." maxLength={500} rows={3} />
-        </Form.Item>
-        <Form.Item name="welcome_msg" label="欢迎语" extra="用户首次连接时自动发送的消息，留空则使用默认提示">
-          <Input.TextArea placeholder="你好！我是 xx 助手，有什么可以帮你的？" maxLength={500} rows={2} />
-        </Form.Item>
+          <Form.Item
+            name="id"
+            label="Bot ID"
+            rules={[
+              { required: true, message: '请输入 Bot ID' },
+              {
+                pattern: /^[a-z0-9][a-z0-9_-]{0,29}$/,
+                message: '小写字母/数字/下划线/短横，1-30 字符',
+              },
+            ]}
+            extra="唯一标识，创建后不可修改。如：octo-butler"
+          >
+            <Input placeholder="octo-butler" />
+          </Form.Item>
+          <Form.Item
+            name="display_name"
+            label="显示名称"
+            rules={[{ required: true, message: '请输入显示名称' }]}
+          >
+            <Input placeholder="Octo 管家" maxLength={100} />
+          </Form.Item>
+          <Form.Item name="description" label="描述">
+            <Input.TextArea placeholder="智能工作助手，支持..." maxLength={500} rows={3} />
+          </Form.Item>
+          <Form.Item name="welcome_msg" label="欢迎语" extra="用户首次连接时自动发送的消息，留空则使用默认提示">
+            <Input.TextArea placeholder="你好！我是 xx 助手，有什么可以帮你的？" maxLength={500} rows={2} />
+          </Form.Item>
         </Form>
       )}
     </Modal>

--- a/src/pages/AppBots/DetailDrawer.tsx
+++ b/src/pages/AppBots/DetailDrawer.tsx
@@ -13,6 +13,7 @@ import {
   type AppBot,
   type AppBotStatus,
 } from '../../api/app-bot'
+import { buildConnectGuide } from './connectGuide'
 
 interface Props {
   botId: string | null
@@ -51,12 +52,6 @@ async function copyToClipboard(text: string): Promise<void> {
   document.body.removeChild(textarea)
 }
 
-/** Get API server URL for bot connect guide */
-function getApiUrl(): string {
-  // Prefer explicit env var; fallback to current origin (admin is co-located with IM server)
-  return import.meta.env.VITE_BOT_API_URL || window.location.origin
-}
-
 const TOKEN_AUTO_HIDE_MS = 30_000
 
 export default function DetailDrawer({ botId, spaceId, open, onClose, onAvatarUploaded }: Props) {
@@ -65,6 +60,7 @@ export default function DetailDrawer({ botId, spaceId, open, onClose, onAvatarUp
   const [tokenVisible, setTokenVisible] = useState(false)
   const [revealing, setRevealing] = useState(false)
   const [rotating, setRotating] = useState(false)
+  const [copyingGuide, setCopyingGuide] = useState(false)
   const [uploadingAvatar, setUploadingAvatar] = useState(false)
   const [avatarVersion, setAvatarVersion] = useState(Date.now)
   const autoHideRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -109,15 +105,20 @@ export default function DetailDrawer({ botId, spaceId, open, onClose, onAvatarUp
     }
   }, [tokenVisible])
 
+  const revealToken = async (): Promise<string | null> => {
+    if (!botId) return null
+    const resp = spaceId
+      ? await revealSpaceAppBotToken(spaceId, botId)
+      : await revealAppBotToken(botId)
+    setBot((prev) => (prev ? { ...prev, token: resp.token } : prev))
+    setTokenVisible(true)
+    return resp.token
+  }
+
   const handleRevealToken = async () => {
-    if (!botId) return
     setRevealing(true)
     try {
-      const resp = spaceId
-        ? await revealSpaceAppBotToken(spaceId, botId)
-        : await revealAppBotToken(botId)
-      setBot((prev) => (prev ? { ...prev, token: resp.token } : prev))
-      setTokenVisible(true)
+      await revealToken()
     } catch (err) {
       if (err instanceof Error) message.error(err.message)
     } finally {
@@ -152,7 +153,36 @@ export default function DetailDrawer({ botId, spaceId, open, onClose, onAvatarUp
     }
   }
 
+  const handleCopyGuide = async () => {
+    if (!bot) return
+    setCopyingGuide(true)
+    try {
+      const token = tokenMasked ? await revealToken() : bot.token
+      if (!token) return
+      await copyToClipboard(
+        buildConnectGuide({
+          displayName: bot.display_name,
+          botId: bot.id,
+          token,
+        }),
+      )
+      message.success('连接指南已复制')
+    } catch (err) {
+      if (err instanceof Error) message.error(err.message)
+      else message.error('复制失败')
+    } finally {
+      setCopyingGuide(false)
+    }
+  }
+
   const status = bot ? STATUS_MAP[bot.status] : null
+  const connectGuide = bot
+    ? buildConnectGuide({
+      displayName: bot.display_name,
+      botId: bot.id,
+      token: tokenMasked ? '<在上方复制 Token>' : (bot.token || '<token>'),
+    })
+    : ''
 
   return (
     <Drawer
@@ -307,27 +337,20 @@ export default function DetailDrawer({ botId, spaceId, open, onClose, onAvatarUp
                 whiteSpace: 'pre-wrap',
               }}
             >
-              {`将 Octo bot ${bot.display_name} 绑定到 Agent。
-默认绑定到当前 Session 的 Agent，agent 标识通过 /status 查看。
-如果用户指定了其他 Agent，使用用户指定的标识替换。
-
-npx -y openclaw-channel-dmwork bind --bot-token ${tokenMasked ? '<在上方复制 Token>' : (bot.token || '<token>')} --api-url ${getApiUrl()} --account-id ${bot.id} --agent <agent标识>`}
+              {connectGuide}
             </div>
             <Space style={{ marginTop: 12 }}>
               <Button
                 size="small"
                 icon={<CopyOutlined />}
-                onClick={() => {
-                  const cmd = `将 Octo bot ${bot.display_name} 绑定到 Agent。\n默认绑定到当前 Session 的 Agent，agent 标识通过 /status 查看。\n如果用户指定了其他 Agent，使用用户指定的标识替换。\n\nnpx -y openclaw-channel-dmwork bind --bot-token ${bot.token || '<token>'} --api-url ${getApiUrl()} --account-id ${bot.id} --agent <agent标识>`
-                  copyToClipboard(cmd).then(() => message.success('连接指南已复制')).catch(() => message.error('复制失败'))
-                }}
-                disabled={tokenMasked}
+                loading={copyingGuide}
+                onClick={handleCopyGuide}
               >
                 复制指南
               </Button>
             </Space>
             <Typography.Paragraph type="secondary" style={{ marginTop: 8, fontSize: 12 }}>
-              💡 如需绑定到其他 Agent，修改 --agent 参数即可。断开连接请在 BotFather 中发送 /disconnect。
+              如需绑定到其他 Agent，修改 --agent 参数即可。断开连接请在 BotFather 中发送 /disconnect。
             </Typography.Paragraph>
           </div>
         </>

--- a/src/pages/AppBots/connectGuide.ts
+++ b/src/pages/AppBots/connectGuide.ts
@@ -1,0 +1,27 @@
+interface BuildConnectGuideParams {
+  displayName: string
+  botId: string
+  token: string
+  apiUrl?: string
+}
+
+/** Get API server URL for bot connect guide. */
+export function getBotApiUrl(): string {
+  return import.meta.env.VITE_BOT_API_URL || window.location.origin
+}
+
+export function buildConnectCommand({
+  botId,
+  token,
+  apiUrl = getBotApiUrl(),
+}: BuildConnectGuideParams): string {
+  return `npx -y openclaw-channel-dmwork bind --bot-token ${token} --api-url ${apiUrl} --account-id ${botId} --agent <agent标识>`
+}
+
+export function buildConnectGuide(params: BuildConnectGuideParams): string {
+  return `将 Octo bot ${params.displayName} 绑定到 Agent。
+默认绑定到当前 Session 的 Agent，agent 标识通过 /status 查看。
+如果用户指定了其他 Agent，使用用户指定的标识替换。
+
+${buildConnectCommand(params)}`
+}


### PR DESCRIPTION
## Summary
- Show the OpenClaw bind guide directly in the app bot creation success modal alongside the one-time token.
- Share bind guide generation between the creation modal and detail drawer.
- Allow the detail drawer's copy guide action to reveal the token when needed before copying the full guide.

## Testing
- npm run build
- git diff --check