### PR TITLE
[DO NOT MERGE] OCT-7 probe: skipped-matrix check context naming

### DIFF
--- a/docs/oct7-matrix-skip-probe.md
+++ b/docs/oct7-matrix-skip-probe.md
@@ -1,0 +1,3 @@
+# OCT-7 matrix-skip probe
+
+Observing whether a skipped matrix build emits per-combo or collapsed check contexts.


### PR DESCRIPTION
Probe PR for OCT-7. Docs-only change to observe what check contexts a skipped matrix `build` job emits. Closed after observation.