### PR TITLE
fix(ci): grant both issues: write and pull-requests: write

### DIFF
--- a/.github/workflows/pr-contributor-welcome.yml
+++ b/.github/workflows/pr-contributor-welcome.yml
@@ -17,3 +17,4 @@ jobs:
     uses: Mininglamp-OSS/.github/.github/workflows/reusable-pr-contributor-welcome.yml@main
     permissions:
       issues: write
+      pull-requests: write


### PR DESCRIPTION
Follow-up to the previous permission fix. The correct final pattern is to declare **both** `issues: write` and `pull-requests: write`, matching `labeler.yml`.

Per yujiawei's analysis: GitHub Actions requires `pull-requests: write` to comment on PR resources even when using the Issues REST endpoint. Granting both removes all ambiguity.