### PR TITLE
fix(ci): add ready_for_review to check-sprint trigger types

### DIFF
--- a/.github/workflows/check-sprint.yml
+++ b/.github/workflows/check-sprint.yml
@@ -33,7 +33,7 @@ name: Check Sprint
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
 
 permissions: {}


### PR DESCRIPTION
## Summary

Add `ready_for_review` to `pull_request_target.types` in `check-sprint.yml`.

**Required companion change** for [Mininglamp-OSS/.github#51](https://github.com/Mininglamp-OSS/.github/pull/51), which adds draft-PR skip to the reusable Sprint check workflow.

## Why

Without `ready_for_review` in caller trigger types, marking a draft PR as ready does not re-trigger the Sprint check. The green "skipped" status cached on the draft SHA persists, allowing the now-ready PR to merge without Sprint validation.

## Change

```diff
-    types: [opened, synchronize, reopened, ...]
+    types: [opened, synchronize, reopened, ..., ready_for_review]
```
