### PR TITLE
fix: add missing web platform option and fix desktop OS labels

### DIFF
--- a/src/pages/Download/index.tsx
+++ b/src/pages/Download/index.tsx
@@ -39,6 +39,7 @@ type ForceFilter = 'all' | 'yes' | 'no'
 const osOptions = [
   { label: 'Android', value: 'android' },
   { label: 'iOS', value: 'ios' },
+  { label: 'Web', value: 'web' },
   { label: 'Windows', value: 'windows' },
   { label: 'macOS', value: 'macos' },
   { label: 'Linux', value: 'linux' },
@@ -55,7 +56,10 @@ interface PlatformMeta {
 function platformMeta(os: string): PlatformMeta {
   if (os === 'ios') return { label: 'iOS', icon: <AppleOutlined />, tone: 'ios' }
   if (os === 'android') return { label: 'Android', icon: <AndroidOutlined />, tone: 'android' }
-  if (WEB_PLATFORMS.has(os)) return { label: 'Web', icon: <GlobalOutlined />, tone: 'web' }
+  if (os === 'web') return { label: 'Web', icon: <GlobalOutlined />, tone: 'web' }
+  if (os === 'windows') return { label: 'Windows', icon: <GlobalOutlined />, tone: 'web' }
+  if (os === 'macos') return { label: 'macOS', icon: <GlobalOutlined />, tone: 'web' }
+  if (os === 'linux') return { label: 'Linux', icon: <GlobalOutlined />, tone: 'web' }
   if (os === 'openclaw-plugin') return { label: 'OpenClaw', icon: <ApiOutlined />, tone: 'plugin' }
   return { label: os.toUpperCase(), icon: null, tone: 'neutral' }
 }


### PR DESCRIPTION
## Summary

- Add `{ label: 'Web', value: 'web' }` to `osOptions`, so admins can create web platform versions via UI (fixes empty web changelog)
- Fix `platformMeta` to display actual OS name (Windows/macOS/Linux) instead of showing all as "Web"

Closes #28

## Test plan

- [ ] Open Download page → click "添加版本" → verify "Web" option appears in platform dropdown
- [ ] Create a version with platform = Web → verify it shows as "Web" in the list
- [ ] Create versions with Windows/macOS/Linux → verify each displays its own name, not "Web"
- [ ] Verify the "Web / 桌面" filter still groups web + windows + macos + linux correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)