### PR TITLE
ci: pin third-party actions to commit SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,8 +80,8 @@ jobs:
       matrix:
         node-version: [18, 20]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm


### PR DESCRIPTION
Pin third-party GitHub Actions to full commit SHAs (with version comments so Dependabot can still bump them). Mutable `@vX` tags are a supply-chain risk (OpenSSF Pinned-Dependencies); commit SHAs are immutable. No behavior change — SHAs resolve to the same versions the tags currently point to.