### PR TITLE
fix(changelog): use GitHub contributor avatars

### DIFF
--- a/src/pages/Changelog/utils.test.ts
+++ b/src/pages/Changelog/utils.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { parseContributors } from './utils'
+
+describe('parseContributors', () => {
+  it('uses GitHub profile avatars for changelog contributors', () => {
+    expect(parseContributors('@contributors: caster-Q, @octocat')).toEqual([
+      {
+        name: 'caster-Q',
+        avatar: 'https://github.com/caster-Q.png?size=48',
+      },
+      {
+        name: '@octocat',
+        avatar: 'https://github.com/octocat.png?size=48',
+      },
+    ])
+  })
+})

--- a/src/pages/Changelog/utils.ts
+++ b/src/pages/Changelog/utils.ts
@@ -185,9 +185,13 @@ export interface Contributor {
   avatar: string
 }
 
-const CONTRIBUTOR_COLORS = ['b6e3f4', 'ffdfbf', 'c0aede', 'd1f4e0', 'ffd5dc', 'ffe4c4', 'c4e0ff', 'f4d1e0']
-
 const CONTRIBUTORS_PATTERN = /^@contributors:\s*(.+)/i
+const GITHUB_AVATAR_SIZE = 48
+
+function githubAvatarUrl(name: string): string {
+  const login = name.replace(/^@+/, '')
+  return `https://github.com/${encodeURIComponent(login)}.png?size=${GITHUB_AVATAR_SIZE}`
+}
 
 export function parseContributors(desc: string): Contributor[] {
   if (!desc) return []
@@ -200,9 +204,9 @@ export function parseContributors(desc: string): Contributor[] {
         .split(/[,，、]\s*/)
         .map((name) => name.trim())
         .filter(Boolean)
-        .map((name, i) => ({
+        .map((name) => ({
           name,
-          avatar: `https://api.dicebear.com/9.x/identicon/svg?seed=${encodeURIComponent(name)}&backgroundColor=${CONTRIBUTOR_COLORS[i % CONTRIBUTOR_COLORS.length]}`,
+          avatar: githubAvatarUrl(name),
         }))
     }
   }


### PR DESCRIPTION
## Summary
- replace generated DiceBear changelog contributor avatars with GitHub profile avatar URLs
- strip a leading @ when building the avatar URL while preserving the displayed contributor text
- add coverage for changelog contributor avatar parsing

## Tests
- npm run build
- npx vitest run src/pages/Changelog/utils.test.ts

## Note
- npm test currently fails in src/store/feature.test.ts because this local Node 25/jsdom run exposes localStorage without clear(); unrelated to this changelog avatar change.