### PR TITLE
fix(ci): add actions:read permission to Octo CI Status workflow

### DIFF
--- a/.github/workflows/octo-ci-status.yml
+++ b/.github/workflows/octo-ci-status.yml
@@ -6,6 +6,9 @@ on:
     types: [completed]
     branches: [main]
 
+permissions:
+  actions: read
+
 jobs:
   notify:
     uses: Mininglamp-OSS/.github/.github/workflows/octo-ci-status.yml@main


### PR DESCRIPTION
## Problem

`Octo CI Status` workflow has been failing with `startup_failure` on **every run** since at least May 21st.

## Root Cause

The caller workflow has no `permissions` block, so the GITHUB_TOKEN gets the repo/org default permissions. The reusable workflow (`Mininglamp-OSS/.github/.github/workflows/octo-ci-status.yml`) needs `actions: read` at the job level to query the GitHub API for workflow run history (state-change detection). Without explicit `actions: read` in the caller, this request fails at startup.

## Fix

Add `permissions: actions: read`, matching the working configuration in octo-server, octo-web, octo-matter, octo-lib, octo-smart-summary, octo-speech, and octo-daemon-cli.

## Verification

All 7 other repos with `permissions: actions: read` have 100% success rate on this workflow.