### PR TITLE
fix(space): send "never" sentinel for permanent invites; fix edit init for permanent links

### DIFF
--- a/src/hooks/useSpaceScope.ts
+++ b/src/hooks/useSpaceScope.ts
@@ -210,8 +210,9 @@ function buildUserScope(role: SpaceMemberRole): SpaceScope {
       },
       createInvite: async (spaceId, data) => {
         const resp = await user.createSpaceUserInvite(spaceId, data)
+        // "never" 是永久哨兵，也属于显式 expires_at，应走 update 写入。
         const hasCustom =
-          data.max_uses !== undefined || (data.expires_at && data.expires_at.length > 0)
+          data.max_uses !== undefined || (data.expires_at !== undefined && data.expires_at !== '')
         if (hasCustom) {
           try {
             await user.updateSpaceUserInvite(spaceId, resp.invite_code, {

--- a/src/pages/Spaces/SpaceInvitesPanel.tsx
+++ b/src/pages/Spaces/SpaceInvitesPanel.tsx
@@ -181,23 +181,31 @@ export default function SpaceInvitesPanel({ spaceId, scope, readOnly = false }: 
       initial: {
         no_limit: record.max_uses === 0,
         max_uses: record.max_uses > 0 ? record.max_uses : undefined,
-        expires_at: record.expires_at ? dayjs(record.expires_at) : DEFAULT_EXPIRES(),
+        // expires_at 为空字符串 = 永久；编辑时应保留永久（null），而非默认回填 7 天
+        expires_at: record.expires_at ? dayjs(record.expires_at) : null,
       },
     })
   }
 
   const handleEditorSubmit = async () => {
     const values = await editorForm.validateFields()
-    const expires = values.expires_at
-      ? values.expires_at.second(0).format('YYYY-MM-DD HH:mm:ss')
-      : ''
+    // expires_at 三态：
+    //   具体时间 → 格式化字符串
+    //   null（选了"永久"）→ "never"（服务端哨兵值，明确要求 NULL expires_at）
+    //   undefined（表单未碰）→ undefined（服务端套默认值）
+    const expires =
+      values.expires_at === undefined
+        ? undefined
+        : values.expires_at === null
+          ? 'never'
+          : values.expires_at.second(0).format('YYYY-MM-DD HH:mm:ss')
     const maxUses = values.no_limit ? 0 : values.max_uses
     setEditorLoading(true)
     try {
       if (editor.mode === 'create') {
         const resp = await scope.api.createInvite(spaceId, {
           max_uses: maxUses,
-          expires_at: expires || undefined,
+          expires_at: expires,
         })
         const copied = await copyText(buildInviteLink(resp.invite_code))
         message.success(


### PR DESCRIPTION
## Summary

Frontend half of the same bug: "selecting permanent still expires after 72 h".

## Root Cause

- handleEditorSubmit sent empty string ("") for "never expires". New server contract requires "never" sentinel.
- openEdit initialised expires_at to DEFAULT_EXPIRES() (7 days) when existing invite had no expiry, silently overwriting permanent links on next Save.

## Changes

### SpaceInvitesPanel.tsx
- handleEditorSubmit: map expires_at=null to "never" sentinel; undefined stays undefined.
- openEdit: initialise expires_at to null (not DEFAULT_EXPIRES) when record.expires_at is empty.

### useSpaceScope.ts
- buildUserScope.createInvite: treat expires_at="never" as custom so the follow-up updateInvite call is issued.

## Companion PR

octo-server fix: `xiaokenbot:fix/space-invite-permanent-expiry-v2`
