### PR TITLE
fix(changelog): stop contributor avatar hover flicker and overflow

### DIFF
--- a/src/pages/Changelog/index.tsx
+++ b/src/pages/Changelog/index.tsx
@@ -90,28 +90,68 @@ const css = `
 .contributor-group {
   display: flex;
   align-items: center;
+  width: var(--reserved-w, auto);
 }
 .contributor-avatar {
   position: relative;
-  transition: transform 0.2s ease, z-index 0s;
+  transition: transform 0.25s cubic-bezier(0.22, 1, 0.36, 1);
   z-index: 0;
 }
 .contributor-avatar:not(:first-child) {
   margin-left: -8px;
 }
-.contributor-group:hover .contributor-avatar {
-  margin-left: 4px;
+.contributor-avatar img {
+  transition: transform 0.2s ease;
 }
-.contributor-group:hover .contributor-avatar:first-child {
-  margin-left: 0;
+/* Fan the stack out on hover using transform only — no layout change, so the
+   parent flex row never re-flows/wraps under the cursor (which caused flicker).
+   Each avatar shifts right by index*4px, taking the per-avatar step from 16px to
+   20px. The group already reserves this fanned width (inline), so the fan fills
+   the reserved box exactly and never overflows the card. Avatars still overlap
+   (20 < 24), so there are no gaps for the cursor to fall into. */
+.contributor-group:hover .contributor-avatar {
+  transform: translateX(calc(var(--contributor-index, 0) * 4px));
 }
 .contributor-avatar:hover {
-  transform: translateY(-4px) scale(1.15);
   z-index: 10;
+}
+.contributor-avatar:hover img {
+  transform: translateY(-4px) scale(1.2);
 }
 .contributor-avatar:hover .contributor-name {
   opacity: 1;
   transform: translateX(-50%) translateY(0);
+}
+.contributor-more-badge {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  border: 2px solid var(--bg-page);
+  background: var(--bg-hover);
+  color: var(--text-secondary);
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1;
+  cursor: default;
+}
+/* Touch devices have no reliable hover; disable the fan/lift so a sticky
+   tap-triggered :hover can't push avatars around or reveal the tooltip. */
+@media (hover: none) {
+  .contributor-group {
+    width: auto;
+  }
+  .contributor-group:hover .contributor-avatar {
+    transform: none;
+  }
+  .contributor-avatar:hover img {
+    transform: none;
+  }
+  .contributor-avatar:hover .contributor-name {
+    opacity: 0;
+  }
 }
 .contributor-name {
   position: absolute;
@@ -388,8 +428,23 @@ function Heatmap({ data }: { data: AppVersion[] }) {
   )
 }
 
+// Stacked contributor avatars. Collapsed (overlapped) at rest, gently fanned
+// out on hover. The group reserves its *fanned* width up front so the surrounding
+// flex row accounts for it — the fan happens inside that reserved box and can
+// never overflow the card (the whole group wraps to its own line if too wide).
+const MAX_VISIBLE_CONTRIBUTORS = 10
+const AVATAR_SIZE = 24
+// Per-avatar step: 16px at rest (8px overlap, via margin-left:-8px in CSS) →
+// 20px on hover (4px overlap). The group reserves the fanned width below.
+const FAN_STEP = 20
+
 function ContributorAvatars({ contributors, showLabel }: { contributors: Contributor[]; showLabel?: boolean }) {
   if (contributors.length === 0) return null
+
+  const visible = contributors.slice(0, MAX_VISIBLE_CONTRIBUTORS)
+  const overflow = contributors.slice(MAX_VISIBLE_CONTRIBUTORS)
+  const itemCount = visible.length + (overflow.length > 0 ? 1 : 0)
+  const reservedWidth = (itemCount - 1) * FAN_STEP + AVATAR_SIZE
 
   return (
     <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
@@ -399,9 +454,16 @@ function ContributorAvatars({ contributors, showLabel }: { contributors: Contrib
           贡献者
         </span>
       )}
-      <div className="contributor-group">
-        {contributors.map((c) => (
-          <div key={c.name} className="contributor-avatar">
+      <div
+        className="contributor-group"
+        style={{ ['--reserved-w' as string]: `${reservedWidth}px`, flexShrink: 0 } as React.CSSProperties}
+      >
+        {visible.map((c, index) => (
+          <div
+            key={c.name}
+            className="contributor-avatar"
+            style={{ ['--contributor-index' as string]: index } as React.CSSProperties}
+          >
             <img
               src={c.avatar}
               alt={c.name}
@@ -410,8 +472,8 @@ function ContributorAvatars({ contributors, showLabel }: { contributors: Contrib
                 event.currentTarget.src = c.fallbackAvatar
               }}
               style={{
-                width: 24,
-                height: 24,
+                width: AVATAR_SIZE,
+                height: AVATAR_SIZE,
                 borderRadius: '50%',
                 border: `2px solid var(--bg-page)`,
                 background: colors.surface.subtle,
@@ -422,6 +484,15 @@ function ContributorAvatars({ contributors, showLabel }: { contributors: Contrib
             <span className="contributor-name">{c.name}</span>
           </div>
         ))}
+        {overflow.length > 0 && (
+          <div
+            className="contributor-avatar contributor-more"
+            style={{ ['--contributor-index' as string]: visible.length } as React.CSSProperties}
+            title={overflow.map((c) => c.name).join('、')}
+          >
+            <span className="contributor-more-badge">+{overflow.length}</span>
+          </div>
+        )}
       </div>
     </div>
   )

--- a/src/pages/Changelog/index.tsx
+++ b/src/pages/Changelog/index.tsx
@@ -460,7 +460,7 @@ function ContributorAvatars({ contributors, showLabel }: { contributors: Contrib
       >
         {visible.map((c, index) => (
           <div
-            key={c.name}
+            key={`${c.name}-${index}`}
             className="contributor-avatar"
             style={{ ['--contributor-index' as string]: index } as React.CSSProperties}
           >
@@ -486,7 +486,7 @@ function ContributorAvatars({ contributors, showLabel }: { contributors: Contrib
         ))}
         {overflow.length > 0 && (
           <div
-            className="contributor-avatar contributor-more"
+            className="contributor-avatar"
             style={{ ['--contributor-index' as string]: visible.length } as React.CSSProperties}
             title={overflow.map((c) => c.name).join('、')}
           >


### PR DESCRIPTION
## Summary

The contributor avatar stack on the Changelog page fanned out on hover by animating `margin`, which changed the group's layout width and re-flowed/wrapped the parent flex row **under the cursor** — producing a hover flicker loop. With many contributors the fanned stack also overflowed past the card's rounded corner.

This PR reworks the interaction so it is flicker-free and overflow-safe, on both desktop and touch.

## Changes

- **No flicker**: fan the stack with `transform: translateX()` (per-avatar index) instead of `margin`, so hover never triggers layout reflow. Fanned step (20px) stays below the avatar width (24px), so avatars remain gapless and the cursor never falls into a gap.
- **No overflow**: the group reserves its *fanned* width up front (via a CSS var), so the fan fills that box exactly and the whole group wraps as one unit instead of spilling over the card.
- **Bounded for large lists**: show at most 10 avatars plus a `+N` overflow badge; the badge's `title` lists the remaining contributor names.
- **Mobile**: under `@media (hover: none)` the fan/lift/name-tooltip are disabled and the reserved width falls back to `auto`, so a sticky tap-triggered `:hover` can't shift avatars or cause horizontal overflow.

Scope is limited to `src/pages/Changelog/index.tsx`.

## Test plan

- [x] `tsc --noEmit` passes
- [x] `vitest run` — 49/49 tests pass
- [x] Verified in a real browser (Playwright) against the test backend:
  - [x] Desktop: hover fans avatars out with no flicker; rightmost avatar stops at the content edge (no overflow past the card)
  - [x] Desktop: no page horizontal scrollbar
  - [x] Mobile (390px, touch): contributor group stays within the viewport (no overflow)

## Notes

- A pre-existing, unrelated horizontal overflow on mobile comes from the platform filter `Tabs` (6 icon tabs on narrow screens), not from the contributor avatars. Left out of this PR — happy to address separately.