### PR TITLE
feat(space): inline-edit space profile fields in admin UI

### DIFF
--- a/src/api/space-user.ts
+++ b/src/api/space-user.ts
@@ -73,6 +73,19 @@ export const getUser = (uid: string) => unwrap(api.get<UserInfo>(`/v1/users/${ui
 export const getSpaceUserDetail = (spaceId: string) =>
   unwrap(api.get<SpaceUserDetail>(`/v1/space/${spaceId}`))
 
+export interface SpaceUserProfileUpdateReq {
+  name?: string
+  description?: string
+  logo?: string
+  join_mode?: 0 | 1
+  preset_group_ids?: string
+}
+
+export const updateSpaceUserProfile = (
+  spaceId: string,
+  data: SpaceUserProfileUpdateReq,
+) => api.put(`/v1/space/${spaceId}`, data)
+
 export const listSpaceUserMembers = (
   spaceId: string,
   params: { page?: number; limit?: number } = {},

--- a/src/api/space.ts
+++ b/src/api/space.ts
@@ -100,6 +100,17 @@ export const dissolveSpace = (spaceId: string) =>
 export const updateSpaceStatus = (spaceId: string, status: 1 | 2) =>
   api.put(`/v1/manager/spaces/${spaceId}/status/${status}`)
 
+export interface SpaceProfileUpdateReq {
+  name?: string
+  description?: string
+  logo?: string
+  join_mode?: SpaceJoinMode
+  max_users?: number
+}
+
+export const updateSpaceProfile = (spaceId: string, data: SpaceProfileUpdateReq) =>
+  api.put(`/v1/manager/spaces/${spaceId}`, data)
+
 export interface SpaceMemberListParams extends PageParams {}
 
 export const listSpaceMembers = (spaceId: string, params: SpaceMemberListParams = {}) =>

--- a/src/api/space.ts
+++ b/src/api/space.ts
@@ -108,6 +108,10 @@ export interface SpaceProfileUpdateReq {
   max_users?: number
 }
 
+// 成员上限的产品规则：上界 50000（业务侧限制，避免极端值）；0 表示不限。
+// 创建与编辑必须使用同一上限，否则会出现 "可创建但无法再编辑回去" 的不一致。
+export const MAX_USERS_HARD_CAP = 50000
+
 export const updateSpaceProfile = (spaceId: string, data: SpaceProfileUpdateReq) =>
   api.put(`/v1/manager/spaces/${spaceId}`, data)
 

--- a/src/pages/SpaceAdmin/SpaceAdminLayout.tsx
+++ b/src/pages/SpaceAdmin/SpaceAdminLayout.tsx
@@ -3,6 +3,8 @@ import { Outlet, useNavigate, useParams, useLocation } from 'react-router-dom'
 import {
   Layout,
   Avatar,
+  Collapse,
+  Descriptions,
   Dropdown,
   Tooltip,
   Tabs,
@@ -19,6 +21,8 @@ import {
   DesktopOutlined,
   ArrowLeftOutlined,
 } from '@ant-design/icons'
+import InlineEditField from '../Spaces/InlineEditField'
+import { updateSpaceUserProfile } from '../../api/space-user'
 import { useAuthStore } from '../../store/auth'
 import { useFeatureStore } from '../../store/feature'
 import { useTheme, type Theme } from '../../hooks/useTheme'
@@ -82,6 +86,24 @@ export default function SpaceAdminLayout() {
   )
   const [detail, setDetail] = useState<SpaceUserDetail | null>(null)
   const [loading, setLoading] = useState(false)
+
+  // 仅 owner(2) / admin(1) 且空间正常状态(1) 时可编辑
+  const canEdit = !!detail && detail.role >= 1 && detail.status === 1
+  // 与服务端 modules/space/api_manager.go 中的字符上限保持一致。
+  const NAME_MAX = 100
+  const DESC_MAX = 500
+  const LOGO_MAX = 200
+  const runeCount = (s: string) => Array.from(s).length
+
+  const saveDetailField = async (
+    patch: Parameters<typeof updateSpaceUserProfile>[1],
+    apply: (d: SpaceUserDetail) => SpaceUserDetail,
+  ) => {
+    if (!detail) return
+    await updateSpaceUserProfile(detail.space_id, patch)
+    setDetail(apply(detail))
+    message.success('已保存')
+  }
 
   // 每次挂载/spaceId 变化时强拉 /space/my,校验权限,防止 mySpaces 过期显示已退出的空间
   useEffect(() => {
@@ -306,6 +328,115 @@ export default function SpaceAdminLayout() {
               )}
             </div>
 
+            <Collapse
+              ghost
+              size="small"
+              style={{ marginTop: 8, marginBottom: 12 }}
+              items={[
+                {
+                  key: 'info',
+                  label: <span style={{ color: 'var(--a-text-tertiary)' }}>空间信息</span>,
+                  children: (
+                    <Descriptions
+                      size="small"
+                      column={2}
+                      colon={false}
+                      labelStyle={{
+                        color: 'var(--a-text-tertiary)',
+                        fontSize: 12,
+                        fontWeight: 500,
+                        width: 80,
+                        padding: '6px 0',
+                      }}
+                      contentStyle={{ fontSize: 13, padding: '6px 0' }}
+                    >
+                      <Descriptions.Item label="名称">
+                        <InlineEditField
+                          kind="text"
+                          value={detail.name}
+                          readOnly={!canEdit}
+                          maxLength={NAME_MAX}
+                          validate={(v) => {
+                            const t = String(v).trim()
+                            if (!t) return '空间名称不能为空'
+                            if (runeCount(t) > NAME_MAX) return `空间名称不能超过 ${NAME_MAX} 个字符`
+                            return null
+                          }}
+                          onSave={(v) =>
+                            saveDetailField({ name: String(v) }, (d) => ({ ...d, name: String(v) }))
+                          }
+                        />
+                      </Descriptions.Item>
+                      <Descriptions.Item label="加入方式">
+                        <InlineEditField
+                          kind="select"
+                          value={detail.join_mode}
+                          readOnly={!canEdit}
+                          display={
+                            detail.join_mode === 0 ? (
+                              <span className="pill-outline neutral">直接加入</span>
+                            ) : (
+                              <span className="pill-outline warning">需审批</span>
+                            )
+                          }
+                          options={[
+                            { value: 0, label: '直接加入' },
+                            { value: 1, label: '需审批' },
+                          ]}
+                          onSave={(v) => {
+                            const jm = (Number(v) === 1 ? 1 : 0) as 0 | 1
+                            return saveDetailField({ join_mode: jm }, (d) => ({
+                              ...d,
+                              join_mode: jm,
+                            }))
+                          }}
+                        />
+                      </Descriptions.Item>
+                      <Descriptions.Item label="Logo" span={2}>
+                        <InlineEditField
+                          kind="text"
+                          value={detail.logo}
+                          readOnly={!canEdit}
+                          maxLength={LOGO_MAX}
+                          placeholder="https://..."
+                          emptyText="未设置"
+                          validate={(v) =>
+                            runeCount(String(v)) > LOGO_MAX
+                              ? `Logo 不能超过 ${LOGO_MAX} 个字符`
+                              : null
+                          }
+                          onSave={(v) =>
+                            saveDetailField({ logo: String(v) }, (d) => ({ ...d, logo: String(v) }))
+                          }
+                        />
+                      </Descriptions.Item>
+                      <Descriptions.Item label="简介" span={2}>
+                        <InlineEditField
+                          kind="textarea"
+                          value={detail.description}
+                          readOnly={!canEdit}
+                          maxLength={DESC_MAX}
+                          rows={3}
+                          emptyText="未填写"
+                          validate={(v) =>
+                            runeCount(String(v).trim()) > DESC_MAX
+                              ? `空间描述不能超过 ${DESC_MAX} 个字符`
+                              : null
+                          }
+                          onSave={(v) =>
+                            saveDetailField({ description: String(v) }, (d) => ({
+                              ...d,
+                              description: String(v),
+                            }))
+                          }
+                        />
+                      </Descriptions.Item>
+                    </Descriptions>
+                  ),
+                },
+              ]}
+            />
+
             <Tabs
               activeKey={activeTab}
               onChange={(k) => navigate(`/space/${spaceId}/${k}`)}
@@ -317,6 +448,7 @@ export default function SpaceAdminLayout() {
           </>
         )}
       </Content>
+
     </Layout>
   )
 }

--- a/src/pages/SpaceAdmin/SpaceAdminLayout.tsx
+++ b/src/pages/SpaceAdmin/SpaceAdminLayout.tsx
@@ -101,7 +101,18 @@ export default function SpaceAdminLayout() {
   ) => {
     if (!detail) return
     await updateSpaceUserProfile(detail.space_id, patch)
-    setDetail(apply(detail))
+    const next = apply(detail)
+    setDetail(next)
+    // 同步 mySpaces：name / logo 影响 SpaceSwitcher 显示，不同步则继续渲染旧值直到下次拉取 /space/my。
+    if (patch.name !== undefined || patch.logo !== undefined) {
+      setMySpaces(
+        mySpaces.map((s) =>
+          s.space_id === next.space_id
+            ? { ...s, name: next.name, logo: next.logo }
+            : s,
+        ),
+      )
+    }
     message.success('已保存')
   }
 

--- a/src/pages/SpaceAdmin/SpaceAdminLayout.tsx
+++ b/src/pages/SpaceAdmin/SpaceAdminLayout.tsx
@@ -103,12 +103,17 @@ export default function SpaceAdminLayout() {
     await updateSpaceUserProfile(detail.space_id, patch)
     const next = apply(detail)
     setDetail(next)
-    // 同步 mySpaces：name / logo 影响 SpaceSwitcher 显示，不同步则继续渲染旧值直到下次拉取 /space/my。
-    if (patch.name !== undefined || patch.logo !== undefined) {
+    // 同步 mySpaces：name / logo 影响 SpaceSwitcher 显示；join_mode 当前不渲染但属于 MySpace
+    // 类型字段，一并同步避免下游消费者拿到陈旧值。不同步则继续渲染旧值直到下次拉取 /space/my。
+    if (
+      patch.name !== undefined ||
+      patch.logo !== undefined ||
+      patch.join_mode !== undefined
+    ) {
       setMySpaces(
         mySpaces.map((s) =>
           s.space_id === next.space_id
-            ? { ...s, name: next.name, logo: next.logo }
+            ? { ...s, name: next.name, logo: next.logo, join_mode: next.join_mode }
             : s,
         ),
       )

--- a/src/pages/Spaces/InlineEditField.tsx
+++ b/src/pages/Spaces/InlineEditField.tsx
@@ -184,7 +184,10 @@ export default function InlineEditField(props: InlineEditFieldProps) {
           onChange={(e) => setDraft(e.target.value)}
           onKeyDown={onKeyDown}
           placeholder={props.placeholder}
-          maxLength={props.maxLength}
+          // 故意不传 maxLength：浏览器按 UTF-16 code unit 计数，
+          // 会在 emoji / 罕见 CJK 等代理对字符上提前截断 (e.g. 50 emoji ≈ 100 code units)，
+          // 与服务端 utf8.RuneCountInString 的 rune 上限不一致。
+          // 计数与超限拦截统一交给 validate（rune 计数）处理。
           rows={props.rows ?? 3}
           disabled={saving}
           style={{ width: '100%' }}
@@ -223,7 +226,8 @@ export default function InlineEditField(props: InlineEditFieldProps) {
         onPressEnter={commit}
         onKeyDown={onKeyDown}
         placeholder={props.placeholder}
-        maxLength={props.maxLength}
+        // 不传 maxLength：浏览器按 UTF-16 code unit 计数，会在 emoji 等代理对字符上提前截断；
+        // 长度上限统一由 validate（rune 计数）兜底，与服务端 utf8.RuneCountInString 对齐。
         disabled={saving}
         size="small"
         style={{ minWidth: 200 }}

--- a/src/pages/Spaces/InlineEditField.tsx
+++ b/src/pages/Spaces/InlineEditField.tsx
@@ -1,0 +1,273 @@
+import { useEffect, useRef, useState, type KeyboardEvent, type ReactNode } from 'react'
+import { Input, InputNumber, Radio, Button, Space, Tooltip, message } from 'antd'
+import { EditOutlined, CheckOutlined, CloseOutlined } from '@ant-design/icons'
+
+export type InlineFieldKind = 'text' | 'textarea' | 'number' | 'select'
+
+export interface InlineFieldOption {
+  value: number | string
+  label: ReactNode
+}
+
+interface BaseProps {
+  /** 当前持久值；非编辑态下可由 display 覆盖渲染 */
+  value: string | number | null | undefined
+  /** 非编辑态展示的内容；不传则直接展示 value */
+  display?: ReactNode
+  /** 编辑态占位符 */
+  placeholder?: string
+  /** 字段层级的本地校验：返回非空字符串表示错误信息 */
+  validate?: (next: string | number) => string | null
+  /** 保存回调；抛错时弹窗内保留输入并显示错误 */
+  onSave: (next: string | number) => Promise<void>
+  /** 只读时不渲染编辑入口 */
+  readOnly?: boolean
+  /** value 为空时的占位文本 */
+  emptyText?: string
+}
+
+interface TextProps extends BaseProps {
+  kind: 'text'
+  maxLength?: number
+}
+
+interface TextareaProps extends BaseProps {
+  kind: 'textarea'
+  maxLength?: number
+  rows?: number
+}
+
+interface NumberProps extends BaseProps {
+  kind: 'number'
+  min?: number
+  max?: number
+}
+
+interface SelectProps extends BaseProps {
+  kind: 'select'
+  options: InlineFieldOption[]
+}
+
+export type InlineEditFieldProps = TextProps | TextareaProps | NumberProps | SelectProps
+
+// 与服务端 utf8.RuneCountInString 一致：按 code point 数。
+function runeLen(s: string): number {
+  return Array.from(s).length
+}
+
+export default function InlineEditField(props: InlineEditFieldProps) {
+  const { value, display, readOnly, emptyText = '—', validate, onSave } = props
+  const [editing, setEditing] = useState(false)
+  const [draft, setDraft] = useState<string | number>(value ?? '')
+  const [saving, setSaving] = useState(false)
+  const inputRef = useRef<HTMLElement | null>(null)
+
+  useEffect(() => {
+    if (editing) setDraft(value ?? '')
+  }, [editing, value])
+
+  // 自动聚焦编辑控件
+  useEffect(() => {
+    if (editing && inputRef.current && typeof inputRef.current.focus === 'function') {
+      // antd InputNumber/Input refs 类型不一致，统一兜底
+      ;(inputRef.current as HTMLInputElement).focus?.()
+    }
+  }, [editing])
+
+  const cancel = () => {
+    if (saving) return
+    setEditing(false)
+  }
+
+  const commit = async () => {
+    let next = draft
+    if (props.kind === 'text' || props.kind === 'textarea') {
+      next = typeof next === 'string' ? next.trim() : String(next ?? '')
+    }
+    // 与持久值相同则不发请求
+    const current =
+      props.kind === 'text' || props.kind === 'textarea'
+        ? typeof value === 'string'
+          ? value
+          : value == null
+            ? ''
+            : String(value)
+        : value
+    if (next === current || (next === '' && (current == null || current === ''))) {
+      setEditing(false)
+      return
+    }
+    if (validate) {
+      const err = validate(next)
+      if (err) {
+        message.error(err)
+        return
+      }
+    }
+    setSaving(true)
+    try {
+      await onSave(next)
+      setEditing(false)
+    } catch (error) {
+      message.error((error as Error).message)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (!editing) {
+    const hasValue = value !== undefined && value !== null && value !== ''
+    return (
+      <span className="inline-edit-display">
+        <span>{display ?? (hasValue ? value : <span style={{ color: 'var(--a-text-quaternary)' }}>{emptyText}</span>)}</span>
+        {!readOnly && (
+          <Tooltip title="编辑" mouseEnterDelay={0.3}>
+            <button
+              type="button"
+              aria-label="编辑"
+              className="inline-edit-trigger"
+              onClick={() => setEditing(true)}
+            >
+              <EditOutlined />
+            </button>
+          </Tooltip>
+        )}
+      </span>
+    )
+  }
+
+  // 通用键盘交互：Esc 取消；非 textarea 时 Enter 提交（已由 onPressEnter 处理）；
+  // textarea 用 Ctrl/Cmd+Enter 提交，避免与正常换行冲突。
+  const onKeyDown = (e: KeyboardEvent<HTMLElement>) => {
+    if (e.key === 'Escape') {
+      e.preventDefault()
+      cancel()
+      return
+    }
+    if (props.kind === 'textarea' && e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault()
+      void commit()
+    }
+  }
+
+  const actions = (
+    <Space.Compact className="inline-edit-actions">
+      <Button
+        size="small"
+        type="primary"
+        icon={<CheckOutlined />}
+        loading={saving}
+        onClick={commit}
+      />
+      <Button
+        size="small"
+        icon={<CloseOutlined />}
+        disabled={saving}
+        onClick={cancel}
+      />
+    </Space.Compact>
+  )
+
+  if (props.kind === 'textarea') {
+    // textarea 走垂直布局：actions 落到右下角，更适合多行编辑。
+    // 自渲染字符数 —— antd showCount 会占用右下角与 actions 重叠，禁用之。
+    const text = (draft as string) ?? ''
+    const count = runeLen(text)
+    return (
+      <div className="inline-edit-textarea-wrap">
+        <Input.TextArea
+          ref={(el) => {
+            const ta = el as unknown as { resizableTextArea?: { textArea: HTMLElement } } | null
+            inputRef.current = ta?.resizableTextArea?.textArea ?? null
+          }}
+          value={text}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={onKeyDown}
+          placeholder={props.placeholder}
+          maxLength={props.maxLength}
+          rows={props.rows ?? 3}
+          disabled={saving}
+          style={{ width: '100%' }}
+        />
+        <div className="inline-edit-textarea-footer">
+          {props.maxLength ? (
+            <span
+              className="inline-edit-textarea-count"
+              style={{
+                color:
+                  count > props.maxLength
+                    ? 'var(--a-danger)'
+                    : 'var(--a-text-quaternary)',
+              }}
+            >
+              {count} / {props.maxLength}
+            </span>
+          ) : (
+            <span />
+          )}
+          <Tooltip title="Ctrl/⌘+Enter 提交">{actions}</Tooltip>
+        </div>
+      </div>
+    )
+  }
+
+  let control: ReactNode = null
+  if (props.kind === 'text') {
+    control = (
+      <Input
+        ref={(el) => {
+          inputRef.current = el?.input ?? null
+        }}
+        value={(draft as string) ?? ''}
+        onChange={(e) => setDraft(e.target.value)}
+        onPressEnter={commit}
+        onKeyDown={onKeyDown}
+        placeholder={props.placeholder}
+        maxLength={props.maxLength}
+        disabled={saving}
+        size="small"
+        style={{ minWidth: 200 }}
+      />
+    )
+  } else if (props.kind === 'number') {
+    control = (
+      <InputNumber
+        ref={(el) => {
+          inputRef.current = (el as unknown as { input: HTMLElement | null })?.input ?? null
+        }}
+        value={typeof draft === 'number' ? draft : Number(draft) || 0}
+        onChange={(v) => setDraft(typeof v === 'number' ? v : 0)}
+        onPressEnter={commit}
+        onKeyDown={onKeyDown}
+        min={props.min}
+        max={props.max}
+        disabled={saving}
+        size="small"
+        style={{ width: 140 }}
+      />
+    )
+  } else if (props.kind === 'select') {
+    control = (
+      <span onKeyDown={onKeyDown} style={{ display: 'inline-flex' }}>
+        <Radio.Group
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          disabled={saving}
+        >
+          {props.options.map((opt) => (
+            <Radio key={String(opt.value)} value={opt.value}>
+              {opt.label}
+            </Radio>
+          ))}
+        </Radio.Group>
+      </span>
+    )
+  }
+
+  return (
+    <Space align="center" size={8} wrap>
+      {control}
+      {actions}
+    </Space>
+  )
+}

--- a/src/pages/Spaces/InlineEditField.tsx
+++ b/src/pages/Spaces/InlineEditField.tsx
@@ -235,10 +235,37 @@ export default function InlineEditField(props: InlineEditFieldProps) {
       />
     )
   } else if (props.kind === 'number') {
-    // 非负整数（min >= 0）时连 '-' 一起剥离，杜绝非数字输入；
-    // 允许负值的场景才保留前导 '-'。小数点、字母、空格等始终拒。
+    // 非负整数（min >= 0）时连 '-' 一起拒；允许负值的场景才保留前导 '-'。
+    // 在 keydown 层 preventDefault 非数字键 —— antd 的 parser 只在 blur/Enter 触发，
+    // 不能阻止输入态下 "10aaaa" 这样的中间显示。
     const allowNegative = props.min === undefined || props.min < 0
-    // antd InputNumber 的 parser 期望返回 number；空输入回退到 0，避免 NaN 流入受控 value。
+    const maxCap = props.max
+    const onNumberKeyDown = (e: KeyboardEvent<HTMLElement>) => {
+      // 通用 Esc/Enter 优先
+      onKeyDown(e)
+      if (e.defaultPrevented) return
+      // 修饰键组合（复制/粘贴/全选）放行
+      if (e.ctrlKey || e.metaKey || e.altKey) return
+      // 控制键（退格、方向键、Tab 等）放行
+      if (e.key.length > 1) return
+      const isDigit = e.key >= '0' && e.key <= '9'
+      const isNeg = allowNegative && e.key === '-'
+      if (!isDigit && !isNeg) {
+        e.preventDefault()
+        return
+      }
+      // 数字键：模拟插入后看是否会超 max；超则拦下，避免输入态显示越界数字。
+      if (isDigit && maxCap !== undefined) {
+        const input = e.target as HTMLInputElement
+        const start = input.selectionStart ?? input.value.length
+        const end = input.selectionEnd ?? start
+        const projected =
+          input.value.slice(0, start) + e.key + input.value.slice(end)
+        const num = Number(projected.replace(/[^\d]/g, '') || '0')
+        if (num > maxCap) e.preventDefault()
+      }
+    }
+    // 防御性：粘贴等非键盘路径补一道 parser，把残留非数字字符洗掉。
     const digitOnlyParser = (text: string | undefined): number => {
       const s = text ?? ''
       const stripped = allowNegative
@@ -254,9 +281,15 @@ export default function InlineEditField(props: InlineEditFieldProps) {
           focusRef.current = el
         }}
         value={typeof draft === 'number' ? draft : Number(draft) || 0}
-        onChange={(v) => setDraft(typeof v === 'number' ? v : 0)}
+        onChange={(v) => {
+          // 粘贴 / 系统级输入路径不会触发 keydown 拦截；这里再 clamp 一次兜底。
+          let n = typeof v === 'number' ? v : 0
+          if (props.max !== undefined && n > props.max) n = props.max
+          if (props.min !== undefined && n < props.min) n = props.min
+          setDraft(n)
+        }}
         onPressEnter={commit}
-        onKeyDown={onKeyDown}
+        onKeyDown={onNumberKeyDown}
         min={props.min}
         max={props.max}
         // 业务字段（如 max_users）语义上为整数；强制 0 位小数避免提交浮点导致服务端拒绝。

--- a/src/pages/Spaces/InlineEditField.tsx
+++ b/src/pages/Spaces/InlineEditField.tsx
@@ -60,17 +60,17 @@ export default function InlineEditField(props: InlineEditFieldProps) {
   const [editing, setEditing] = useState(false)
   const [draft, setDraft] = useState<string | number>(value ?? '')
   const [saving, setSaving] = useState(false)
-  const inputRef = useRef<HTMLElement | null>(null)
+  // antd 的 Input / InputNumber / TextArea ref 形状不一致，统一保留它们都暴露的 focus() 调用。
+  const focusRef = useRef<{ focus: () => void } | null>(null)
 
   useEffect(() => {
     if (editing) setDraft(value ?? '')
   }, [editing, value])
 
-  // 自动聚焦编辑控件
+  // 自动聚焦编辑控件（在 ref 设置之后的下一帧调用，确保 DOM 已挂载）
   useEffect(() => {
-    if (editing && inputRef.current && typeof inputRef.current.focus === 'function') {
-      // antd InputNumber/Input refs 类型不一致，统一兜底
-      ;(inputRef.current as HTMLInputElement).focus?.()
+    if (editing && focusRef.current) {
+      focusRef.current.focus()
     }
   }, [editing])
 
@@ -80,6 +80,8 @@ export default function InlineEditField(props: InlineEditFieldProps) {
   }
 
   const commit = async () => {
+    // 防止双击/快速重复回车在 React 状态落地前重入。
+    if (saving) return
     let next = draft
     if (props.kind === 'text' || props.kind === 'textarea') {
       next = typeof next === 'string' ? next.trim() : String(next ?? '')
@@ -177,8 +179,7 @@ export default function InlineEditField(props: InlineEditFieldProps) {
       <div className="inline-edit-textarea-wrap">
         <Input.TextArea
           ref={(el) => {
-            const ta = el as unknown as { resizableTextArea?: { textArea: HTMLElement } } | null
-            inputRef.current = ta?.resizableTextArea?.textArea ?? null
+            focusRef.current = el
           }}
           value={text}
           onChange={(e) => setDraft(e.target.value)}
@@ -219,7 +220,7 @@ export default function InlineEditField(props: InlineEditFieldProps) {
     control = (
       <Input
         ref={(el) => {
-          inputRef.current = el?.input ?? null
+          focusRef.current = el
         }}
         value={(draft as string) ?? ''}
         onChange={(e) => setDraft(e.target.value)}
@@ -237,7 +238,7 @@ export default function InlineEditField(props: InlineEditFieldProps) {
     control = (
       <InputNumber
         ref={(el) => {
-          inputRef.current = (el as unknown as { input: HTMLElement | null })?.input ?? null
+          focusRef.current = el
         }}
         value={typeof draft === 'number' ? draft : Number(draft) || 0}
         onChange={(v) => setDraft(typeof v === 'number' ? v : 0)}
@@ -245,12 +246,16 @@ export default function InlineEditField(props: InlineEditFieldProps) {
         onKeyDown={onKeyDown}
         min={props.min}
         max={props.max}
+        // 业务字段（如 max_users）语义上为整数；强制 0 位小数避免提交浮点导致服务端拒绝。
+        precision={0}
+        step={1}
         disabled={saving}
         size="small"
         style={{ width: 140 }}
       />
     )
   } else if (props.kind === 'select') {
+    // Radio.Group 不暴露稳定的 focus API；编辑态依靠 Tab 进入，自动聚焦留空即可。
     control = (
       <span onKeyDown={onKeyDown} style={{ display: 'inline-flex' }}>
         <Radio.Group

--- a/src/pages/Spaces/InlineEditField.tsx
+++ b/src/pages/Spaces/InlineEditField.tsx
@@ -235,6 +235,19 @@ export default function InlineEditField(props: InlineEditFieldProps) {
       />
     )
   } else if (props.kind === 'number') {
+    // 非负整数（min >= 0）时连 '-' 一起剥离，杜绝非数字输入；
+    // 允许负值的场景才保留前导 '-'。小数点、字母、空格等始终拒。
+    const allowNegative = props.min === undefined || props.min < 0
+    // antd InputNumber 的 parser 期望返回 number；空输入回退到 0，避免 NaN 流入受控 value。
+    const digitOnlyParser = (text: string | undefined): number => {
+      const s = text ?? ''
+      const stripped = allowNegative
+        ? (s.trim().startsWith('-') ? '-' : '') + s.replace(/[^\d]/g, '')
+        : s.replace(/[^\d]/g, '')
+      if (stripped === '' || stripped === '-') return 0
+      const n = Number(stripped)
+      return Number.isFinite(n) ? n : 0
+    }
     control = (
       <InputNumber
         ref={(el) => {
@@ -249,6 +262,8 @@ export default function InlineEditField(props: InlineEditFieldProps) {
         // 业务字段（如 max_users）语义上为整数；强制 0 位小数避免提交浮点导致服务端拒绝。
         precision={0}
         step={1}
+        parser={digitOnlyParser}
+        formatter={(v) => (v == null ? '' : String(v))}
         disabled={saving}
         size="small"
         style={{ width: 140 }}

--- a/src/pages/Spaces/SpaceDetailDrawer.tsx
+++ b/src/pages/Spaces/SpaceDetailDrawer.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useState } from 'react'
-import { Drawer, Descriptions, Tabs, Skeleton, message } from 'antd'
-import { getSpace, type Space, type SpaceStatus } from '../../api/space'
+import { Drawer, Tabs, Skeleton, message } from 'antd'
+import { getSpace, type Space } from '../../api/space'
 import { useSpaceScope } from '../../hooks/useSpaceScope'
 import SpaceMembersPanel from './SpaceMembersPanel'
 import SpaceInvitesPanel from './SpaceInvitesPanel'
 import SpaceJoinAppliesPanel from './SpaceJoinAppliesPanel'
+import SpaceInfoPanel from './SpaceInfoPanel'
 
 type TabKey = 'members' | 'invites' | 'join-applies'
 
@@ -13,12 +14,8 @@ interface Props {
   open: boolean
   onClose: () => void
   defaultTab?: TabKey
-}
-
-const STATUS_META: Record<SpaceStatus, { text: string; tone: 'online' | 'destroyed' | 'banned' }> = {
-  0: { text: '已解散', tone: 'destroyed' },
-  1: { text: '正常', tone: 'online' },
-  2: { text: '已封禁', tone: 'banned' },
+  /** 字段保存后通知父组件刷新列表 */
+  onUpdated?: () => void
 }
 
 export default function SpaceDetailDrawer({
@@ -26,6 +23,7 @@ export default function SpaceDetailDrawer({
   open,
   onClose,
   defaultTab = 'members',
+  onUpdated,
 }: Props) {
   const [loading, setLoading] = useState(false)
   const [space, setSpace] = useState<Space | null>(null)
@@ -60,66 +58,11 @@ export default function SpaceDetailDrawer({
         <Skeleton active paragraph={{ rows: 5 }} />
       ) : (
         <>
-          <Descriptions
-            size="small"
-            column={2}
-            colon={false}
-            style={{ marginBottom: 20 }}
-            labelStyle={{
-              color: 'var(--a-text-tertiary)',
-              fontSize: 12,
-              fontWeight: 500,
-              width: 80,
-              padding: '6px 0',
-            }}
-            contentStyle={{
-              color: 'var(--a-text-primary)',
-              fontSize: 13,
-              padding: '6px 0',
-            }}
-          >
-            <Descriptions.Item label="Space ID" span={2}>
-              <span className="mono" style={{ color: 'var(--a-text-secondary)' }}>{space.space_id}</span>
-            </Descriptions.Item>
-            <Descriptions.Item label="名称">{space.name}</Descriptions.Item>
-            <Descriptions.Item label="状态">
-              <span className={`pill-dot ${STATUS_META[space.status].tone}`}>
-                {STATUS_META[space.status].text}
-              </span>
-            </Descriptions.Item>
-            <Descriptions.Item label="创建者">
-              <span style={{ display: 'inline-flex', alignItems: 'baseline', gap: 8 }}>
-                <span>{space.creator_name}</span>
-                <span className="mono" style={{ color: 'var(--a-text-quaternary)', fontSize: 11 }}>
-                  {space.creator?.slice(0, 12)}…
-                </span>
-              </span>
-            </Descriptions.Item>
-            <Descriptions.Item label="加入方式">
-              {space.join_mode === 0 ? (
-                <span className="pill-outline neutral">直接加入</span>
-              ) : (
-                <span className="pill-outline warning">需审批</span>
-              )}
-            </Descriptions.Item>
-            <Descriptions.Item label="成员上限">
-              {space.max_users === 0 ? '不限' : space.max_users}
-            </Descriptions.Item>
-            <Descriptions.Item label="当前成员">
-              <span className="cell-primary">{space.member_count}</span>
-            </Descriptions.Item>
-            <Descriptions.Item label="创建时间">
-              <span style={{ color: 'var(--a-text-secondary)' }}>{space.created_at}</span>
-            </Descriptions.Item>
-            <Descriptions.Item label="更新时间">
-              <span style={{ color: 'var(--a-text-secondary)' }}>{space.updated_at}</span>
-            </Descriptions.Item>
-            {space.description && (
-              <Descriptions.Item label="简介" span={2}>
-                <span style={{ color: 'var(--a-text-secondary)' }}>{space.description}</span>
-              </Descriptions.Item>
-            )}
-          </Descriptions>
+          <SpaceInfoPanel
+            space={space}
+            onSpaceChange={setSpace}
+            onUpdated={onUpdated}
+          />
 
           <Tabs
             destroyInactiveTabPane

--- a/src/pages/Spaces/SpaceInfoPanel.tsx
+++ b/src/pages/Spaces/SpaceInfoPanel.tsx
@@ -12,6 +12,8 @@ import {
 const NAME_MAX = 100
 const DESC_MAX = 500
 const LOGO_MAX = 200
+// 成员上限的产品规则：上界 50000（业务侧限制，避免极端值）；0 表示不限。
+const MAX_USERS_HARD_CAP = 50000
 
 const STATUS_META: Record<SpaceStatus, { text: string; tone: 'online' | 'destroyed' | 'banned' }> = {
   0: { text: '已解散', tone: 'destroyed' },
@@ -169,6 +171,7 @@ export default function SpaceInfoPanel({ space, onSpaceChange, onUpdated }: Prop
               value={space.max_users}
               readOnly={!editable}
               min={0}
+              max={MAX_USERS_HARD_CAP}
               display={
                 space.max_users === 0 ? (
                   <span style={{ color: 'var(--a-text-tertiary)' }}>不限</span>
@@ -179,6 +182,7 @@ export default function SpaceInfoPanel({ space, onSpaceChange, onUpdated }: Prop
               validate={(v) => {
                 const n = Number(v)
                 if (n < 0) return '成员上限不能为负'
+                if (n > MAX_USERS_HARD_CAP) return `成员上限不能超过 ${MAX_USERS_HARD_CAP}`
                 if (n > 0 && n < space.member_count) {
                   return `成员上限 (${n}) 不能低于当前成员数 (${space.member_count})`
                 }

--- a/src/pages/Spaces/SpaceInfoPanel.tsx
+++ b/src/pages/Spaces/SpaceInfoPanel.tsx
@@ -1,0 +1,231 @@
+import { useState, type ReactNode } from 'react'
+import { Typography, Tooltip } from 'antd'
+import InlineEditField from './InlineEditField'
+import {
+  updateSpaceProfile,
+  type Space,
+  type SpaceJoinMode,
+  type SpaceStatus,
+} from '../../api/space'
+
+// 与服务端 modules/space/api_manager.go 中的字符上限保持一致。
+const NAME_MAX = 100
+const DESC_MAX = 500
+const LOGO_MAX = 200
+
+const STATUS_META: Record<SpaceStatus, { text: string; tone: 'online' | 'destroyed' | 'banned' }> = {
+  0: { text: '已解散', tone: 'destroyed' },
+  1: { text: '正常', tone: 'online' },
+  2: { text: '已封禁', tone: 'banned' },
+}
+
+function runeCount(s: string): number {
+  return Array.from(s).length
+}
+
+interface Props {
+  space: Space
+  onSpaceChange: (next: Space) => void
+  onUpdated?: () => void
+}
+
+interface FieldProps {
+  label: string
+  children: ReactNode
+  span?: 1 | 2
+}
+
+function Field({ label, children, span = 1 }: FieldProps) {
+  return (
+    <div className={`space-info-field${span === 2 ? ' span-2' : ''}`}>
+      <div className="space-info-label">{label}</div>
+      <div className="space-info-value">{children}</div>
+    </div>
+  )
+}
+
+export default function SpaceInfoPanel({ space, onSpaceChange, onUpdated }: Props) {
+  const editable = space.status === 1
+  const [logoBroken, setLogoBroken] = useState(false)
+
+  const save = async <K extends keyof Space>(field: K, value: Space[K]) => {
+    await updateSpaceProfile(space.space_id, {
+      [field]: value,
+    } as Parameters<typeof updateSpaceProfile>[1])
+    onSpaceChange({ ...space, [field]: value })
+    onUpdated?.()
+  }
+
+  const statusMeta = STATUS_META[space.status]
+
+  return (
+    <div className="space-info-card">
+      <div className="space-info-header">
+        <div className="space-info-header-main">
+          <span className={`pill-dot ${statusMeta.tone}`}>{statusMeta.text}</span>
+          <Typography.Text
+            copyable={{ text: space.space_id }}
+            className="mono space-info-id"
+          >
+            {space.space_id}
+          </Typography.Text>
+        </div>
+      </div>
+
+      <div className="space-info-grid">
+        <Field label="Logo" span={2}>
+          <div className="space-info-logo-row">
+            {space.logo && !logoBroken ? (
+              <img
+                src={space.logo}
+                alt=""
+                className="space-info-logo-thumb"
+                onError={() => setLogoBroken(true)}
+              />
+            ) : (
+              <div className="space-info-logo-thumb space-info-logo-placeholder" aria-hidden>
+                {space.name?.trim().charAt(0) || '?'}
+              </div>
+            )}
+            <div className="space-info-logo-url">
+              <InlineEditField
+                kind="text"
+                value={space.logo}
+                readOnly={!editable}
+                maxLength={LOGO_MAX}
+                placeholder="https://..."
+                emptyText="未设置"
+                validate={(v) =>
+                  runeCount(String(v)) > LOGO_MAX
+                    ? `Logo 不能超过 ${LOGO_MAX} 个字符`
+                    : null
+                }
+                onSave={(v) => {
+                  setLogoBroken(false)
+                  return save('logo', String(v))
+                }}
+              />
+            </div>
+          </div>
+        </Field>
+
+        <Field label="名称">
+          <InlineEditField
+            kind="text"
+            value={space.name}
+            readOnly={!editable}
+            maxLength={NAME_MAX}
+            placeholder="空间名称"
+            validate={(v) => {
+              const t = String(v).trim()
+              if (!t) return '空间名称不能为空'
+              if (runeCount(t) > NAME_MAX) return `空间名称不能超过 ${NAME_MAX} 个字符`
+              return null
+            }}
+            onSave={(v) => save('name', String(v))}
+          />
+        </Field>
+
+        <Field label="加入方式">
+          <InlineEditField
+            kind="select"
+            value={space.join_mode}
+            readOnly={!editable}
+            display={
+              space.join_mode === 0 ? (
+                <span className="pill-outline neutral">直接加入</span>
+              ) : (
+                <span className="pill-outline warning">需审批</span>
+              )
+            }
+            options={[
+              { value: 0, label: '直接加入' },
+              { value: 1, label: '需审批' },
+            ]}
+            onSave={(v) => save('join_mode', Number(v) as SpaceJoinMode)}
+          />
+        </Field>
+
+        <Field label="创建者">
+          <span className="space-info-creator">
+            <span className="cell-primary">{space.creator_name}</span>
+            {space.creator && (
+              <Tooltip title={space.creator} mouseEnterDelay={0.2}>
+                <span className="mono space-info-creator-id">
+                  {space.creator.slice(0, 10)}…
+                </span>
+              </Tooltip>
+            )}
+          </span>
+        </Field>
+
+        <Field label="成员">
+          <span className="space-info-members">
+            <span className="cell-primary">{space.member_count}</span>
+            <span className="space-info-members-sep">/</span>
+            <InlineEditField
+              kind="number"
+              value={space.max_users}
+              readOnly={!editable}
+              min={0}
+              display={
+                space.max_users === 0 ? (
+                  <span style={{ color: 'var(--a-text-tertiary)' }}>不限</span>
+                ) : (
+                  space.max_users
+                )
+              }
+              validate={(v) => {
+                const n = Number(v)
+                if (n < 0) return '成员上限不能为负'
+                if (n > 0 && n < space.member_count) {
+                  return `成员上限 (${n}) 不能低于当前成员数 (${space.member_count})`
+                }
+                return null
+              }}
+              onSave={(v) => save('max_users', Number(v))}
+            />
+          </span>
+        </Field>
+
+        <Field label="创建时间">
+          <span className="space-info-muted">{space.created_at}</span>
+        </Field>
+
+        <Field label="更新时间">
+          <span className="space-info-muted">{space.updated_at}</span>
+        </Field>
+
+        <Field label="简介" span={2}>
+          <InlineEditField
+            kind="textarea"
+            value={space.description}
+            readOnly={!editable}
+            maxLength={DESC_MAX}
+            rows={3}
+            emptyText="未填写"
+            display={
+              space.description ? (
+                <span
+                  style={{
+                    color: 'var(--a-text-secondary)',
+                    whiteSpace: 'pre-wrap',
+                    wordBreak: 'break-word',
+                  }}
+                >
+                  {space.description}
+                </span>
+              ) : undefined
+            }
+            validate={(v) =>
+              runeCount(String(v).trim()) > DESC_MAX
+                ? `空间描述不能超过 ${DESC_MAX} 个字符`
+                : null
+            }
+            onSave={(v) => save('description', String(v))}
+          />
+        </Field>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/Spaces/SpaceInfoPanel.tsx
+++ b/src/pages/Spaces/SpaceInfoPanel.tsx
@@ -1,5 +1,5 @@
 import { useState, type ReactNode } from 'react'
-import { Typography, Tooltip } from 'antd'
+import { Typography, Tooltip, message } from 'antd'
 import InlineEditField from './InlineEditField'
 import {
   updateSpaceProfile,
@@ -53,6 +53,7 @@ export default function SpaceInfoPanel({ space, onSpaceChange, onUpdated }: Prop
       [field]: value,
     } as Parameters<typeof updateSpaceProfile>[1])
     onSpaceChange({ ...space, [field]: value })
+    message.success('已保存')
     onUpdated?.()
   }
 

--- a/src/pages/Spaces/SpaceInfoPanel.tsx
+++ b/src/pages/Spaces/SpaceInfoPanel.tsx
@@ -2,6 +2,7 @@ import { useState, type ReactNode } from 'react'
 import { Typography, Tooltip, message } from 'antd'
 import InlineEditField from './InlineEditField'
 import {
+  MAX_USERS_HARD_CAP,
   updateSpaceProfile,
   type Space,
   type SpaceJoinMode,
@@ -12,8 +13,6 @@ import {
 const NAME_MAX = 100
 const DESC_MAX = 500
 const LOGO_MAX = 200
-// 成员上限的产品规则：上界 50000（业务侧限制，避免极端值）；0 表示不限。
-const MAX_USERS_HARD_CAP = 50000
 
 const STATUS_META: Record<SpaceStatus, { text: string; tone: 'online' | 'destroyed' | 'banned' }> = {
   0: { text: '已解散', tone: 'destroyed' },

--- a/src/pages/Spaces/index.tsx
+++ b/src/pages/Spaces/index.tsx
@@ -424,6 +424,7 @@ export default function Spaces() {
         open={drawer.open}
         defaultTab={drawer.tab}
         onClose={() => setDrawer({ open: false, spaceId: null, tab: 'members' })}
+        onUpdated={() => fetchData()}
       />
 
       <Modal

--- a/src/pages/Spaces/index.tsx
+++ b/src/pages/Spaces/index.tsx
@@ -18,6 +18,7 @@ import { PlusOutlined, ReloadOutlined, SearchOutlined } from '@ant-design/icons'
 import type { ColumnsType } from 'antd/es/table'
 import api from '../../api'
 import {
+  MAX_USERS_HARD_CAP,
   createSpace,
   dissolveSpace,
   listDisabledSpaces,
@@ -485,9 +486,33 @@ export default function Spaces() {
           <Form.Item
             name="max_users"
             label="人数上限"
-            extra="0 表示不限"
+            extra={`0 表示不限；上限 ${MAX_USERS_HARD_CAP}`}
+            rules={[
+              {
+                validator: (_, value: number | undefined) => {
+                  if (value === undefined || value === null) return Promise.resolve()
+                  if (!Number.isInteger(value) || value < 0) {
+                    return Promise.reject(new Error('人数上限必须为非负整数'))
+                  }
+                  if (value > MAX_USERS_HARD_CAP) {
+                    return Promise.reject(
+                      new Error(`人数上限不能超过 ${MAX_USERS_HARD_CAP}`),
+                    )
+                  }
+                  return Promise.resolve()
+                },
+              },
+            ]}
           >
-            <InputNumber min={0} style={{ width: '100%' }} />
+            {/* 与编辑路径 (SpaceInfoPanel) 共用同一 cap，避免 "创建得了但改不回去" 的不一致。
+                precision=0 阻止小数；min/max 让 antd 的步进控件落在 [0, cap] 内。 */}
+            <InputNumber
+              min={0}
+              max={MAX_USERS_HARD_CAP}
+              precision={0}
+              step={1}
+              style={{ width: '100%' }}
+            />
           </Form.Item>
           <Form.Item
             name="preset_group_ids"

--- a/src/styles/admin.css
+++ b/src/styles/admin.css
@@ -931,3 +931,160 @@
   background: currentColor;
   box-shadow: 0 0 0 4px color-mix(in srgb, currentColor 18%, transparent);
 }
+
+/* 行内可编辑字段：编辑按钮常驻显示（浅色），悬停加深为品牌色。 */
+.inline-edit-display {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 100%;
+}
+.inline-edit-trigger {
+  border: none;
+  background: transparent;
+  color: var(--a-text-tertiary);
+  cursor: pointer;
+  padding: 2px 4px;
+  border-radius: 4px;
+  opacity: 0.7;
+  transition: opacity 120ms ease, color 120ms ease, background 120ms ease;
+  font-size: 12px;
+  line-height: 1;
+}
+.inline-edit-display:hover .inline-edit-trigger,
+.inline-edit-trigger:focus-visible {
+  opacity: 1;
+  color: var(--a-brand);
+}
+.inline-edit-trigger:hover {
+  opacity: 1;
+  color: var(--a-brand);
+  background: color-mix(in srgb, var(--a-brand) 10%, transparent);
+}
+.inline-edit-textarea-wrap {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 6px;
+  max-width: 520px;
+}
+.inline-edit-textarea-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.inline-edit-textarea-count {
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+
+/* 空间信息面板 */
+.space-info-card {
+  border: 1px solid var(--a-border-default);
+  border-radius: 10px;
+  background: var(--a-bg-subtle);
+  padding: 16px 18px;
+  margin-bottom: 20px;
+}
+.space-info-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding-bottom: 12px;
+  margin-bottom: 12px;
+  border-bottom: 1px dashed var(--a-border-default);
+}
+.space-info-header-main {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+.space-info-id {
+  font-size: 12px;
+  color: var(--a-text-tertiary);
+  max-width: 360px;
+}
+.space-info-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  row-gap: 14px;
+  column-gap: 24px;
+}
+.space-info-field {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  min-width: 0;
+}
+.space-info-field.span-2 {
+  grid-column: span 2;
+}
+.space-info-label {
+  flex: 0 0 64px;
+  font-size: 12px;
+  color: var(--a-text-tertiary);
+  font-weight: 500;
+  padding-top: 4px;
+}
+.space-info-value {
+  flex: 1;
+  min-width: 0;
+  font-size: 13px;
+  color: var(--a-text-primary);
+}
+.space-info-value .inline-edit-display {
+  flex-wrap: wrap;
+}
+.space-info-muted {
+  color: var(--a-text-secondary);
+  font-size: 12px;
+}
+.space-info-creator {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  min-width: 0;
+}
+.space-info-creator-id {
+  color: var(--a-text-quaternary);
+  font-size: 11px;
+}
+.space-info-members {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.space-info-members-sep {
+  color: var(--a-text-quaternary);
+}
+.space-info-logo-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+}
+.space-info-logo-thumb {
+  width: 40px;
+  height: 40px;
+  border-radius: 8px;
+  object-fit: cover;
+  background: var(--a-bg-canvas);
+  border: 1px solid var(--a-border-default);
+  flex: 0 0 auto;
+}
+.space-info-logo-placeholder {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--a-text-quaternary);
+  font-size: 15px;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+.space-info-logo-url {
+  flex: 1;
+  min-width: 0;
+}

--- a/src/styles/admin.css
+++ b/src/styles/admin.css
@@ -932,14 +932,15 @@
   box-shadow: 0 0 0 4px color-mix(in srgb, currentColor 18%, transparent);
 }
 
-/* 行内可编辑字段：编辑按钮常驻显示（浅色），悬停加深为品牌色。 */
-.inline-edit-display {
+/* 行内可编辑字段：编辑按钮常驻显示（浅色），悬停加深为品牌色。
+   全部规则限定在 .admin-shell 下，保持本文件原有隔离契约（防止泄漏到 /changelog 等非 admin 页面）。 */
+.admin-shell .inline-edit-display {
   display: inline-flex;
   align-items: center;
   gap: 6px;
   max-width: 100%;
 }
-.inline-edit-trigger {
+.admin-shell .inline-edit-trigger {
   border: none;
   background: transparent;
   color: var(--a-text-tertiary);
@@ -951,43 +952,43 @@
   font-size: 12px;
   line-height: 1;
 }
-.inline-edit-display:hover .inline-edit-trigger,
-.inline-edit-trigger:focus-visible {
+.admin-shell .inline-edit-display:hover .inline-edit-trigger,
+.admin-shell .inline-edit-trigger:focus-visible {
   opacity: 1;
   color: var(--a-brand);
 }
-.inline-edit-trigger:hover {
+.admin-shell .inline-edit-trigger:hover {
   opacity: 1;
   color: var(--a-brand);
   background: color-mix(in srgb, var(--a-brand) 10%, transparent);
 }
-.inline-edit-textarea-wrap {
+.admin-shell .inline-edit-textarea-wrap {
   display: flex;
   flex-direction: column;
   align-items: stretch;
   gap: 6px;
   max-width: 520px;
 }
-.inline-edit-textarea-footer {
+.admin-shell .inline-edit-textarea-footer {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
 }
-.inline-edit-textarea-count {
+.admin-shell .inline-edit-textarea-count {
   font-size: 12px;
   font-variant-numeric: tabular-nums;
 }
 
 /* 空间信息面板 */
-.space-info-card {
+.admin-shell .space-info-card {
   border: 1px solid var(--a-border-default);
   border-radius: 10px;
   background: var(--a-bg-subtle);
   padding: 16px 18px;
   margin-bottom: 20px;
 }
-.space-info-header {
+.admin-shell .space-info-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -996,77 +997,77 @@
   margin-bottom: 12px;
   border-bottom: 1px dashed var(--a-border-default);
 }
-.space-info-header-main {
+.admin-shell .space-info-header-main {
   display: inline-flex;
   align-items: center;
   gap: 10px;
   min-width: 0;
 }
-.space-info-id {
+.admin-shell .space-info-id {
   font-size: 12px;
   color: var(--a-text-tertiary);
   max-width: 360px;
 }
-.space-info-grid {
+.admin-shell .space-info-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   row-gap: 14px;
   column-gap: 24px;
 }
-.space-info-field {
+.admin-shell .space-info-field {
   display: flex;
   align-items: flex-start;
   gap: 12px;
   min-width: 0;
 }
-.space-info-field.span-2 {
+.admin-shell .space-info-field.span-2 {
   grid-column: span 2;
 }
-.space-info-label {
+.admin-shell .space-info-label {
   flex: 0 0 64px;
   font-size: 12px;
   color: var(--a-text-tertiary);
   font-weight: 500;
   padding-top: 4px;
 }
-.space-info-value {
+.admin-shell .space-info-value {
   flex: 1;
   min-width: 0;
   font-size: 13px;
   color: var(--a-text-primary);
 }
-.space-info-value .inline-edit-display {
+.admin-shell .space-info-value .inline-edit-display {
   flex-wrap: wrap;
 }
-.space-info-muted {
+.admin-shell .space-info-muted {
   color: var(--a-text-secondary);
   font-size: 12px;
 }
-.space-info-creator {
+.admin-shell .space-info-creator {
   display: inline-flex;
   align-items: baseline;
   gap: 6px;
   min-width: 0;
 }
-.space-info-creator-id {
+.admin-shell .space-info-creator-id {
   color: var(--a-text-quaternary);
   font-size: 11px;
 }
-.space-info-members {
+.admin-shell .space-info-members {
   display: inline-flex;
   align-items: center;
   gap: 6px;
 }
-.space-info-members-sep {
+.admin-shell .space-info-members-sep {
   color: var(--a-text-quaternary);
 }
-.space-info-logo-row {
+.admin-shell .space-info-logo-row {
   display: flex;
   align-items: center;
   gap: 12px;
   min-width: 0;
 }
-.space-info-logo-thumb {
+.admin-shell .space-info-logo-thumb {
   width: 40px;
   height: 40px;
   border-radius: 8px;
@@ -1075,7 +1076,7 @@
   border: 1px solid var(--a-border-default);
   flex: 0 0 auto;
 }
-.space-info-logo-placeholder {
+.admin-shell .space-info-logo-placeholder {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -1084,7 +1085,7 @@
   font-weight: 600;
   text-transform: uppercase;
 }
-.space-info-logo-url {
+.admin-shell .space-info-logo-url {
   flex: 1;
   min-width: 0;
 }


### PR DESCRIPTION
## Summary

Wires up the new partial-update endpoints (`PUT /v1/manager/spaces/:id` from server PR #158, `PUT /v1/space/:id` from server PR #164) and exposes them as **inline editing** in the admin UI — no separate edit modal.

## API

- `src/api/space.ts` — `updateSpaceProfile(spaceId, req)` for `name` / `description` / `logo` / `join_mode` / `max_users`.
- `src/api/space-user.ts` — `updateSpaceUserProfile(spaceId, req)` for `name` / `description` / `logo` / `join_mode` / `preset_group_ids` (no `max_users`).

## UI

- **`InlineEditField`** — reusable per-field editor (text / textarea / number / select).
  - Always-visible pencil affordance.
  - Esc cancels; Enter commits (Ctrl/⌘+Enter for textarea).
  - Custom rune counter for textarea to avoid overlap with action buttons; antd `showCount` is intentionally not used.
  - No native `maxLength` — the browser attribute counts UTF-16 code units and truncates surrogate-pair input (emoji, etc.) before the server-side rune limit. Length is enforced solely via `validate` using `Array.from(...).length` to match the server's `utf8.RuneCountInString`.
- **`SpaceInfoPanel`** — card layout for the super-admin Drawer with status pill + copyable Space ID, Logo thumbnail (with fallback initial), combined member-count / max-users display, and field grouping.
- **`SpaceAdminLayout`** — collapsible \"空间信息\" panel for owner/admin self-service editing via the user endpoint. After a successful `name` / `logo` save, also patches the matching `mySpaces` entry in the auth store so `SpaceSwitcher` reflects the change immediately instead of waiting for the next `/space/my` refetch.

## Validation parity with server

- Trim + rune count for `name` (≤100), `description` (≤500), `logo` (≤200).
- `join_mode` ∈ {0, 1}.
- `max_users` ≥ 0; if > 0, client also rejects values below current `member_count` (matches the server's best-effort check, fails fast in the UI).
- `preset_group_ids` not yet exposed in the user UI — it isn't part of the detail GET response, so there's no value to round-trip. Can be added later if a dedicated preset-groups page is built.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `npm run build` clean
- [ ] Super-admin flow: edit each field on an active space; verify Drawer + list both refresh; banned/disbanded spaces hide edit affordance
- [ ] Owner / admin flow: edit fields via `/space/:id`; verify SpaceSwitcher name updates immediately
- [ ] Idempotent save (same value) skips the request
- [ ] Validation: empty name, oversized name (including emoji-heavy input), `max_users` below member count
- [ ] Keyboard: Esc cancels, Enter / Ctrl+Enter commits