### PR TITLE
ci: allow manual CI validation runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     paths-ignore:


### PR DESCRIPTION
## Summary
- add workflow_dispatch to the CI workflow so release validation can run explicitly on main HEAD
- keep existing push and pull_request behavior unchanged

## Why
release-publish requires a successful CI run whose head_sha exactly matches the release tag commit. PR #107 had CI on the PR head, but the squash-merged main commit did not get a push-triggered CI run, leaving no valid release evidence.

## Test plan
- git diff --check