### PR TITLE
chore(ci): add edited trigger to check-sprint and auto-add workflows

### DIFF
--- a/.github/workflows/auto-add-to-project.yml
+++ b/.github/workflows/auto-add-to-project.yml
@@ -5,7 +5,7 @@ on:
   issues:
     types: [opened]
   pull_request_target:
-    types: [opened]
+    types: [opened, edited]
 
 permissions: {}
 

--- a/.github/workflows/check-sprint.yml
+++ b/.github/workflows/check-sprint.yml
@@ -33,7 +33,7 @@ name: Check Sprint
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, edited]
     branches: [main]
 
 permissions: {}


### PR DESCRIPTION
This PR adds the `edited` event to the `pull_request_target.types` trigger in both `check-sprint.yml` and `auto-add-to-project.yml`, enabling the Issue-first Sprint check flow to work correctly when a developer adds a `Closes #<issue>` reference to a PR description after opening.