### PR TITLE
fix: move permissions to workflow top level for pr-contributor-welcome

### DIFF
--- a/.github/workflows/pr-contributor-welcome.yml
+++ b/.github/workflows/pr-contributor-welcome.yml
@@ -10,10 +10,9 @@ on:
   pull_request_target: # zizmor: ignore[dangerous-triggers] metadata-only automation; no PR code executed
     types: [opened]
 
-permissions: {}
+permissions:
+  issues: write
 
 jobs:
   welcome:
     uses: Mininglamp-OSS/.github/.github/workflows/reusable-pr-contributor-welcome.yml@main
-    permissions:
-      issues: write


### PR DESCRIPTION
## 问题

`.github/workflows/pr-contributor-welcome.yml` 存在权限配置 bug：

- 顶层 `permissions: {}` 清空了所有权限
- job 级别的 `permissions: issues: write` 对 reusable workflow 调用（`uses:`）无效
- 导致 `GITHUB_TOKEN` 没有写权限，发欢迎评论时出现 403 错误

## 修复

将权限配置移至 workflow 顶层，并移除 job 级别的 `permissions` 块：

```yaml
# 修复前（错误写法）
permissions: {}

jobs:
  welcome:
    uses: Mininglamp-OSS/.github/.github/workflows/reusable-pr-contributor-welcome.yml@main
    permissions:
      issues: write

# 修复后（正确写法）
permissions:
  issues: write

jobs:
  welcome:
    uses: Mininglamp-OSS/.github/.github/workflows/reusable-pr-contributor-welcome.yml@main
```

## 参考

GitHub 文档：[reusable workflow 中的权限继承](https://docs.github.com/en/actions/using-workflows/reusing-workflows#supported-keywords-for-jobs-that-call-a-reusable-workflow) — job 级别的 `permissions` 对 `uses:` 类型的 job 不适用，必须在 workflow 顶层设置。