### PR TITLE
fix(app-bots): fetch latest detail when opening edit modal

### DIFF
--- a/src/pages/AppBots/EditModal.tsx
+++ b/src/pages/AppBots/EditModal.tsx
@@ -3,6 +3,8 @@ import { Modal, Form, Input, Avatar, Upload, message } from 'antd'
 import { CameraOutlined, LoadingOutlined, RobotOutlined } from '@ant-design/icons'
 import { useTranslation } from 'react-i18next'
 import {
+  getAppBot,
+  getSpaceAppBot,
   updateAppBot,
   updateSpaceAppBot,
   uploadAppBotAvatar,
@@ -24,19 +26,45 @@ export default function EditModal({ bot, spaceId, open, onClose, onSuccess, onAv
   const { t } = useTranslation('appBots')
   const [form] = Form.useForm<AppBotUpdateReq>()
   const [loading, setLoading] = useState(false)
+  const [fetching, setFetching] = useState(false)
   const [uploading, setUploading] = useState(false)
   const [avatarVersion, setAvatarVersion] = useState(Date.now)
 
+  // On open, fetch the latest detail so the form reflects the current value
+  // rather than a (possibly stale) list-row snapshot.
   useEffect(() => {
-    if (open && bot) {
+    if (!open || !bot) return
+
+    setAvatarVersion(Date.now())
+
+    const fill = (data: Pick<AppBot, 'display_name' | 'description' | 'welcome_msg'>) => {
       form.setFieldsValue({
-        display_name: bot.display_name,
-        description: bot.description,
-        welcome_msg: bot.welcome_msg,
+        display_name: data.display_name,
+        description: data.description,
+        welcome_msg: data.welcome_msg,
       })
-      setAvatarVersion(Date.now())
     }
-  }, [open, bot, form])
+
+    // Pre-fill from the row data immediately to avoid a blank flash, then
+    // overwrite with the freshly fetched detail.
+    fill(bot)
+
+    let stale = false
+    setFetching(true)
+    const fetchBot = spaceId ? getSpaceAppBot(spaceId, bot.id) : getAppBot(bot.id)
+    fetchBot
+      .then((data) => {
+        if (!stale) fill(data)
+      })
+      .catch((err: Error) => {
+        if (!stale) message.error(err.message)
+      })
+      .finally(() => {
+        if (!stale) setFetching(false)
+      })
+
+    return () => { stale = true }
+  }, [open, bot, spaceId, form])
 
   const handleOk = async () => {
     if (!bot) return
@@ -78,6 +106,8 @@ export default function EditModal({ bot, spaceId, open, onClose, onSuccess, onAv
       onOk={handleOk}
       onCancel={onClose}
       confirmLoading={loading}
+      loading={fetching}
+      okButtonProps={{ disabled: fetching }}
       destroyOnClose
     >
       {/* Avatar upload */}

--- a/src/pages/AppBots/EditModal.tsx
+++ b/src/pages/AppBots/EditModal.tsx
@@ -26,7 +26,11 @@ export default function EditModal({ bot, spaceId, open, onClose, onSuccess, onAv
   const { t } = useTranslation('appBots')
   const [form] = Form.useForm<AppBotUpdateReq>()
   const [loading, setLoading] = useState(false)
-  const [fetching, setFetching] = useState(false)
+  // The latest fetched (or row-fallback) detail. Drives the modal title and the
+  // "loaded" gate below. Deriving the gate from `detail.id === bot.id` (rather
+  // than a flag flipped inside the effect) avoids the one-frame window where the
+  // OK button could render enabled before the fetch starts.
+  const [detail, setDetail] = useState<AppBot | null>(null)
   const [uploading, setUploading] = useState(false)
   const [avatarVersion, setAvatarVersion] = useState(Date.now)
 
@@ -36,6 +40,7 @@ export default function EditModal({ bot, spaceId, open, onClose, onSuccess, onAv
     if (!open || !bot) return
 
     setAvatarVersion(Date.now())
+    setDetail(null)
 
     const fill = (data: Pick<AppBot, 'display_name' | 'description' | 'welcome_msg'>) => {
       form.setFieldsValue({
@@ -50,21 +55,26 @@ export default function EditModal({ bot, spaceId, open, onClose, onSuccess, onAv
     fill(bot)
 
     let stale = false
-    setFetching(true)
     const fetchBot = spaceId ? getSpaceAppBot(spaceId, bot.id) : getAppBot(bot.id)
     fetchBot
       .then((data) => {
-        if (!stale) fill(data)
+        if (stale) return
+        fill(data)
+        setDetail(data)
       })
       .catch((err: Error) => {
-        if (!stale) message.error(err.message)
-      })
-      .finally(() => {
-        if (!stale) setFetching(false)
+        if (stale) return
+        message.error(err.message)
+        // Fall back to the row snapshot as the editable baseline so the user
+        // is not locked out when the detail fetch fails.
+        setDetail(bot)
       })
 
     return () => { stale = true }
   }, [open, bot, spaceId, form])
+
+  // True only once the detail for the currently-open bot has settled.
+  const detailReady = !!detail && detail.id === bot?.id
 
   const handleOk = async () => {
     if (!bot) return
@@ -101,13 +111,13 @@ export default function EditModal({ bot, spaceId, open, onClose, onSuccess, onAv
 
   return (
     <Modal
-      title={t('edit.title', { name: bot?.display_name || '' })}
+      title={t('edit.title', { name: detail?.display_name ?? bot?.display_name ?? '' })}
       open={open}
       onOk={handleOk}
       onCancel={onClose}
       confirmLoading={loading}
-      loading={fetching}
-      okButtonProps={{ disabled: fetching }}
+      loading={!detailReady}
+      okButtonProps={{ disabled: !detailReady }}
       destroyOnClose
     >
       {/* Avatar upload */}


### PR DESCRIPTION
## Summary

The App Bot edit modal pre-filled its form from the **stale list-row snapshot** instead of fetching the current value, so it never called `GET /v1/admin/app_bot/:bot_id` (or the space-scoped equivalent). If the bot was modified elsewhere after the list loaded, the edit form showed outdated values and could silently overwrite newer data on save.

This change makes the edit modal fetch the latest detail on open, consistent with how `DetailDrawer` already works.

## Changes

- `EditModal` now calls `getAppBot(id)` / `getSpaceAppBot(spaceId, id)` when it opens and pre-fills the form with the response.
- Pre-fills from the row data first to avoid a blank flash, then overwrites with the freshly fetched detail.
- Shows a `Modal` loading skeleton while fetching and disables the save button until the latest detail is loaded.
- Uses a `stale` guard to avoid races when switching bots quickly; falls back to the row data with an error toast if the fetch fails.

## Test plan

- [x] `tsc --noEmit` type-check passes
- [x] `vitest run` passes (9/9)
- [ ] Manual: open the edit modal and confirm a request to `GET /v1/admin/app_bot/:bot_id` fires and the form reflects the latest values
- [ ] Manual: verify the loading skeleton shows and the save button is disabled until the detail loads

Closes #68