### PR TITLE
fix: gate manager UI with capabilities

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,11 @@
 import { BrowserRouter, Routes, Route, Navigate, useParams } from 'react-router-dom'
 import { useAuthStore } from './store/auth'
 import { useFeatureStore } from './store/feature'
+import {
+  firstManagerPath,
+  hasManagerCapability,
+  type ManagerCapabilityKey,
+} from './auth/capabilities'
 import MainLayout from './layouts/MainLayout'
 import AdminThemeProvider from './layouts/AdminThemeProvider'
 import Login from './pages/Login'
@@ -21,6 +26,25 @@ function SuperOnlyRoute({ children }: { children: React.ReactNode }) {
   const { isLoggedIn, scope } = useAuthStore()
   if (!isLoggedIn) return <Navigate to="/login" replace />
   if (scope !== 'super') return <Navigate to="/space" replace />
+  return <>{children}</>
+}
+
+function CapabilityRoute({
+  capability,
+  children,
+}: {
+  capability: ManagerCapabilityKey
+  children: React.ReactNode
+}) {
+  const { managerCapabilities, managerProfileStatus } = useAuthStore()
+  if (
+    managerProfileStatus === 'idle' ||
+    managerProfileStatus === 'loading' ||
+    managerCapabilities === null
+  ) return null
+  if (!hasManagerCapability(managerCapabilities, capability)) {
+    return <Navigate to={firstManagerPath(managerCapabilities)} replace />
+  }
   return <>{children}</>
 }
 
@@ -108,13 +132,62 @@ function AdminRoutes() {
         }
       >
         <Route index element={<Navigate to="/dashboard" replace />} />
