### PR TITLE
feat(app-bot): serve connect plugin package & API URL from backend

### DIFF
--- a/src/api/app-bot.ts
+++ b/src/api/app-bot.ts
@@ -5,6 +5,16 @@ import api from './index'
 export type AppBotScope = 'platform' | 'space'
 export type AppBotStatus = 0 | 1 | 2 // 0=draft 1=published 2=unpublished
 
+/**
+ * Backend-owned facts the frontend needs to assemble the bot connect guide.
+ * The server is the single source of truth so a package rename/canary or a
+ * split admin/bot-api host never requires a frontend redeploy.
+ */
+export interface BotConnectInfo {
+  plugin_package: string
+  api_url: string
+}
+
 export interface AppBot {
   id: string
   uid: string
@@ -16,6 +26,7 @@ export interface AppBot {
   space_id: string | null
   status: AppBotStatus
   token?: string
+  connect?: BotConnectInfo
   created_by: string
   created_at: string
   updated_at: string
@@ -37,6 +48,7 @@ export interface AppBotCreateResp {
   id: string
   uid: string
   token: string
+  connect?: BotConnectInfo
 }
 
 export interface AppBotUpdateReq {

--- a/src/pages/AppBots/CreateModal.tsx
+++ b/src/pages/AppBots/CreateModal.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { Button, Form, Input, Modal, Space, Typography, message } from 'antd'
 import { CopyOutlined } from '@ant-design/icons'
 import { useTranslation } from 'react-i18next'
-import { createAppBot, createSpaceAppBot, type AppBotCreateReq } from '../../api/app-bot'
+import { createAppBot, createSpaceAppBot, type AppBotCreateReq, type BotConnectInfo } from '../../api/app-bot'
 import { buildConnectGuide } from './connectGuide'
 
 interface Props {
@@ -16,6 +16,7 @@ interface CreatedBotInfo {
   id: string
   displayName: string
   token: string
+  connect?: BotConnectInfo
 }
 
 /** Copy text to clipboard with fallback */
@@ -59,6 +60,7 @@ export default function CreateModal({ open, spaceId, onClose, onSuccess }: Props
         id: resp.id || values.id,
         displayName: values.display_name,
         token: resp.token,
+        connect: resp.connect,
       })
     } catch (err) {
       if (err instanceof Error) message.error(err.message)
@@ -97,6 +99,7 @@ export default function CreateModal({ open, spaceId, onClose, onSuccess }: Props
             displayName: createdBot.displayName,
             botId: createdBot.id,
             token: createdBot.token,
+            connect: createdBot.connect,
           },
           t,
         ),
@@ -113,6 +116,7 @@ export default function CreateModal({ open, spaceId, onClose, onSuccess }: Props
         displayName: createdBot.displayName,
         botId: createdBot.id,
         token: createdBot.token,
+        connect: createdBot.connect,
       },
       t,
     )

--- a/src/pages/AppBots/DetailDrawer.tsx
+++ b/src/pages/AppBots/DetailDrawer.tsx
@@ -174,6 +174,7 @@ export default function DetailDrawer({ botId, spaceId, open, onClose, onAvatarUp
             displayName: bot.display_name,
             botId: bot.id,
             token,
+            connect: bot.connect,
           },
           t,
         ),
@@ -193,6 +194,7 @@ export default function DetailDrawer({ botId, spaceId, open, onClose, onAvatarUp
         displayName: bot.display_name,
         botId: bot.id,
         token: tokenMasked ? t('detail.guide.tokenPlaceholder') : (bot.token || '<token>'),
+        connect: bot.connect,
       },
       t,
     )

--- a/src/pages/AppBots/connectGuide.test.ts
+++ b/src/pages/AppBots/connectGuide.test.ts
@@ -1,0 +1,41 @@
+import type { TFunction } from 'i18next'
+import { describe, expect, it } from 'vitest'
+import { buildConnectCommand, getBotApiUrl } from './connectGuide'
+
+// buildConnectCommand only needs the agent placeholder from i18n.
+const t = ((key: string) =>
+  key.endsWith('agentPlaceholder') ? 'agent-id' : key) as unknown as TFunction
+
+const base = { displayName: 'My Bot', botId: 'bot-123', token: 'tok-abc' }
+
+describe('buildConnectCommand', () => {
+  it('uses the plugin package and api url supplied by the backend', () => {
+    const cmd = buildConnectCommand(
+      { ...base, connect: { plugin_package: 'create-openclaw-octo', api_url: 'https://api.example.com' } },
+      t,
+    )
+    expect(cmd).toBe(
+      'npx -y create-openclaw-octo bind --bot-token tok-abc --api-url https://api.example.com --account-id bot-123 --agent <agent-id>',
+    )
+  })
+
+  it('adopts a renamed package from the backend without a frontend change', () => {
+    const cmd = buildConnectCommand(
+      { ...base, connect: { plugin_package: 'openclaw-channel-next', api_url: 'https://api.example.com' } },
+      t,
+    )
+    expect(cmd).toContain('npx -y openclaw-channel-next bind')
+  })
+
+  it('falls back to the maintained default package when connect is absent', () => {
+    const cmd = buildConnectCommand(base, t)
+    expect(cmd).toContain('npx -y create-openclaw-octo bind')
+    // Must not emit the deprecated package name.
+    expect(cmd).not.toContain('openclaw-channel-dmwork')
+  })
+
+  it('falls back to getBotApiUrl when connect omits api_url', () => {
+    const cmd = buildConnectCommand(base, t)
+    expect(cmd).toContain(`--api-url ${getBotApiUrl()} `)
+  })
+})

--- a/src/pages/AppBots/connectGuide.ts
+++ b/src/pages/AppBots/connectGuide.ts
@@ -1,23 +1,35 @@
 import type { TFunction } from 'i18next'
+import type { BotConnectInfo } from '../../api/app-bot'
+
+/**
+ * Fallback npm package an Agent runs (`npx -y <pkg> bind ...`) when the backend
+ * does not supply `connect.plugin_package`. Kept in sync with octo-server's
+ * `botutil.DefaultPluginPackage`; the backend is the source of truth, this only
+ * covers older servers that predate the `connect` field.
+ */
+const DEFAULT_PLUGIN_PACKAGE = 'create-openclaw-octo'
 
 interface BuildConnectGuideParams {
   displayName: string
   botId: string
   token: string
-  apiUrl?: string
+  /** Backend-owned connect facts; falls back to defaults when absent. */
+  connect?: BotConnectInfo
 }
 
-/** Get API server URL for bot connect guide. */
+/** Fallback API server URL for the bot connect guide when the backend omits it. */
 export function getBotApiUrl(): string {
   return import.meta.env.VITE_BOT_API_URL || window.location.origin
 }
 
 export function buildConnectCommand(
-  { botId, token, apiUrl = getBotApiUrl() }: BuildConnectGuideParams,
+  { botId, token, connect }: BuildConnectGuideParams,
   t: TFunction,
 ): string {
   const agent = t('appBots:detail.guide.agentPlaceholder')
-  return `npx -y openclaw-channel-dmwork bind --bot-token ${token} --api-url ${apiUrl} --account-id ${botId} --agent <${agent}>`
+  const pluginPackage = connect?.plugin_package || DEFAULT_PLUGIN_PACKAGE
+  const apiUrl = connect?.api_url || getBotApiUrl()
+  return `npx -y ${pluginPackage} bind --bot-token ${token} --api-url ${apiUrl} --account-id ${botId} --agent <${agent}>`
 }
 
 export function buildConnectGuide(params: BuildConnectGuideParams, t: TFunction): string {


### PR DESCRIPTION
## Summary

Closes #108

Frontend follow-up to **Mininglamp-OSS/octo-server#446** (backend merged in octo-server#447).

The App Bot "connect guide" (`npx -y <pkg> bind ...`) was assembled entirely in this frontend, hardcoding two server-owned facts:

1. The channel-adapter npm package `openclaw-channel-dmwork` — **now deprecated**; the maintained package is `create-openclaw-octo`.
2. `--api-url`, derived from `VITE_BOT_API_URL || window.location.origin`. The `window.location.origin` fallback is the **admin dashboard origin**, which silently dropped the `/api` path and diverged from the bind command BotFather sends users.

The backend now returns a `connect { plugin_package, api_url }` object on the App Bot read/create endpoints (admin + space). This PR consumes it, so a package rename/canary or a split admin/bot-api host no longer needs a frontend redeploy.

## Changes

- **`src/api/app-bot.ts`**: new `BotConnectInfo` interface; `connect?: BotConnectInfo` added to `AppBot` and `AppBotCreateResp`.
- **`src/pages/AppBots/connectGuide.ts`**: package = `connect?.plugin_package ?? 'create-openclaw-octo'`, url = `connect?.api_url ?? getBotApiUrl()`. Removed the unused `apiUrl?` param.
- **`DetailDrawer.tsx` / `CreateModal.tsx`**: thread `connect` (from the bot detail / create response) into `buildConnectGuide`.
- **`connectGuide.test.ts`** (new): backend value, package rename, default fallback (asserts the deprecated package never appears), and api_url fallback.

## Behavior / compatibility

- **Additive + safe**: when the backend omits `connect` (older servers), it falls back to the maintained default package and `getBotApiUrl()` — current behavior preserved.
- **Fixes a latent bug**: the old guide produced `--api-url <origin>` (no `/api`), inconsistent with BotFather. The new value matches the canonical command.

## Verified against im-test

`GET /v1/space/{id}/app_bot/{botId}` returns:

```json
"connect": {
  "api_url": "https://<host>/api",
  "plugin_package": "create-openclaw-octo"
}
```

`api_url` includes `/api`, matching octo-server's BotFather `command.tmpl` bind line (`--api-url {{.APIURL}}` where `APIURL = DeriveAPIURL = External.BaseURL`).

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vitest run` — 9 files / 35 tests pass (incl. 4 new)
- [x] `npm run build` (`tsc && vite build`) succeeds
- [x] Endpoint verified against im-test (connect shape + `/api` suffix)

