### PR TITLE
chore(ci): add octo-pr-feed workflow to activate global pr-feed channel

### DIFF
--- a/.github/workflows/octo-pr-feed.yml
+++ b/.github/workflows/octo-pr-feed.yml
@@ -2,7 +2,7 @@ name: Octo PR Feed
 
 on:
   pull_request_target: # zizmor: ignore[dangerous-triggers] metadata-only automation; no PR code executed
-    types: [opened, closed, reopened]
+    types: [opened]
     branches: [main]
 
 permissions: {}

--- a/.github/workflows/octo-pr-feed.yml
+++ b/.github/workflows/octo-pr-feed.yml
@@ -1,0 +1,27 @@
+name: Octo PR Feed
+
+on:
+  pull_request_target: # zizmor: ignore[dangerous-triggers] metadata-only automation; no PR code executed
+    types: [opened, closed, reopened]
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  notify:
+    if: ${{ !github.event.pull_request.draft }}
+    uses: Mininglamp-OSS/.github/.github/workflows/octo-pr-feed.yml@main
+    with:
+      repo_name: ${{ github.event.repository.name }}
+      pr_number: ${{ github.event.pull_request.number }}
+      pr_title: ${{ github.event.pull_request.title }}
+      pr_url: ${{ github.event.pull_request.html_url }}
+      pr_author: ${{ github.event.pull_request.user.login }}
+      pr_merged: ${{ github.event.pull_request.merged }}
+      pr_additions: ${{ github.event.pull_request.additions }}
+      pr_deletions: ${{ github.event.pull_request.deletions }}
+      pr_changed_files: ${{ github.event.pull_request.changed_files }}
+      event_action: ${{ github.event.action }}
+      project_group_id: 'a48e308c2ead4d9dbcdc30fff0f01eaf'
+    secrets:
+      OCTO_BOT_TOKEN: ${{ secrets.OCTO_BOT_TOKEN }}


### PR DESCRIPTION
## Summary

Adds `octo-pr-feed.yml` — the final missing workflow from the org's standard CI suite.

**What it does:** Sends PR lifecycle events (opened / closed / reopened) to:
1. This repo's dedicated Octo group (`project_group_id`)
2. The global pr-feed monitoring channel (`1c303c142e9840f2a9b46c10b0972e8d`)

**Why it was missing:** The `octo-pr-feed.yml` reusable existed in `Mininglamp-OSS/.github` but no caller had ever been deployed to any repo, leaving the pr-feed channel empty.

**Design note:** `opened` events are not covered by any existing workflow. `closed`/`reopened` are also handled here (for the global pr-feed); `octo-pr-result-notify.yml` continues to handle these for the project group with more detailed review context.

No application code modified — thin caller only.