-        <Route path="dashboard" element={<Dashboard />} />
-        <Route path="users" element={<Users />} />
-        <Route path="groups" element={<Groups />} />
-        <Route path="spaces" element={<Spaces />} />
-        <Route path="system-setting" element={<SystemSetting />} />
-        <Route path="backup" element={<Backup />} />
-        <Route path="download" element={<Download />} />
+        <Route
+          path="dashboard"
+          element={
+            <CapabilityRoute capability="dashboard.read">
+              <Dashboard />
+            </CapabilityRoute>
+          }
+        />
+        <Route
+          path="users"
+          element={
+            <CapabilityRoute capability="users.read">
+              <Users />
+            </CapabilityRoute>
+          }
+        />
+        <Route
+          path="groups"
+          element={
+            <CapabilityRoute capability="groups.read">
+              <Groups />
+            </CapabilityRoute>
+          }
+        />
+        <Route
+          path="spaces"
+          element={
+            <CapabilityRoute capability="space.read">
+              <Spaces />
+            </CapabilityRoute>
+          }
+        />
+        <Route
+          path="system-setting"
+          element={
+            <CapabilityRoute capability="system_setting">
+              <SystemSetting />
+            </CapabilityRoute>
+          }
+        />
+        <Route
+          path="backup"
+          element={
+            <CapabilityRoute capability="backup">
+              <Backup />
+            </CapabilityRoute>
+          }
+        />
+        <Route
+          path="download"
+          element={
+            <CapabilityRoute capability="appversion.read">
+              <Download />
+            </CapabilityRoute>
+          }
+        />
         <Route
           path="app-bots"
           element={

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { BrowserRouter, Routes, Route, Navigate, useParams } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
 import { useAuthStore } from './store/auth'
 import { useFeatureStore } from './store/feature'
 import {
@@ -48,6 +49,16 @@ function CapabilityRoute({
   return <>{children}</>
 }
 
+function ManagerIndexRoute() {
+  const { managerCapabilities, managerProfileStatus } = useAuthStore()
+  if (
+    managerProfileStatus === 'idle' ||
+    managerProfileStatus === 'loading' ||
+    managerCapabilities === null
+  ) return null
+  return <Navigate to={firstManagerPath(managerCapabilities)} replace />
+}
+
 function SpaceOnlyRoute({ children }: { children: React.ReactNode }) {
   const { isLoggedIn, scope } = useAuthStore()
   if (!isLoggedIn || scope !== 'space') return <Navigate to="/space" replace />
@@ -66,6 +77,25 @@ function AppBotsGate({ fallback, children }: { fallback: string; children: React
 function SpaceAppBotsGate({ children }: { children: React.ReactNode }) {
   const { spaceId } = useParams<{ spaceId: string }>()
   return <AppBotsGate fallback={`/space/${spaceId}/members`}>{children}</AppBotsGate>
+}
+
+function ManagerAppBotsGate({ children }: { children: React.ReactNode }) {
+  const managerCapabilities = useAuthStore((s) => s.managerCapabilities)
+  return <AppBotsGate fallback={firstManagerPath(managerCapabilities)}>{children}</AppBotsGate>
+}
+
+function NoAccess() {
+  const { t } = useTranslation('layout')
+  return (
+    <div style={{ minHeight: 320, display: 'grid', placeItems: 'center', textAlign: 'center' }}>
+      <div>
+        <h1 className="page-title">{t('noAccess.title')}</h1>
+        <p className="page-subtitle" style={{ marginBottom: 0 }}>
+          {t('noAccess.subtitle')}
+        </p>
+      </div>
+    </div>
+  )
 }
 
 /**
@@ -131,7 +161,7 @@ function AdminRoutes() {
           </SuperOnlyRoute>
         }
       >
-        <Route index element={<Navigate to="/dashboard" replace />} />
+        <Route index element={<ManagerIndexRoute />} />
         <Route
           path="dashboard"
           element={
@@ -191,11 +221,12 @@ function AdminRoutes() {
         <Route
           path="app-bots"
           element={
-            <AppBotsGate fallback="/dashboard">
+            <ManagerAppBotsGate>
               <AppBots />
-            </AppBotsGate>
+            </ManagerAppBotsGate>
           }
         />
+        <Route path="no-access" element={<NoAccess />} />
       </Route>
     </Routes>
   )

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,4 +1,5 @@
 import api from './index'
+import { normalizeManagerCapabilities, type ManagerMe } from '../auth/capabilities'
 
 interface LoginParams {
   username: string
@@ -13,3 +14,9 @@ interface LoginResponse {
 
 export const login = (params: LoginParams) =>
   api.post<LoginResponse>('/v1/manager/login', params).then((res) => res.data)
+
+export const getManagerMe = () =>
+  api.get<ManagerMe>('/v1/manager/me').then((res) => ({
+    ...res.data,
+    capabilities: normalizeManagerCapabilities(res.data.capabilities),
+  }))

--- a/src/auth/capabilities.test.ts
+++ b/src/auth/capabilities.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import {
+  firstManagerPath,
+  hasManagerCapability,
+  normalizeManagerCapabilities,
+} from './capabilities'
+
+describe('manager capabilities', () => {
+  it('normalizes missing capability keys to false', () => {
+    const capabilities = normalizeManagerCapabilities({
+      'dashboard.read': true,
+      system_setting: false,
+    })
+
+    expect(capabilities['dashboard.read']).toBe(true)
+    expect(capabilities.system_setting).toBe(false)
+    expect(capabilities.backup).toBe(false)
+  })
+
+  it('checks capabilities strictly', () => {
+    const capabilities = normalizeManagerCapabilities({
+      'dashboard.read': 1,
+      system_setting: true,
+    })
+
+    expect(hasManagerCapability(capabilities, 'dashboard.read')).toBe(false)
+    expect(hasManagerCapability(capabilities, 'system_setting')).toBe(true)
+  })
+
+  it('selects the first readable manager path', () => {
+    const capabilities = normalizeManagerCapabilities({
+      'space.read': true,
+      'appversion.read': true,
+    })
+
+    expect(firstManagerPath(capabilities)).toBe('/spaces')
+  })
+})

--- a/src/auth/capabilities.test.ts
+++ b/src/auth/capabilities.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   firstManagerPath,
   hasManagerCapability,
+  MANAGER_NO_ACCESS_PATH,
   normalizeManagerCapabilities,
 } from './capabilities'
 
@@ -34,5 +35,15 @@ describe('manager capabilities', () => {
     })
 
     expect(firstManagerPath(capabilities)).toBe('/spaces')
+  })
+
+  it('falls back to no-access when no readable manager path exists', () => {
+    const capabilities = normalizeManagerCapabilities({
+      'users.write': true,
+      'space.destructive': true,
+    })
+
+    expect(firstManagerPath(capabilities)).toBe(MANAGER_NO_ACCESS_PATH)
+    expect(firstManagerPath(null)).toBe(MANAGER_NO_ACCESS_PATH)
   })
 })

--- a/src/auth/capabilities.ts
+++ b/src/auth/capabilities.ts
@@ -7,6 +7,7 @@ export const MANAGER_CAPABILITY_KEYS = [
   'dashboard.trigger',
   'users.read',
   'users.write',
+  // Reserved for administrator-account management UI when that surface is added.
   'users.manage_admin',
   'groups.read',
   'groups.write',
@@ -14,6 +15,8 @@ export const MANAGER_CAPABILITY_KEYS = [
   'space.write',
   'space.destructive',
 ] as const
+
+export const MANAGER_NO_ACCESS_PATH = '/no-access'
 
 export type ManagerCapabilityKey = (typeof MANAGER_CAPABILITY_KEYS)[number]
 
@@ -50,5 +53,5 @@ export function firstManagerPath(capabilities: ManagerCapabilities | null | unde
   if (hasManagerCapability(capabilities, 'system_setting')) return '/system-setting'
   if (hasManagerCapability(capabilities, 'backup')) return '/backup'
   if (hasManagerCapability(capabilities, 'appversion.read')) return '/download'
-  return '/dashboard'
+  return MANAGER_NO_ACCESS_PATH
 }

--- a/src/auth/capabilities.ts
+++ b/src/auth/capabilities.ts
@@ -1,0 +1,54 @@
+export const MANAGER_CAPABILITY_KEYS = [
+  'system_setting',
+  'backup',
+  'appversion.read',
+  'appversion.write',
+  'dashboard.read',
+  'dashboard.trigger',
+  'users.read',
+  'users.write',
+  'users.manage_admin',
+  'groups.read',
+  'groups.write',
+  'space.read',
+  'space.write',
+  'space.destructive',
+] as const
+
+export type ManagerCapabilityKey = (typeof MANAGER_CAPABILITY_KEYS)[number]
+
+export type ManagerCapabilities = Record<ManagerCapabilityKey, boolean>
+
+export interface ManagerMe {
+  uid: string
+  name: string
+  role: string
+  capabilities: ManagerCapabilities
+}
+
+export function normalizeManagerCapabilities(
+  capabilities?: Partial<Record<ManagerCapabilityKey, unknown>> | null,
+): ManagerCapabilities {
+  return MANAGER_CAPABILITY_KEYS.reduce((acc, key) => {
+    acc[key] = capabilities?.[key] === true
+    return acc
+  }, {} as ManagerCapabilities)
+}
+
+export function hasManagerCapability(
+  capabilities: ManagerCapabilities | null | undefined,
+  key: ManagerCapabilityKey,
+): boolean {
+  return capabilities?.[key] === true
+}
+
+export function firstManagerPath(capabilities: ManagerCapabilities | null | undefined): string {
+  if (hasManagerCapability(capabilities, 'dashboard.read')) return '/dashboard'
+  if (hasManagerCapability(capabilities, 'users.read')) return '/users'
+  if (hasManagerCapability(capabilities, 'groups.read')) return '/groups'
+  if (hasManagerCapability(capabilities, 'space.read')) return '/spaces'
+  if (hasManagerCapability(capabilities, 'system_setting')) return '/system-setting'
+  if (hasManagerCapability(capabilities, 'backup')) return '/backup'
+  if (hasManagerCapability(capabilities, 'appversion.read')) return '/download'
+  return '/dashboard'
+}

--- a/src/hooks/useSpaceScope.ts
+++ b/src/hooks/useSpaceScope.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
 import { useAuthStore } from '../store/auth'
+import { hasManagerCapability, type ManagerCapabilities } from '../auth/capabilities'
 import * as manager from '../api/space'
 import * as user from '../api/space-user'
 
@@ -78,6 +79,8 @@ export interface SpaceScope {
   canManageInvites: boolean
   canRemoveMembers: boolean
   canAddMembers: boolean
+  canChangeMemberRoles: boolean
+  canUpdateSpaceProfile: boolean
   canReviewApplies: boolean
   supportsMemberSearch: boolean
   supportsMemberPagination: boolean
@@ -107,14 +110,18 @@ export interface SpaceScope {
   }
 }
 
-function buildSuperScope(): SpaceScope {
+function buildSuperScope(capabilities: ManagerCapabilities | null): SpaceScope {
+  const canWrite = hasManagerCapability(capabilities, 'space.write')
+  const canDestructive = hasManagerCapability(capabilities, 'space.destructive')
   return {
     kind: 'super',
     role: 'super',
-    canManageInvites: true,
-    canRemoveMembers: true,
-    canAddMembers: true,
-    canReviewApplies: true,
+    canManageInvites: canWrite,
+    canRemoveMembers: canDestructive,
+    canAddMembers: canWrite,
+    canChangeMemberRoles: canDestructive,
+    canUpdateSpaceProfile: canWrite,
+    canReviewApplies: canWrite,
     supportsMemberSearch: true,
     supportsMemberPagination: true,
     supportsApplyFilter: true,
@@ -165,6 +172,8 @@ function buildUserScope(role: SpaceMemberRole): SpaceScope {
     canManageInvites: isManager,
     canRemoveMembers: isManager,
     canAddMembers: false,
+    canChangeMemberRoles: role === 2,
+    canUpdateSpaceProfile: isManager,
     canReviewApplies: isManager,
     supportsMemberSearch: false,
     supportsMemberPagination: true,
@@ -238,8 +247,9 @@ function buildUserScope(role: SpaceMemberRole): SpaceScope {
 
 export function useSpaceScope(role?: SpaceMemberRole): SpaceScope {
   const scope = useAuthStore((s) => s.scope)
+  const capabilities = useAuthStore((s) => s.managerCapabilities)
   return useMemo(() => {
-    if (scope === 'super') return buildSuperScope()
+    if (scope === 'super') return buildSuperScope(capabilities)
     return buildUserScope(role ?? 0)
-  }, [scope, role])
+  }, [capabilities, scope, role])
 }

--- a/src/i18n/locales/en-US/layout.json
+++ b/src/i18n/locales/en-US/layout.json
@@ -9,5 +9,7 @@
   "theme.dark": "Dark",
   "theme.auto": "Auto",
   "managerProfile.loadFailed": "Failed to load manager permissions",
-  "managerProfile.retry": "Retry"
+  "managerProfile.retry": "Retry",
+  "noAccess.title": "No Available Access",
+  "noAccess.subtitle": "This manager account does not have access to any admin console sections."
 }

--- a/src/i18n/locales/en-US/layout.json
+++ b/src/i18n/locales/en-US/layout.json
@@ -7,5 +7,7 @@
   "theme.tooltip": "Theme: {{name}}",
   "theme.light": "Light",
   "theme.dark": "Dark",
-  "theme.auto": "Auto"
+  "theme.auto": "Auto",
+  "managerProfile.loadFailed": "Failed to load manager permissions",
+  "managerProfile.retry": "Retry"
 }

--- a/src/i18n/locales/zh-CN/layout.json
+++ b/src/i18n/locales/zh-CN/layout.json
@@ -9,5 +9,7 @@
   "theme.dark": "深色",
   "theme.auto": "跟随系统",
   "managerProfile.loadFailed": "管理员权限加载失败",
-  "managerProfile.retry": "重试"
+  "managerProfile.retry": "重试",
+  "noAccess.title": "暂无可访问功能",
+  "noAccess.subtitle": "当前管理员账号没有可进入的管理台能力。"
 }

--- a/src/i18n/locales/zh-CN/layout.json
+++ b/src/i18n/locales/zh-CN/layout.json
@@ -7,5 +7,7 @@
   "theme.tooltip": "主题：{{name}}",
   "theme.light": "浅色",
   "theme.dark": "深色",
-  "theme.auto": "跟随系统"
+  "theme.auto": "跟随系统",
+  "managerProfile.loadFailed": "管理员权限加载失败",
+  "managerProfile.retry": "重试"
 }

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { Outlet, useNavigate, useLocation } from 'react-router-dom'
-import { Layout, Menu, Avatar, Dropdown, Tooltip, Breadcrumb } from 'antd'
+import { Layout, Menu, Avatar, Dropdown, Tooltip, Breadcrumb, message, Spin, Button } from 'antd'
 import type { MenuProps } from 'antd'
 import { useTranslation } from 'react-i18next'
 import {
@@ -21,6 +21,8 @@ import {
 } from '@ant-design/icons'
 import { useAuthStore } from '../store/auth'
 import { useFeatureStore } from '../store/feature'
+import { getManagerMe } from '../api/auth'
+import { firstManagerPath, hasManagerCapability } from '../auth/capabilities'
 import LanguageSwitcher from '../components/LanguageSwitcher'
 import { useTheme } from '../hooks/useTheme'
 import type { Theme } from '../hooks/useTheme'
@@ -39,7 +41,17 @@ const MainLayout: React.FC = () => {
   const [collapsed, setCollapsed] = useState(false)
   const navigate = useNavigate()
   const location = useLocation()
-  const { name, logout } = useAuthStore()
+  const {
+    name,
+    token,
+    scope,
+    managerCapabilities,
+    managerProfileStatus,
+    setManagerProfileLoading,
+    setManagerMe,
+    setManagerProfileError,
+    logout,
+  } = useAuthStore()
   const { theme, effective, setTheme } = useTheme()
   const appBotsAvailable = useFeatureStore((s) => s.appBotsAvailable)
   const probeAppBots = useFeatureStore((s) => s.probeAppBots)
@@ -48,6 +60,35 @@ const MainLayout: React.FC = () => {
   useEffect(() => {
     void probeAppBots()
   }, [probeAppBots])
+
+  const loadManagerProfile = useCallback(async () => {
+    if (scope !== 'super' || !token) return
+    setManagerProfileLoading()
+    try {
+      setManagerMe(await getManagerMe())
+    } catch (error) {
+      setManagerProfileError()
+      message.error((error as Error).message)
+    }
+  }, [
+    scope,
+    setManagerMe,
+    setManagerProfileError,
+    setManagerProfileLoading,
+    token,
+  ])
+
+  useEffect(() => {
+    if (scope !== 'super' || !token) return
+    if (managerCapabilities !== null || managerProfileStatus !== 'idle') return
+    void loadManagerProfile()
+  }, [
+    loadManagerProfile,
+    managerCapabilities,
+    managerProfileStatus,
+    scope,
+    token,
+  ])
 
   const themeLabel = useMemo<Record<Theme, string>>(
     () => ({
@@ -59,21 +100,36 @@ const MainLayout: React.FC = () => {
   )
 
   const menuItems = useMemo<MenuItem[]>(() => {
-    const base: MenuItem[] = [
-      { key: '/dashboard', icon: <DashboardOutlined />, label: t('nav:dashboard') },
-      { key: '/users', icon: <UserOutlined />, label: t('nav:users') },
-      { key: '/groups', icon: <TeamOutlined />, label: t('nav:groups') },
-      { key: '/spaces', icon: <AppstoreOutlined />, label: t('nav:spaces') },
-    ]
-    const tail: MenuItem[] = [
-      { key: '/system-setting', icon: <SettingOutlined />, label: t('nav:systemSetting') },
-      { key: '/backup', icon: <CloudUploadOutlined />, label: t('nav:backup') },
-      { key: '/download', icon: <DownloadOutlined />, label: t('nav:download') },
-    ]
+    if (managerCapabilities === null) return []
+
+    const base: MenuItem[] = []
+    if (hasManagerCapability(managerCapabilities, 'dashboard.read')) {
+      base.push({ key: '/dashboard', icon: <DashboardOutlined />, label: t('nav:dashboard') })
+    }
+    if (hasManagerCapability(managerCapabilities, 'users.read')) {
+      base.push({ key: '/users', icon: <UserOutlined />, label: t('nav:users') })
+    }
+    if (hasManagerCapability(managerCapabilities, 'groups.read')) {
+      base.push({ key: '/groups', icon: <TeamOutlined />, label: t('nav:groups') })
+    }
+    if (hasManagerCapability(managerCapabilities, 'space.read')) {
+      base.push({ key: '/spaces', icon: <AppstoreOutlined />, label: t('nav:spaces') })
+    }
+
+    const tail: MenuItem[] = []
+    if (hasManagerCapability(managerCapabilities, 'system_setting')) {
+      tail.push({ key: '/system-setting', icon: <SettingOutlined />, label: t('nav:systemSetting') })
+    }
+    if (hasManagerCapability(managerCapabilities, 'backup')) {
+      tail.push({ key: '/backup', icon: <CloudUploadOutlined />, label: t('nav:backup') })
+    }
+    if (hasManagerCapability(managerCapabilities, 'appversion.read')) {
+      tail.push({ key: '/download', icon: <DownloadOutlined />, label: t('nav:download') })
+    }
     return appBotsAvailable === true
       ? [...base, { key: '/app-bots', icon: <RobotOutlined />, label: t('nav:appBots') }, ...tail]
       : [...base, ...tail]
-  }, [appBotsAvailable, t])
+  }, [appBotsAvailable, managerCapabilities, t])
 
   const handleMenuClick = ({ key }: { key: string }) => {
     navigate(key)
@@ -85,6 +141,11 @@ const MainLayout: React.FC = () => {
   }
 
   const activeItem = menuItems.find((item) => item.key === location.pathname)
+  const homePath = firstManagerPath(managerCapabilities)
+  const managerProfilePending =
+    scope === 'super' && managerCapabilities === null && managerProfileStatus !== 'error'
+  const managerProfileFailed =
+    scope === 'super' && managerCapabilities === null && managerProfileStatus === 'error'
 
   const isDark = effective === 'dark'
   const surface = isDark ? '#14171f' : '#ffffff'
@@ -169,9 +230,9 @@ const MainLayout: React.FC = () => {
                   <a
                     onClick={(e) => {
                       e.preventDefault()
-                      navigate('/dashboard')
+                      navigate(homePath)
                     }}
-                    href="/dashboard"
+                    href={homePath}
                   >
                     {t('layout:breadcrumb.admin')}
                   </a>
@@ -264,7 +325,30 @@ const MainLayout: React.FC = () => {
               : '0 1px 2px rgba(16,24,40,0.05)',
           }}
         >
-          <Outlet />
+          {managerProfilePending ? (
+            <div style={{ minHeight: 320, display: 'grid', placeItems: 'center' }}>
+              <Spin />
+            </div>
+          ) : managerProfileFailed ? (
+            <div
+              style={{
+                minHeight: 320,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                flexDirection: 'column',
+                gap: 12,
+                color: 'var(--a-text-secondary)',
+              }}
+            >
+              <span>{t('layout:managerProfile.loadFailed')}</span>
+              <Button onClick={() => void loadManagerProfile()}>
+                {t('layout:managerProfile.retry')}
+              </Button>
+            </div>
+          ) : (
+            <Outlet />
+          )}
         </Content>
       </Layout>
     </Layout>

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -54,6 +54,8 @@ import {
   type DashboardTrendItem,
 } from '../../api/dashboard'
 import { ApiError } from '../../api'
+import { hasManagerCapability } from '../../auth/capabilities'
+import { useAuthStore } from '../../store/auth'
 
 const { RangePicker } = DatePicker
 const { Text } = Typography
@@ -697,6 +699,9 @@ function LazyTablePlaceholder({ title, hint }: { title: string; hint: string }) 
 
 export default function Dashboard() {
   const { t } = useTranslation(['dashboard', 'common'])
+  const canRunEtl = useAuthStore((s) =>
+    hasManagerCapability(s.managerCapabilities, 'dashboard.trigger'),
+  )
   const [dateRange, setDateRange] = useState<[Dayjs, Dayjs]>(defaultDateRange)
   const [selectedSpaceIds, setSelectedSpaceIds] = useState<string[]>([])
   const [spaceOptions, setSpaceOptions] = useState<DashboardSpaceItem[]>([])
@@ -1561,22 +1566,24 @@ export default function Dashboard() {
           <h1 className="page-title">{t('title')}</h1>
           <p className="page-subtitle">{t('subtitle')}</p>
         </div>
-        <Popconfirm
-          title={t('action.runEtlConfirmTitle')}
-          description={t('action.runEtlConfirmDesc')}
-          okText={t('common:action.confirm')}
-          cancelText={t('common:action.cancel')}
-          onConfirm={handleRunEtl}
-          disabled={etlLoading}
-        >
-          <Button
-            type="primary"
-            icon={<SyncOutlined />}
-            loading={etlLoading}
+        {canRunEtl && (
+          <Popconfirm
+            title={t('action.runEtlConfirmTitle')}
+            description={t('action.runEtlConfirmDesc')}
+            okText={t('common:action.confirm')}
+            cancelText={t('common:action.cancel')}
+            onConfirm={handleRunEtl}
+            disabled={etlLoading}
           >
-            {t('action.runEtl')}
-          </Button>
-        </Popconfirm>
+            <Button
+              type="primary"
+              icon={<SyncOutlined />}
+              loading={etlLoading}
+            >
+              {t('action.runEtl')}
+            </Button>
+          </Popconfirm>
+        )}
       </div>
 
       <nav className="dashboard-anchor-nav" aria-label={t('nav.aria')}>

--- a/src/pages/Download/index.tsx
+++ b/src/pages/Download/index.tsx
@@ -23,6 +23,8 @@ import {
 import type { ColumnsType } from 'antd/es/table'
 import { useTranslation } from 'react-i18next'
 import api from '../../api'
+import { hasManagerCapability } from '../../auth/capabilities'
+import { useAuthStore } from '../../store/auth'
 
 interface AppVersion {
   id: number
@@ -76,6 +78,9 @@ function formatUrl(url: string): string {
 
 export default function Download() {
   const { t } = useTranslation(['download', 'common'])
+  const canWrite = useAuthStore((s) =>
+    hasManagerCapability(s.managerCapabilities, 'appversion.write'),
+  )
   const [loading, setLoading] = useState(false)
   const [data, setData] = useState<AppVersion[]>([])
   const [total, setTotal] = useState(0)
@@ -118,12 +123,14 @@ export default function Download() {
   }, [data, platformFilter, forceFilter])
 
   const handleAdd = () => {
+    if (!canWrite) return
     setEditingId(null)
     form.resetFields()
     setModalVisible(true)
   }
 
   const handleEdit = (record: AppVersion) => {
+    if (!canWrite) return
     setEditingId(record.id)
     form.setFieldsValue({
       app_version: record.app_version,
@@ -136,6 +143,7 @@ export default function Download() {
   }
 
   const handleSubmit = async () => {
+    if (!canWrite) return
     const values = await form.validateFields()
     const payload = {
       ...values,
@@ -156,7 +164,7 @@ export default function Download() {
     }
   }
 
-  const columns: ColumnsType<AppVersion> = [
+  const baseColumns: ColumnsType<AppVersion> = [
     {
       title: t('column.appVersion'),
       dataIndex: 'app_version',
@@ -234,34 +242,42 @@ export default function Download() {
       width: 170,
       render: (value) => <span style={{ color: 'var(--a-text-tertiary)' }}>{value}</span>,
     },
-    {
-      title: t('column.action'),
-      key: 'action',
-      width: 80,
-      align: 'right',
-      render: (_, record) => (
-        <div className="row-actions">
-          <Button
-            size="small"
-            className="btn-row-edit"
-            icon={<EditOutlined />}
-            onClick={() => handleEdit(record)}
-          >
-            {t('action.edit')}
-          </Button>
-        </div>
-      ),
-    },
   ]
+
+  const columns: ColumnsType<AppVersion> = canWrite
+    ? [
+        ...baseColumns,
+        {
+          title: t('column.action'),
+          key: 'action',
+          width: 80,
+          align: 'right',
+          render: (_, record) => (
+            <div className="row-actions">
+              <Button
+                size="small"
+                className="btn-row-edit"
+                icon={<EditOutlined />}
+                onClick={() => handleEdit(record)}
+              >
+                {t('action.edit')}
+              </Button>
+            </div>
+          ),
+        },
+      ]
+    : baseColumns
 
   return (
     <div>
       <h1 className="page-title">{t('title')}</h1>
       <p className="page-subtitle">{t('subtitle')}</p>
       <div className="toolbar">
-        <Button type="primary" icon={<PlusOutlined />} onClick={handleAdd}>
-          {t('action.addVersion')}
-        </Button>
+        {canWrite && (
+          <Button type="primary" icon={<PlusOutlined />} onClick={handleAdd}>
+            {t('action.addVersion')}
+          </Button>
+        )}
         <Select
           value={platformFilter}
           onChange={setPlatformFilter}

--- a/src/pages/Groups/index.tsx
+++ b/src/pages/Groups/index.tsx
@@ -4,6 +4,8 @@ import { SearchOutlined, ReloadOutlined } from '@ant-design/icons'
 import type { ColumnsType } from 'antd/es/table'
 import { useTranslation } from 'react-i18next'
 import api from '../../api'
+import { hasManagerCapability } from '../../auth/capabilities'
+import { useAuthStore } from '../../store/auth'
 
 const { Text } = Typography
 
@@ -25,6 +27,9 @@ interface RemoveMemberModal {
 
 export default function Groups() {
   const { t } = useTranslation(['groups', 'common'])
+  const canWrite = useAuthStore((s) =>
+    hasManagerCapability(s.managerCapabilities, 'groups.write'),
+  )
   const [loading, setLoading] = useState(false)
   const [data, setData] = useState<Group[]>([])
   const [total, setTotal] = useState(0)
@@ -72,6 +77,7 @@ export default function Groups() {
   }, [data, statusFilter])
 
   const handleBan = async (groupNo: string, status: number) => {
+    if (!canWrite) return
     Modal.confirm({
       title: status === 0 ? t('confirm.ban') : t('confirm.unban'),
       onOk: async () => {
@@ -83,17 +89,20 @@ export default function Groups() {
   }
 
   const handleForbid = async (groupNo: string, on: number) => {
+    if (!canWrite) return
     await api.put(`/v1/manager/groups/${groupNo}/forbidden/${on}`)
     message.success(on === 1 ? t('toast.forbidden') : t('toast.unforbidden'))
     fetchData()
   }
 
   const openRemoveModal = (group: Group) => {
+    if (!canWrite) return
     form.resetFields()
     setRemoveModal({ open: true, groupNo: group.group_no, groupName: group.name })
   }
 
   const handleRemoveMember = async () => {
+    if (!canWrite) return
     const { uid } = await form.validateFields()
     const uids = (uid as string).split(/[,，\s]+/).map((s) => s.trim()).filter(Boolean)
     if (uids.length === 0) return
@@ -110,7 +119,7 @@ export default function Groups() {
     }
   }
 
-  const columns: ColumnsType<Group> = [
+  const baseColumns: ColumnsType<Group> = [
     {
       title: t('column.name'),
       dataIndex: 'name',
@@ -158,28 +167,34 @@ export default function Groups() {
         </span>
       ),
     },
-    {
-      title: t('column.action'),
-      key: 'action',
-      width: 240,
-      align: 'right',
-      render: (_, record) => (
-        <div className="row-actions" style={{ display: 'inline-flex', gap: 4 }}>
-          {record.status === 1 ? (
-            <Button size="small" danger onClick={() => handleBan(record.group_no, 0)}>{t('action.ban')}</Button>
-          ) : (
-            <Button size="small" type="primary" ghost onClick={() => handleBan(record.group_no, 1)}>{t('action.unban')}</Button>
-          )}
-          {record.forbidden !== 1 ? (
-            <Button size="small" className="btn-mute" onClick={() => handleForbid(record.group_no, 1)}>{t('action.forbid')}</Button>
-          ) : (
-            <Button size="small" type="primary" ghost onClick={() => handleForbid(record.group_no, 0)}>{t('action.unforbid')}</Button>
-          )}
-          <Button size="small" danger onClick={() => openRemoveModal(record)}>{t('action.removeMember')}</Button>
-        </div>
-      ),
-    },
   ]
+
+  const columns: ColumnsType<Group> = canWrite
+    ? [
+        ...baseColumns,
+        {
+          title: t('column.action'),
+          key: 'action',
+          width: 240,
+          align: 'right',
+          render: (_, record) => (
+            <div className="row-actions" style={{ display: 'inline-flex', gap: 4 }}>
+              {record.status === 1 ? (
+                <Button size="small" danger onClick={() => handleBan(record.group_no, 0)}>{t('action.ban')}</Button>
+              ) : (
+                <Button size="small" type="primary" ghost onClick={() => handleBan(record.group_no, 1)}>{t('action.unban')}</Button>
+              )}
+              {record.forbidden !== 1 ? (
+                <Button size="small" className="btn-mute" onClick={() => handleForbid(record.group_no, 1)}>{t('action.forbid')}</Button>
+              ) : (
+                <Button size="small" type="primary" ghost onClick={() => handleForbid(record.group_no, 0)}>{t('action.unforbid')}</Button>
+              )}
+              <Button size="small" danger onClick={() => openRemoveModal(record)}>{t('action.removeMember')}</Button>
+            </div>
+          ),
+        },
+      ]
+    : baseColumns
 
   return (
     <div>

--- a/src/pages/Spaces/SpaceDetailDrawer.tsx
+++ b/src/pages/Spaces/SpaceDetailDrawer.tsx
@@ -45,7 +45,8 @@ export default function SpaceDetailDrawer({
       .finally(() => setLoading(false))
   }, [open, spaceId, defaultTab])
 
-  const readOnly = !!space && (space.status !== 1 || !scope.canUpdateSpaceProfile)
+  const inactiveSpace = !!space && space.status !== 1
+  const profileReadOnly = inactiveSpace || !scope.canUpdateSpaceProfile
 
   return (
     <Drawer
@@ -62,7 +63,7 @@ export default function SpaceDetailDrawer({
         <>
           <SpaceInfoPanel
             space={space}
-            readOnly={readOnly}
+            readOnly={profileReadOnly}
             onSpaceChange={setSpace}
             onUpdated={onUpdated}
           />
@@ -79,7 +80,7 @@ export default function SpaceDetailDrawer({
                   <SpaceMembersPanel
                     spaceId={space.space_id}
                     scope={scope}
-                    readOnly={readOnly}
+                    readOnly={inactiveSpace}
                   />
                 ),
               },
@@ -90,7 +91,7 @@ export default function SpaceDetailDrawer({
                   <SpaceInvitesPanel
                     spaceId={space.space_id}
                     scope={scope}
-                    readOnly={readOnly}
+                    readOnly={inactiveSpace}
                   />
                 ),
               },
@@ -101,7 +102,7 @@ export default function SpaceDetailDrawer({
                   <SpaceJoinAppliesPanel
                     spaceId={space.space_id}
                     scope={scope}
-                    readOnly={readOnly}
+                    readOnly={inactiveSpace}
                   />
                 ),
               },

--- a/src/pages/Spaces/SpaceDetailDrawer.tsx
+++ b/src/pages/Spaces/SpaceDetailDrawer.tsx
@@ -45,7 +45,7 @@ export default function SpaceDetailDrawer({
       .finally(() => setLoading(false))
   }, [open, spaceId, defaultTab])
 
-  const readOnly = !!space && space.status !== 1
+  const readOnly = !!space && (space.status !== 1 || !scope.canUpdateSpaceProfile)
 
   return (
     <Drawer
@@ -62,6 +62,7 @@ export default function SpaceDetailDrawer({
         <>
           <SpaceInfoPanel
             space={space}
+            readOnly={readOnly}
             onSpaceChange={setSpace}
             onUpdated={onUpdated}
           />

--- a/src/pages/Spaces/SpaceInfoPanel.tsx
+++ b/src/pages/Spaces/SpaceInfoPanel.tsx
@@ -27,6 +27,7 @@ function runeCount(s: string): number {
 
 interface Props {
   space: Space
+  readOnly?: boolean
   onSpaceChange: (next: Space) => void
   onUpdated?: () => void
 }
@@ -46,9 +47,9 @@ function Field({ label, children, span = 1 }: FieldProps) {
   )
 }
 
-export default function SpaceInfoPanel({ space, onSpaceChange, onUpdated }: Props) {
+export default function SpaceInfoPanel({ space, readOnly = false, onSpaceChange, onUpdated }: Props) {
   const { t } = useTranslation('spaces')
-  const editable = space.status === 1
+  const editable = space.status === 1 && !readOnly
   const [logoBroken, setLogoBroken] = useState(false)
 
   const save = async <K extends keyof Space>(field: K, value: Space[K]) => {

--- a/src/pages/Spaces/SpaceMembersPanel.tsx
+++ b/src/pages/Spaces/SpaceMembersPanel.tsx
@@ -50,7 +50,7 @@ export default function SpaceMembersPanel({ spaceId, scope, readOnly = false, on
 
   const canAdd = !readOnly && scope.canAddMembers
   const canRemove = !readOnly && scope.canRemoveMembers
-  const canChangeRole = !readOnly && (scope.kind === 'super' || scope.role === 2)
+  const canChangeRole = !readOnly && scope.canChangeMemberRoles
 
   const fetchData = async (nextPage = page, kw = keyword) => {
     setLoading(true)

--- a/src/pages/Spaces/index.tsx
+++ b/src/pages/Spaces/index.tsx
@@ -18,6 +18,7 @@ import { PlusOutlined, ReloadOutlined, SearchOutlined } from '@ant-design/icons'
 import { useTranslation } from 'react-i18next'
 import type { ColumnsType } from 'antd/es/table'
 import api from '../../api'
+import { hasManagerCapability } from '../../auth/capabilities'
 import {
   MAX_USERS_HARD_CAP,
   createSpace,
@@ -29,6 +30,7 @@ import {
   type SpaceJoinMode,
   type SpaceStatus,
 } from '../../api/space'
+import { useAuthStore } from '../../store/auth'
 import SpaceDetailDrawer from './SpaceDetailDrawer'
 
 interface UserOptionRaw {
@@ -55,6 +57,12 @@ const STATUS_META: Record<SpaceStatus, { textKey: string; tone: 'online' | 'dest
 
 export default function Spaces() {
   const { t } = useTranslation(['spaces', 'common'])
+  const canWrite = useAuthStore((s) =>
+    hasManagerCapability(s.managerCapabilities, 'space.write'),
+  )
+  const canDestructive = useAuthStore((s) =>
+    hasManagerCapability(s.managerCapabilities, 'space.destructive'),
+  )
   const [tab, setTab] = useState<TabKey>('active')
   const [loading, setLoading] = useState(false)
   const [data, setData] = useState<SpaceItem[]>([])
@@ -147,6 +155,7 @@ export default function Spaces() {
   }
 
   const handleBan = (space: SpaceItem) => {
+    if (!canDestructive) return
     Modal.confirm({
       title: t('ban.title', { name: space.name }),
       content: t('ban.content'),
@@ -164,6 +173,7 @@ export default function Spaces() {
   }
 
   const handleUnban = (space: SpaceItem) => {
+    if (!canDestructive) return
     Modal.confirm({
       title: t('unban.title', { name: space.name }),
       onOk: async () => {
@@ -179,6 +189,7 @@ export default function Spaces() {
   }
 
   const handleDissolve = (space: SpaceItem) => {
+    if (!canDestructive) return
     Modal.confirm({
       title: t('dissolve.title', { name: space.name }),
       content: t('dissolve.content'),
@@ -202,6 +213,7 @@ export default function Spaces() {
   ) => setDrawer({ open: true, spaceId, tab })
 
   const handleCreate = async () => {
+    if (!canWrite) return
     const values = await createForm.validateFields()
     const preset = values.preset_group_ids?.trim()
     if (preset) {
@@ -339,7 +351,7 @@ export default function Spaces() {
           >
             {t('action.inviteCode')}
           </Button>
-          {record.status === 1 && (
+          {canDestructive && record.status === 1 && (
             <>
               <Button size="small" danger onClick={() => handleBan(record)}>
                 {t('action.ban')}
@@ -349,7 +361,7 @@ export default function Spaces() {
               </Button>
             </>
           )}
-          {record.status === 2 && (
+          {canDestructive && record.status === 2 && (
             <Button size="small" type="primary" ghost onClick={() => handleUnban(record)}>
               {t('action.unban')}
             </Button>
@@ -389,17 +401,19 @@ export default function Spaces() {
           {t('common:action.refresh')}
         </Button>
         <div className="toolbar-spacer" />
-        <Button
-          type="primary"
-          icon={<PlusOutlined />}
-          onClick={() => {
-            setCreateOpen(true)
-            setUserOptions([])
-            searchUsers('')
-          }}
-        >
-          {t('action.create')}
-        </Button>
+        {canWrite && (
+          <Button
+            type="primary"
+            icon={<PlusOutlined />}
+            onClick={() => {
+              setCreateOpen(true)
+              setUserOptions([])
+              searchUsers('')
+            }}
+          >
+            {t('action.create')}
+          </Button>
+        )}
       </div>
 
       <Table<SpaceItem>

--- a/src/pages/Users/index.tsx
+++ b/src/pages/Users/index.tsx
@@ -4,6 +4,8 @@ import { SearchOutlined, ReloadOutlined, RobotOutlined, SettingOutlined } from '
 import type { ColumnsType } from 'antd/es/table'
 import { useTranslation } from 'react-i18next'
 import api from '../../api'
+import { hasManagerCapability } from '../../auth/capabilities'
+import { useAuthStore } from '../../store/auth'
 
 const { Text } = Typography
 
@@ -26,6 +28,9 @@ type StatusFilter = 'all' | 'online' | 'offline' | 'banned' | 'destroyed'
 
 export default function Users() {
   const { t } = useTranslation(['users', 'common'])
+  const canWrite = useAuthStore((s) =>
+    hasManagerCapability(s.managerCapabilities, 'users.write'),
+  )
   const [loading, setLoading] = useState(false)
   const [data, setData] = useState<User[]>([])
   const [total, setTotal] = useState(0)
@@ -105,6 +110,7 @@ export default function Users() {
   }
 
   const handleBan = async (uid: string, status: number) => {
+    if (!canWrite) return
     Modal.confirm({
       title: status === 0 ? t('confirm.ban') : t('confirm.unban'),
       onOk: async () => {
@@ -115,7 +121,7 @@ export default function Users() {
     })
   }
 
-  const columns: ColumnsType<User> = [
+  const baseColumns: ColumnsType<User> = [
     {
       title: t('column.name'),
       dataIndex: 'name',
@@ -189,23 +195,29 @@ export default function Users() {
       width: 170,
       render: (value) => <span style={{ color: 'var(--a-text-tertiary)' }}>{value}</span>,
     },
-    {
-      title: t('column.action'),
-      key: 'action',
-      width: 100,
-      align: 'right',
-      render: (_, record) => (
-        <div className="row-actions" style={{ display: 'inline-flex', gap: 4 }}>
-          {record.status === 1 && record.is_destroy !== 1 && (
-            <Button size="small" danger onClick={() => handleBan(record.uid, 0)}>{t('action.ban')}</Button>
-          )}
-          {record.status === 0 && record.is_destroy !== 1 && (
-            <Button size="small" type="primary" ghost onClick={() => handleBan(record.uid, 1)}>{t('action.unban')}</Button>
-          )}
-        </div>
-      ),
-    },
   ]
+
+  const columns: ColumnsType<User> = canWrite
+    ? [
+        ...baseColumns,
+        {
+          title: t('column.action'),
+          key: 'action',
+          width: 100,
+          align: 'right',
+          render: (_, record) => (
+            <div className="row-actions" style={{ display: 'inline-flex', gap: 4 }}>
+              {record.status === 1 && record.is_destroy !== 1 && (
+                <Button size="small" danger onClick={() => handleBan(record.uid, 0)}>{t('action.ban')}</Button>
+              )}
+              {record.status === 0 && record.is_destroy !== 1 && (
+                <Button size="small" type="primary" ghost onClick={() => handleBan(record.uid, 1)}>{t('action.unban')}</Button>
+              )}
+            </div>
+          ),
+        },
+      ]
+    : baseColumns
 
   return (
     <div>

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -1,7 +1,9 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
+import type { ManagerCapabilities, ManagerMe } from '../auth/capabilities'
 
 export type AuthScope = 'super' | 'space' | ''
+export type ManagerProfileStatus = 'idle' | 'loading' | 'loaded' | 'error'
 
 export interface MySpace {
   space_id: string
@@ -21,10 +23,15 @@ interface AuthState {
   role: string
   uid: string
   isLoggedIn: boolean
+  managerCapabilities: ManagerCapabilities | null
+  managerProfileStatus: ManagerProfileStatus
   mySpaces: MySpace[]
   currentSpaceId: string
   loginSuper: (token: string, name: string, role: string) => void
   loginSpace: (token: string, uid: string, name: string, mySpaces: MySpace[]) => void
+  setManagerProfileLoading: () => void
+  setManagerMe: (profile: ManagerMe) => void
+  setManagerProfileError: () => void
   setMySpaces: (mySpaces: MySpace[]) => void
   setCurrentSpaceId: (spaceId: string) => void
   logout: () => void
@@ -39,6 +46,8 @@ export const useAuthStore = create<AuthState>()(
       role: '',
       uid: '',
       isLoggedIn: false,
+      managerCapabilities: null,
+      managerProfileStatus: 'idle',
       mySpaces: [],
       currentSpaceId: '',
       loginSuper: (token, name, role) =>
@@ -49,6 +58,8 @@ export const useAuthStore = create<AuthState>()(
           role,
           uid: '',
           isLoggedIn: true,
+          managerCapabilities: null,
+          managerProfileStatus: 'idle',
           mySpaces: [],
           currentSpaceId: '',
         }),
@@ -60,8 +71,24 @@ export const useAuthStore = create<AuthState>()(
           role: '',
           uid,
           isLoggedIn: true,
+          managerCapabilities: null,
+          managerProfileStatus: 'idle',
           mySpaces,
           currentSpaceId: mySpaces[0]?.space_id ?? '',
+        }),
+      setManagerProfileLoading: () => set({ managerProfileStatus: 'loading' }),
+      setManagerMe: (profile) =>
+        set({
+          name: profile.name,
+          role: profile.role,
+          uid: profile.uid,
+          managerCapabilities: profile.capabilities,
+          managerProfileStatus: 'loaded',
+        }),
+      setManagerProfileError: () =>
+        set({
+          managerCapabilities: null,
+          managerProfileStatus: 'error',
         }),
       setMySpaces: (mySpaces) =>
         set((s) => ({
@@ -80,6 +107,8 @@ export const useAuthStore = create<AuthState>()(
           role: '',
           uid: '',
           isLoggedIn: false,
+          managerCapabilities: null,
+          managerProfileStatus: 'idle',
           mySpaces: [],
           currentSpaceId: '',
         }),


### PR DESCRIPTION
## Summary
- fetch `/v1/manager/me` for manager identity and capability-driven UI gates
- hide system settings and protected manager routes unless the corresponding capability is present
- gate dashboard ETL, app version writes, user/group writes, and space write/destructive actions by capability
- add loading/retry handling so cached App Bot availability cannot render a partial empty shell before capabilities load

## Tests
- `npm test`
- `npm run build`

## Notes
- Existing `PUT /v1/manager/download/versions/{id}` usage is left in place; this PR only hides version write controls behind `appversion.write`. Backend endpoint ownership still needs separate confirmation.

Closes #92