### PR TITLE
feat(spaces): reflect multi-field member search in placeholder

### DIFF
--- a/src/i18n/locales/en-US/spaces.json
+++ b/src/i18n/locales/en-US/spaces.json
@@ -60,6 +60,7 @@
   "detail.tab.invites": "Invite Codes",
   "detail.tab.joinApplies": "Join Requests",
   "members.search.placeholder": "Search UID / nickname",
+  "members.search.placeholderSuper": "Search nickname / username / UID / Email / phone",
   "members.add": "Add Member",
   "members.role.member": "Member",
   "members.role.admin": "Admin",

--- a/src/i18n/locales/zh-CN/spaces.json
+++ b/src/i18n/locales/zh-CN/spaces.json
@@ -60,6 +60,7 @@
   "detail.tab.invites": "邀请码",
   "detail.tab.joinApplies": "加入申请",
   "members.search.placeholder": "搜索 UID / 昵称",
+  "members.search.placeholderSuper": "搜索 昵称 / 用户名 / UID / Email / 手机号",
   "members.add": "添加成员",
   "members.role.member": "成员",
   "members.role.admin": "管理员",

--- a/src/pages/Spaces/SpaceMembersPanel.tsx
+++ b/src/pages/Spaces/SpaceMembersPanel.tsx
@@ -276,7 +276,11 @@ export default function SpaceMembersPanel({ spaceId, scope, readOnly = false }: 
     <div>
       <div className="toolbar toolbar-plain">
         <Input
-          placeholder={t('members.search.placeholder')}
+          placeholder={t(
+            scope.kind === 'super'
+              ? 'members.search.placeholderSuper'
+              : 'members.search.placeholder',
+          )}
           value={keyword}
           onChange={(e) => setKeyword(e.target.value)}
           onPressEnter={handleSearch}


### PR DESCRIPTION
## Summary

The manager member-list API `GET /v1/manager/spaces/:space_id/members` now matches `keyword` across **昵称 (name) / username / email / phone / uid** (previously only `name`+`uid`). The frontend already forwards `keyword` to the backend, so no request/response changes are needed — this PR only updates the search-box placeholder so the UI advertises the real capability.

## Changes

- `SpaceMembersPanel.tsx`: derive the search placeholder from the scope.
  - **super scope** (admin backend, hits the extended endpoint): `搜索 昵称 / 用户名 / UID / Email / 手机号`
  - **user scope** (non-admin; listing only filters `name`+`uid` client-side via `/v1/space/:id/members`, backend unchanged): keeps `搜索 UID / 昵称` to avoid overstating capability.
- Field order aligned with the existing 'create space → owner' search placeholder for consistency.

## Notes / follow-up

- Backend change is backward compatible (structure, pagination, auth unchanged).
- Remaining inconsistency (not in this PR): 用户管理 list search (`Users/index.tsx`) reads `搜索 UID/手机号/用户名/Email` (missing 昵称) yet hits the same `/v1/manager/user/list` as the owner search. Worth unifying separately.

## Test plan

- [ ] Admin: 空间管理 → 详情 → 成员, search by nickname / username / email / phone / uid all return matches.
- [ ] Placeholder shows the full field list in admin view.