### PR TITLE
feat(ci): add PR contributor welcome caller

### DIFF
--- a/.github/workflows/pr-contributor-welcome.yml
+++ b/.github/workflows/pr-contributor-welcome.yml
@@ -1,0 +1,19 @@
+name: PR Contributor Welcome
+
+on:
+  # pull_request_target runs in the context of the base repo so the GITHUB_TOKEN
+  # has write access even for fork PRs — required to post a welcome comment.
+  #
+  # SECURITY: the called reusable workflow does NOT check out any PR branch code;
+  # it only reads PR metadata via the GitHub API. This matches the pattern used
+  # by auto-add-to-project.yml and labeler.yml.
+  pull_request_target: # zizmor: ignore[dangerous-triggers] metadata-only automation; no PR code executed
+    types: [opened]
+
+permissions: {}
+
+jobs:
+  welcome:
+    uses: Mininglamp-OSS/.github/.github/workflows/reusable-pr-contributor-welcome.yml@main
+    permissions:
+      pull-requests: write


### PR DESCRIPTION
## Summary

Adds the `pr-contributor-welcome.yml` caller that delegates to the org-level reusable workflow [`reusable-pr-contributor-welcome.yml`](https://github.com/Mininglamp-OSS/.github/blob/main/.github/workflows/reusable-pr-contributor-welcome.yml).

**What this does:**
- Triggers on `pull_request_target: [opened]` (fork PRs included)
- Skips org members and non-first-time contributors silently
- Posts a brief welcome comment to first-time external contributors

**Security:** no code is checked out — metadata-only API calls. Same safe pattern as `labeler.yml` and `auto-add-to-project.yml`.

Part of the org-wide PR contributor welcome rollout (ref: Mininglamp-OSS/.github#32).