### PR TITLE
[DO NOT MERGE] OCT-7 gate validation: docs-only skip passes

### DIFF
--- a/docs/oct7-gate-docs.md
+++ b/docs/oct7-gate-docs.md
@@ -1,0 +1,3 @@
+# OCT-7 gate docs-only validation
+
+Build should skip; CI Gate should still report SUCCESS.


### PR DESCRIPTION
Validation: docs-only change -> build skips -> CI Gate still runs (always()) and reports SUCCESS -> not perma-blocked. Closed after verification.