### PR TITLE
feat(expert-market): admin surface for platform experts and squads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "dayjs": "^1.11.13",
         "i18next": "^26.3.0",
         "i18next-browser-languagedetector": "^8.2.1",
+        "jszip": "^3.10.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-i18next": "^17.0.8",
@@ -2255,6 +2256,12 @@
         "toggle-selection": "^1.0.6"
       }
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmmirror.com/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmmirror.com/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2906,6 +2913,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmmirror.com/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmmirror.com/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmmirror.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -2921,6 +2940,12 @@
       "resolved": "https://registry.npmmirror.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmmirror.com/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -3104,6 +3129,27 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmmirror.com/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmmirror.com/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/loose-envify": {
@@ -3291,6 +3337,12 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmmirror.com/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parse5": {
       "version": "7.3.0",
       "resolved": "https://registry.npmmirror.com/parse5/-/parse5-7.3.0.tgz",
@@ -3403,6 +3455,12 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
     },
     "node_modules/proxy-from-env": {
       "version": "2.1.0",
@@ -4149,6 +4207,21 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmmirror.com/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmmirror.com/requires-port/-/requires-port-1.0.0.tgz",
@@ -4214,6 +4287,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmmirror.com/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmmirror.com/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -4261,6 +4340,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmmirror.com/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -4328,6 +4413,15 @@
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "node_modules/string-convert": {
       "version": "0.2.1",
@@ -4679,6 +4773,12 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmmirror.com/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "6.4.3",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "dayjs": "^1.11.13",
     "i18next": "^26.3.0",
     "i18next-browser-languagedetector": "^8.2.1",
+    "jszip": "^3.10.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-i18next": "^17.0.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 5.29.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       axios:
         specifier: ^1.9.0
-        version: 1.18.1
+        version: 1.18.1(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0)
       dayjs:
         specifier: ^1.11.13
         version: 1.11.21
@@ -26,6 +26,9 @@ importers:
       i18next-browser-languagedetector:
         specifier: ^8.2.1
         version: 8.2.1
+      jszip:
+        specifier: ^3.10.1
+        version: 3.10.1
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -50,13 +53,13 @@ importers:
         version: 18.3.7(@types/react@18.3.31)
       '@vitejs/plugin-react':
         specifier: ^4.4.1
-        version: 4.4.1(vite@6.4.3)
+        version: 4.4.1(supports-color@7.2.0)(vite@6.4.3)
       '@vitest/coverage-v8':
         specifier: ^3.2.6
-        version: 3.2.7(vitest@3.2.7(jsdom@24.1.3))
+        version: 3.2.7(supports-color@7.2.0)(vitest@3.2.7(jsdom@24.1.3(supports-color@7.2.0))(supports-color@7.2.0))
       jsdom:
         specifier: ^24.1.3
-        version: 24.1.3
+        version: 24.1.3(supports-color@7.2.0)
       typescript:
         specifier: ^5.8.2
         version: 5.8.2
@@ -65,7 +68,7 @@ importers:
         version: 6.4.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.7(jsdom@24.1.3)
+        version: 3.2.7(jsdom@24.1.3(supports-color@7.2.0))(supports-color@7.2.0)
 
 packages:
 
@@ -817,6 +820,9 @@ packages:
   copy-to-clipboard@3.3.3:
     resolution: {integrity: sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==}
 
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -1018,12 +1024,21 @@ packages:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -1081,6 +1096,12 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  jszip@3.10.1:
+    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
@@ -1148,6 +1169,9 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
+  pako@1.0.2:
+    resolution: {integrity: sha512-qCaDHl8pk5JSbz5k1Bi5zTZf430DUuV13pmcFEHHan4fW++WIwm2HXUirpzfciBRyFUN+eeZW11bfIM/Y4Zeog==}
+
   parse5@7.1.2:
     resolution: {integrity: sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==}
 
@@ -1176,6 +1200,9 @@ packages:
   postcss@8.5.20:
     resolution: {integrity: sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==}
     engines: {node: ^10 || ^12 || >=14}
+
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
   proxy-from-env@2.1.0:
     resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
@@ -1464,6 +1491,9 @@ packages:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
 
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
 
@@ -1480,6 +1510,9 @@ packages:
 
   rrweb-cssom@0.7.1:
     resolution: {integrity: sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==}
+
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
@@ -1502,6 +1535,9 @@ packages:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -1538,6 +1574,9 @@ packages:
   string-width@5.1.2:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -1623,6 +1662,9 @@ packages:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
@@ -1848,20 +1890,20 @@ snapshots:
 
   '@babel/compat-data@7.29.7': {}
 
-  '@babel/core@7.29.7':
+  '@babel/core@7.29.7(supports-color@7.2.0)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
       '@babel/helper-compilation-targets': 7.29.7
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)
       '@babel/helpers': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@7.2.0)
       '@babel/types': 7.29.7
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -1886,19 +1928,19 @@ snapshots:
 
   '@babel/helper-globals@7.29.7': {}
 
-  '@babel/helper-module-imports@7.29.7':
+  '@babel/helper-module-imports@7.29.7(supports-color@7.2.0)':
     dependencies:
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@7.2.0)
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)':
     dependencies:
-      '@babel/core': 7.29.7
-      '@babel/helper-module-imports': 7.29.7
+      '@babel/core': 7.29.7(supports-color@7.2.0)
+      '@babel/helper-module-imports': 7.29.7(supports-color@7.2.0)
       '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.7
+      '@babel/traverse': 7.29.7(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -1919,14 +1961,14 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
-  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7)':
+  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7(supports-color@7.2.0))':
     dependencies:
-      '@babel/core': 7.29.7
+      '@babel/core': 7.29.7(supports-color@7.2.0)
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/runtime@7.29.7': {}
@@ -1937,7 +1979,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
 
-  '@babel/traverse@7.29.7':
+  '@babel/traverse@7.29.7(supports-color@7.2.0)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
@@ -1945,7 +1987,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
       '@babel/types': 7.29.7
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -2299,33 +2341,33 @@ snapshots:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
 
-  '@vitejs/plugin-react@4.4.1(vite@6.4.3)':
+  '@vitejs/plugin-react@4.4.1(supports-color@7.2.0)(vite@6.4.3)':
     dependencies:
-      '@babel/core': 7.29.7
-      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
-      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7)
+      '@babel/core': 7.29.7(supports-color@7.2.0)
+      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))
+      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
       vite: 6.4.3
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@3.2.7(vitest@3.2.7(jsdom@24.1.3))':
+  '@vitest/coverage-v8@3.2.7(supports-color@7.2.0)(vitest@3.2.7(jsdom@24.1.3(supports-color@7.2.0))(supports-color@7.2.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
       ast-v8-to-istanbul: 0.3.12
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 5.0.6
+      istanbul-lib-source-maps: 5.0.6(supports-color@7.2.0)
       istanbul-reports: 3.2.0
       magic-string: 0.30.17
       magicast: 0.3.5
       std-env: 3.9.0
       test-exclude: 7.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.7(jsdom@24.1.3)
+      vitest: 3.2.7(jsdom@24.1.3(supports-color@7.2.0))(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -2371,21 +2413,21 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
-  agent-base@6.0.0:
+  agent-base@6.0.0(supports-color@7.2.0):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  agent-base@7.0.2:
+  agent-base@7.0.2(supports-color@7.2.0):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  agent-base@7.1.0:
+  agent-base@7.1.0(supports-color@7.2.0):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -2467,11 +2509,11 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  axios@1.18.1:
+  axios@1.18.1(debug@4.4.3(supports-color@7.2.0))(supports-color@7.2.0):
     dependencies:
-      follow-redirects: 1.16.0
+      follow-redirects: 1.16.0(debug@4.4.3(supports-color@7.2.0))
       form-data: 4.0.6
-      https-proxy-agent: 5.0.1
+      https-proxy-agent: 5.0.1(supports-color@7.2.0)
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
@@ -2538,6 +2580,8 @@ snapshots:
     dependencies:
       toggle-selection: 1.0.6
 
+  core-util-is@1.0.3: {}
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -2557,9 +2601,11 @@ snapshots:
 
   dayjs@1.11.21: {}
 
-  debug@4.4.3:
+  debug@4.4.3(supports-color@7.2.0):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 7.2.0
 
   decimal.js@10.6.0: {}
 
@@ -2640,7 +2686,9 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.5
 
-  follow-redirects@1.16.0: {}
+  follow-redirects@1.16.0(debug@4.4.3(supports-color@7.2.0)):
+    optionalDependencies:
+      debug: 4.4.3(supports-color@7.2.0)
 
   foreground-child@3.1.0:
     dependencies:
@@ -2713,24 +2761,24 @@ snapshots:
     dependencies:
       void-elements: 3.1.0
 
-  http-proxy-agent@7.0.2:
+  http-proxy-agent@7.0.2(supports-color@7.2.0):
     dependencies:
-      agent-base: 7.1.0
-      debug: 4.4.3
+      agent-base: 7.1.0(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@5.0.1:
+  https-proxy-agent@5.0.1(supports-color@7.2.0):
     dependencies:
-      agent-base: 6.0.0
-      debug: 4.4.3
+      agent-base: 6.0.0(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@7.0.5:
+  https-proxy-agent@7.0.5(supports-color@7.2.0):
     dependencies:
-      agent-base: 7.0.2
-      debug: 4.4.3
+      agent-base: 7.0.2(supports-color@7.2.0)
+      debug: 4.4.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -2746,9 +2794,15 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  immediate@3.0.6: {}
+
+  inherits@2.0.4: {}
+
   is-fullwidth-code-point@3.0.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
+
+  isarray@1.0.0: {}
 
   isexe@2.0.0: {}
 
@@ -2760,10 +2814,10 @@ snapshots:
       make-dir: 4.0.0
       supports-color: 7.2.0
 
-  istanbul-lib-source-maps@5.0.6:
+  istanbul-lib-source-maps@5.0.6(supports-color@7.2.0):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
       - supports-color
@@ -2787,15 +2841,15 @@ snapshots:
 
   js-tokens@9.0.1: {}
 
-  jsdom@24.1.3:
+  jsdom@24.1.3(supports-color@7.2.0):
     dependencies:
       cssstyle: 4.0.1
       data-urls: 5.0.0
       decimal.js: 10.6.0
       form-data: 4.0.6
       html-encoding-sniffer: 4.0.0
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.5
+      http-proxy-agent: 7.0.2(supports-color@7.2.0)
+      https-proxy-agent: 7.0.5(supports-color@7.2.0)
       is-potential-custom-element-name: 1.0.1
       nwsapi: 2.2.24
       parse5: 7.1.2
@@ -2822,6 +2876,17 @@ snapshots:
       string-convert: 0.2.1
 
   json5@2.2.3: {}
+
+  jszip@3.10.1:
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.2
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
+
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
 
   loose-envify@1.4.0:
     dependencies:
@@ -2877,6 +2942,8 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
+  pako@1.0.2: {}
+
   parse5@7.1.2:
     dependencies:
       entities: 4.4.0
@@ -2901,6 +2968,8 @@ snapshots:
       nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  process-nextick-args@2.0.1: {}
 
   proxy-from-env@2.1.0: {}
 
@@ -3268,6 +3337,16 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+
   requires-port@1.0.0: {}
 
   resize-observer-polyfill@1.5.1: {}
@@ -3307,6 +3386,8 @@ snapshots:
 
   rrweb-cssom@0.7.1: {}
 
+  safe-buffer@5.1.2: {}
+
   safer-buffer@2.1.2: {}
 
   saxes@6.0.0:
@@ -3324,6 +3405,8 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.8.5: {}
+
+  setimmediate@1.0.5: {}
 
   shebang-command@2.0.0:
     dependencies:
@@ -3354,6 +3437,10 @@ snapshots:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
       strip-ansi: 7.2.0
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
 
   strip-ansi@6.0.1:
     dependencies:
@@ -3430,10 +3517,12 @@ snapshots:
     dependencies:
       react: 18.3.1
 
-  vite-node@3.2.4:
+  util-deprecate@1.0.2: {}
+
+  vite-node@3.2.4(supports-color@7.2.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
       vite: 6.4.3
@@ -3462,7 +3551,7 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  vitest@3.2.7(jsdom@24.1.3):
+  vitest@3.2.7(jsdom@24.1.3(supports-color@7.2.0))(supports-color@7.2.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.7
@@ -3473,7 +3562,7 @@ snapshots:
       '@vitest/spy': 3.2.7
       '@vitest/utils': 3.2.7
       chai: 5.2.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@7.2.0)
       expect-type: 1.4.0
       magic-string: 0.30.17
       pathe: 2.0.3
@@ -3485,10 +3574,10 @@ snapshots:
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
       vite: 6.4.3
-      vite-node: 3.2.4
+      vite-node: 3.2.4(supports-color@7.2.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      jsdom: 24.1.3
+      jsdom: 24.1.3(supports-color@7.2.0)
     transitivePeerDependencies:
       - jiti
       - less

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+# Approve esbuild's postinstall (pnpm 11 blocks dependency build scripts by
+# default; vite needs the esbuild binary built).
+allowBuilds:
+  esbuild: true

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import Download from './pages/Download'
 import SystemSetting from './pages/SystemSetting'
 import SystemMcp from './pages/SystemMcp'
 import SkillMarket from './pages/SkillMarket'
+import ExpertMarket from './pages/ExpertMarket'
 import Changelog from './pages/Changelog'
 import AppBots from './pages/AppBots'
 import SystemSkill from './pages/SystemSkill'
@@ -218,6 +219,14 @@ function AdminRoutes() {
           element={
             <CapabilityRoute capability="skill.read">
               <SkillMarket />
+            </CapabilityRoute>
+          }
+        />
+        <Route
+          path="expert-market"
+          element={
+            <CapabilityRoute capability="expert.read">
+              <ExpertMarket />
             </CapabilityRoute>
           }
         />

--- a/src/api/expert.ts
+++ b/src/api/expert.ts
@@ -1,0 +1,405 @@
+/**
+ * octo-marketplace admin client for Expert (专家) and Squad (专家团) resources.
+ *
+ * Uses the shared marketplace axios instance from ./marketplace, which handles
+ * baseURL, auth token injection, Accept-Language, and error-envelope
+ * normalization. Marketplace admits only role=superAdmin on the /admin/*
+ * namespace; this file trusts that gate and only adds resource-specific types
+ * + endpoint wrappers. Same pattern as ./mcp.ts and ./skill.ts.
+ *
+ * Wire contract: marketplace wraps every success payload as `{data: T}` (lists
+ * add `pagination`) and every field is snake_case. Types here mirror the wire
+ * exactly — page code reads snake_case directly.
+ *
+ * Creation model (see plan async-honking-yao): the admin never uploads the
+ * container zip. The browser unzips it (parseContainer.ts), presigns + PUTs
+ * each bundled skill package via `uploadExpertSkill`, then submits a flat JSON
+ * manifest to create/patch. Mirrors octo-cli `marketplace expert create`.
+ */
+
+import { marketplaceApi as expertApi, putPresignedFile } from './marketplace'
+
+// ─── Shared types (mirror octo-marketplace internal/model/expert_dto.go) ───
+
+export type ExpertKind = 'agent' | 'squad'
+export type ExpertVisibility = 'public' | 'private' | 'system'
+
+/** Read projection of a skill on an expert/squad (never echoes bytes). */
+export interface SkillRef {
+  name: string
+  has_content?: boolean
+  can_download?: boolean
+  file_name?: string
+  file_size?: number
+  files?: string[]
+}
+
+/** Write shape referenced in create/patch `skills[]`. A name-only entry keeps
+ *  (on patch) or omits (on create) the stored package; an `upload_object_key`
+ *  binds a freshly presigned-uploaded package. */
+export interface SkillWrite {
+  name: string
+  upload_object_key?: string
+  file_name?: string
+  file_size?: number
+}
+
+// ─── Expert (single agent) ─────────────────────────────────────────────────
+
+export interface ExpertListItem {
+  expert_id: string
+  short_name: string
+  name: string
+  summary: string
+  category: string
+  tags: string[]
+  visibility: ExpertVisibility
+  creator_name: string
+  created_by_type?: string
+  skill_count?: number
+}
+
+export interface ExpertDetail extends ExpertListItem {
+  instruction: string
+  mcp_config: string
+  skills: SkillRef[]
+  created_at: string
+  updated_at: string
+}
+
+/** Flat create manifest (octo-cli parity). Visibility is stamped to `system`
+ *  by the admin endpoint and short_name is server-derived from name, so
+ *  callers omit both (the strict decoder rejects unknown fields). */
+export interface CreateExpertParams {
+  name: string
+  summary: string
+  category: string
+  tags?: string[]
+  instruction: string
+  mcp_config: string
+  skills: SkillWrite[]
+}
+
+/** Partial update — metadata only, or a full spec replacement. */
+export interface PatchExpertParams {
+  name?: string
+  summary?: string
+  category?: string
+  tags?: string[]
+  instruction?: string
+  mcp_config?: string
+  skills?: SkillWrite[]
+}
+
+// ─── Squad (expert team) ────────────────────────────────────────────────────
+
+export interface SquadDependencies {
+  blocking: string[]
+  recommended: string[]
+}
+
+export interface SquadMember {
+  member_key: string
+  name: string
+  role: string
+  is_leader: boolean
+  instruction: string
+  mcp_config: string
+  skills: SkillRef[]
+}
+
+export interface SquadMemberWrite {
+  member_key: string
+  name: string
+  role: string
+  is_leader: boolean
+  instruction: string
+  mcp_config: string
+  skills: SkillWrite[]
+}
+
+export interface SquadListItem {
+  squad_id: string
+  short_name: string
+  name: string
+  summary: string
+  category: string
+  tags: string[]
+  visibility: ExpertVisibility
+  creator_name: string
+  created_by_type?: string
+  member_count?: number
+}
+
+export interface SquadDetail extends SquadListItem {
+  leader: string
+  strategies: string[]
+  dependencies: SquadDependencies
+  permission: string
+  members: SquadMember[]
+  created_at: string
+  updated_at: string
+}
+
+export interface CreateSquadParams {
+  name: string
+  summary: string
+  category: string
+  tags?: string[]
+  leader: string
+  strategies?: string[]
+  dependencies?: SquadDependencies
+  permission?: string
+  members: SquadMemberWrite[]
+}
+
+export interface PatchSquadParams {
+  name?: string
+  summary?: string
+  category?: string
+  tags?: string[]
+  leader?: string
+  strategies?: string[]
+  dependencies?: SquadDependencies
+  permission?: string
+  members?: SquadMemberWrite[]
+}
+
+// ─── Categories / tags ──────────────────────────────────────────────────────
+
+export interface ExpertCategory {
+  expert_category_id: string
+  name: string
+  icon_key?: string
+  sort_order: number
+  count?: number
+}
+
+export interface ExpertTag {
+  name: string
+  count: number
+}
+
+// ─── List params + response projection ──────────────────────────────────────
+
+export interface ListExpertParams {
+  keyword?: string
+  category?: string
+  limit?: number
+  offset?: number
+}
+
+export interface ListResponse<T> {
+  items: T[]
+  total: number
+}
+
+interface ListEnvelope<T> {
+  data: T[]
+  pagination?: { total: number; page: number; page_size: number }
+}
+
+function buildListQuery(params: ListExpertParams): Record<string, unknown> {
+  const query: Record<string, unknown> = {}
+  const keyword = params.keyword?.trim()
+  if (keyword) query.keyword = keyword
+  query.category = params.category ?? 'all'
+  // The admin list endpoints page by number (page/page_size), not
+  // limit/offset — same translation as ./skill.ts.
+  const pageSize = params.limit && params.limit > 0 ? params.limit : 20
+  query.page_size = pageSize
+  query.page =
+    params.offset && params.offset > 0 ? Math.floor(params.offset / pageSize) + 1 : 1
+  return query
+}
+
+// ─── Experts ────────────────────────────────────────────────────────────────
+
+export async function listSystemExperts(
+  params: ListExpertParams = {}
+): Promise<ListResponse<ExpertListItem>> {
+  const resp = await expertApi.get<ListEnvelope<ExpertListItem>>('/admin/experts', {
+    params: buildListQuery(params),
+  })
+  return {
+    items: resp.data.data ?? [],
+    total: resp.data.pagination?.total ?? 0,
+  }
+}
+
+export async function getSystemExpert(id: string): Promise<ExpertDetail> {
+  const resp = await expertApi.get<{ data: ExpertDetail }>(
+    `/admin/experts/${encodeURIComponent(id)}`
+  )
+  return resp.data.data
+}
+
+export async function createSystemExpert(
+  params: CreateExpertParams
+): Promise<ExpertDetail> {
+  const resp = await expertApi.post<{ data: ExpertDetail }>('/admin/experts', params)
+  return resp.data.data
+}
+
+export async function patchSystemExpert(
+  id: string,
+  params: PatchExpertParams
+): Promise<ExpertDetail> {
+  const resp = await expertApi.patch<{ data: ExpertDetail }>(
+    `/admin/experts/${encodeURIComponent(id)}`,
+    params
+  )
+  return resp.data.data
+}
+
+export async function deleteSystemExpert(id: string): Promise<void> {
+  await expertApi.delete(`/admin/experts/${encodeURIComponent(id)}`)
+}
+
+/** Stored SKILL.md text of the expert's skill at `index`. */
+export async function getSystemExpertSkillMd(id: string, index: number): Promise<string> {
+  const resp = await expertApi.get<{ data: { content: string } }>(
+    `/admin/experts/${encodeURIComponent(id)}/skill_md`,
+    { params: { i: index } }
+  )
+  return resp.data.data.content
+}
+
+// ─── Squads ───────────────────────────────────────────────────────────────
+
+export async function listSystemSquads(
+  params: ListExpertParams = {}
+): Promise<ListResponse<SquadListItem>> {
+  const resp = await expertApi.get<ListEnvelope<SquadListItem>>('/admin/squads', {
+    params: buildListQuery(params),
+  })
+  return {
+    items: resp.data.data ?? [],
+    total: resp.data.pagination?.total ?? 0,
+  }
+}
+
+export async function getSystemSquad(id: string): Promise<SquadDetail> {
+  const resp = await expertApi.get<{ data: SquadDetail }>(
+    `/admin/squads/${encodeURIComponent(id)}`
+  )
+  return resp.data.data
+}
+
+export async function createSystemSquad(
+  params: CreateSquadParams
+): Promise<SquadDetail> {
+  const resp = await expertApi.post<{ data: SquadDetail }>('/admin/squads', params)
+  return resp.data.data
+}
+
+export async function patchSystemSquad(
+  id: string,
+  params: PatchSquadParams
+): Promise<SquadDetail> {
+  const resp = await expertApi.patch<{ data: SquadDetail }>(
+    `/admin/squads/${encodeURIComponent(id)}`,
+    params
+  )
+  return resp.data.data
+}
+
+export async function deleteSystemSquad(id: string): Promise<void> {
+  await expertApi.delete(`/admin/squads/${encodeURIComponent(id)}`)
+}
+
+/** Stored SKILL.md text of a squad member's skill at `index`. */
+export async function getSystemSquadSkillMd(
+  id: string,
+  memberKey: string,
+  index: number
+): Promise<string> {
+  const resp = await expertApi.get<{ data: { content: string } }>(
+    `/admin/squads/${encodeURIComponent(id)}/skill_md`,
+    { params: { member: memberKey, i: index } }
+  )
+  return resp.data.data.content
+}
+
+// ─── Categories ─────────────────────────────────────────────────────────────
+
+export async function listExpertCategories(): Promise<ExpertCategory[]> {
+  const resp = await expertApi.get<{ data: ExpertCategory[] }>('/admin/expert_categories')
+  return resp.data.data ?? []
+}
+
+export async function createExpertCategory(params: {
+  name: string
+  icon_key?: string
+  sort_order?: number
+}): Promise<ExpertCategory> {
+  const resp = await expertApi.post<{ data: ExpertCategory }>(
+    '/admin/expert_categories',
+    params
+  )
+  return resp.data.data
+}
+
+export async function updateExpertCategory(
+  id: string,
+  params: { name?: string; icon_key?: string; sort_order?: number }
+): Promise<ExpertCategory> {
+  const resp = await expertApi.patch<{ data: ExpertCategory }>(
+    `/admin/expert_categories/${encodeURIComponent(id)}`,
+    params
+  )
+  return resp.data.data
+}
+
+export async function deleteExpertCategory(id: string): Promise<void> {
+  await expertApi.delete(`/admin/expert_categories/${encodeURIComponent(id)}`)
+}
+
+// ─── Tags (read-only suggestions) ────────────────────────────────────────────
+
+export async function listExpertTags(kind: ExpertKind): Promise<ExpertTag[]> {
+  const resp = await expertApi.get<{ data: ExpertTag[] }>('/admin/expert_tags', {
+    params: { kind },
+  })
+  return resp.data.data ?? []
+}
+
+// ─── Skill package upload (presigned, two-step) ──────────────────────────────
+
+/** POST /admin/expert_skill_uploads response. Mirrors octo-cli's
+ *  `expert-skill-upload create`. `upload_object_key` is what the caller
+ *  references in a create/patch `skills[]` entry after PUTting the bytes. */
+export interface ExpertSkillUploadInit {
+  upload_object_key: string
+  presigned_url: string
+  method: string
+  headers: Record<string, string>
+  expires_in?: number
+}
+
+/** Two-step skill-package upload: presign, then PUT the raw `.zip/.skill`
+ *  bytes directly to the returned URL, then hand back a ready `SkillWrite`
+ *  entry. The container zip is never uploaded — only its bundled packages. */
+export async function uploadExpertSkill(
+  name: string,
+  file: File | Blob,
+  fileName: string
+): Promise<SkillWrite> {
+  const size = file.size
+  const initResp = await expertApi.post<{ data: ExpertSkillUploadInit }>(
+    '/admin/expert_skill_uploads',
+    { file_name: fileName, file_size: size }
+  )
+  const { upload_object_key, presigned_url, method, headers } = initResp.data.data
+  await putPresignedFile(
+    presigned_url,
+    file instanceof File ? file : new File([file], fileName),
+    { method, headers: headers ?? {} }
+  )
+  return {
+    name,
+    upload_object_key,
+    file_name: fileName,
+    file_size: size,
+  }
+}

--- a/src/api/expert.ts
+++ b/src/api/expert.ts
@@ -379,22 +379,25 @@ export interface ExpertSkillUploadInit {
 
 /** Two-step skill-package upload: presign, then PUT the raw `.zip/.skill`
  *  bytes directly to the returned URL, then hand back a ready `SkillWrite`
- *  entry. The container zip is never uploaded — only its bundled packages. */
+ *  entry. The container zip is never uploaded — only its bundled packages.
+ *  `opts.signal` aborts both legs (batch cancel). */
 export async function uploadExpertSkill(
   name: string,
   file: File | Blob,
-  fileName: string
+  fileName: string,
+  opts: { signal?: AbortSignal } = {}
 ): Promise<SkillWrite> {
   const size = file.size
   const initResp = await expertApi.post<{ data: ExpertSkillUploadInit }>(
     '/admin/expert_skill_uploads',
-    { file_name: fileName, file_size: size }
+    { file_name: fileName, file_size: size },
+    { signal: opts.signal }
   )
   const { upload_object_key, presigned_url, method, headers } = initResp.data.data
   await putPresignedFile(
     presigned_url,
     file instanceof File ? file : new File([file], fileName),
-    { method, headers: headers ?? {} }
+    { method, headers: headers ?? {}, signal: opts.signal }
   )
   return {
     name,

--- a/src/api/marketplace.ts
+++ b/src/api/marketplace.ts
@@ -87,6 +87,30 @@ export function assertSafeExternalUrl(raw: string): void {
   throw new ApiError('Upload URL scheme is not allowed', 502, 'invalid_response')
 }
 
+/** In dev, marketplace's built-in storage presigns absolute URLs to its own
+ *  host (http://127.0.0.1:8092/api/v1/_storage/…). The admin app runs on the
+ *  Vite origin, so a direct PUT is cross-origin and the storage endpoint
+ *  sends no CORS headers. Route those URLs through the `/market` dev proxy
+ *  (the inverse of vite.config.ts's `/market` → strip rewrite) so the PUT is
+ *  same-origin. Real OSS hosts (https) pass through untouched; prod serves
+ *  everything behind one nginx origin so the rewrite never applies there. */
+function toSameOriginUploadUrl(raw: string): string {
+  if (!import.meta.env.DEV) return raw
+  try {
+    const url = new URL(raw)
+    if (
+      url.protocol === 'http:' &&
+      (url.hostname === 'localhost' || url.hostname === '127.0.0.1') &&
+      url.pathname.startsWith('/api/v1/_storage/')
+    ) {
+      return `/market${url.pathname}${url.search}`
+    }
+  } catch {
+    // Not an absolute URL — let assertSafeExternalUrl report it.
+  }
+  return raw
+}
+
 /** PUT `file` bytes to a marketplace-issued presigned URL. Uses fetch (not
  *  the marketplace axios instance) because the presigned URL points at the
  *  local dev proxy or an OSS host — not the admin base URL — and we don't
@@ -98,7 +122,7 @@ export async function putPresignedFile(
   options: { method?: string; headers?: Record<string, string> } = {}
 ): Promise<void> {
   assertSafeExternalUrl(presignedUrl)
-  const putResp = await fetch(presignedUrl, {
+  const putResp = await fetch(toSameOriginUploadUrl(presignedUrl), {
     method: options.method || 'PUT',
     headers: options.headers ?? {},
     body: file,

--- a/src/api/marketplace.ts
+++ b/src/api/marketplace.ts
@@ -111,22 +111,44 @@ function toSameOriginUploadUrl(raw: string): string {
   return raw
 }
 
+/** Ceiling for one presigned PUT (worst case: a 20 MiB package on a slow
+ *  link). Without it a stalled TCP connection would hang an import batch
+ *  forever — fetch has no default timeout, unlike the axios instance above. */
+const UPLOAD_TIMEOUT_MS = 120_000
+
 /** PUT `file` bytes to a marketplace-issued presigned URL. Uses fetch (not
  *  the marketplace axios instance) because the presigned URL points at the
  *  local dev proxy or an OSS host — not the admin base URL — and we don't
  *  want the token / Accept-Language interceptors leaking into a third-party
- *  call. Errors become ApiError so upload flows share a single error type. */
+ *  call. Errors become ApiError so upload flows share a single error type.
+ *  `options.signal` lets a caller cancel an in-flight batch; the timeout
+ *  applies either way. */
 export async function putPresignedFile(
   presignedUrl: string,
   file: File,
-  options: { method?: string; headers?: Record<string, string> } = {}
+  options: { method?: string; headers?: Record<string, string>; signal?: AbortSignal } = {}
 ): Promise<void> {
   assertSafeExternalUrl(presignedUrl)
-  const putResp = await fetch(toSameOriginUploadUrl(presignedUrl), {
-    method: options.method || 'PUT',
-    headers: options.headers ?? {},
-    body: file,
-  })
+  const timeout = AbortSignal.timeout(UPLOAD_TIMEOUT_MS)
+  const signal = options.signal ? AbortSignal.any([options.signal, timeout]) : timeout
+  let putResp: Response
+  try {
+    putResp = await fetch(toSameOriginUploadUrl(presignedUrl), {
+      method: options.method || 'PUT',
+      headers: options.headers ?? {},
+      body: file,
+      signal,
+    })
+  } catch (err) {
+    const name = (err as Error)?.name
+    if (name === 'TimeoutError') {
+      throw new ApiError(`Upload timed out after ${UPLOAD_TIMEOUT_MS / 1000}s`, 408, 'upload_timeout')
+    }
+    if (name === 'AbortError') {
+      throw new ApiError('Upload cancelled', undefined, 'upload_cancelled')
+    }
+    throw err
+  }
   if (!putResp.ok) {
     throw new ApiError(`Upload failed (${putResp.status})`, putResp.status)
   }

--- a/src/api/mcp.ts
+++ b/src/api/mcp.ts
@@ -156,8 +156,12 @@ export async function listSystemMcps(
   const keyword = params.keyword?.trim()
   if (keyword) query.keyword = keyword
   query.category = params.category ?? 'all'
-  if (params.limit && params.limit > 0) query.limit = params.limit
-  if (params.offset && params.offset > 0) query.offset = params.offset
+  // The admin list endpoint pages by number (page/page_size), not
+  // limit/offset — same translation as ./skill.ts and ./expert.ts.
+  const pageSize = params.limit && params.limit > 0 ? params.limit : 20
+  query.page_size = pageSize
+  query.page =
+    params.offset && params.offset > 0 ? Math.floor(params.offset / pageSize) + 1 : 1
   const resp = await mcpApi.get<{
     data: McpListItem[]
     pagination: { total: number; page: number; page_size: number }

--- a/src/api/skill.test.ts
+++ b/src/api/skill.test.ts
@@ -130,6 +130,8 @@ describe('uploadIcon', () => {
       method: 'PUT',
       headers: { 'content-type': 'image/png' },
       body: file,
+      // putPresignedFile now bounds every PUT with a timeout signal.
+      signal: expect.any(AbortSignal),
     })
     expect(result).toEqual({ object_key: 'icons/icon-1/logo.png' })
   })

--- a/src/auth/capabilities.test.ts
+++ b/src/auth/capabilities.test.ts
@@ -37,6 +37,16 @@ describe('manager capabilities', () => {
     expect(firstManagerPath(capabilities)).toBe('/spaces')
   })
 
+  it('routes an expert-only manager to the expert market', () => {
+    const capabilities = normalizeManagerCapabilities({
+      'expert.read': true,
+      'expert.write': true,
+    })
+
+    expect(firstManagerPath(capabilities)).toBe('/expert-market')
+    expect(hasManagerCapability(capabilities, 'expert.read')).toBe(true)
+  })
+
   it('falls back to no-access when no readable manager path exists', () => {
     const capabilities = normalizeManagerCapabilities({
       'users.write': true,

--- a/src/auth/capabilities.ts
+++ b/src/auth/capabilities.ts
@@ -23,6 +23,11 @@ export const MANAGER_CAPABILITY_KEYS = [
   // system-level public Skills and categories.
   'skill.read',
   'skill.write',
+  // Expert Market admin surface. Read = list experts / squads; write = create
+  // (upload container) / edit metadata / re-upload / delete platform-provided
+  // (visibility=system) expert + squad records, and manage their categories.
+  'expert.read',
+  'expert.write',
 ] as const
 
 export const MANAGER_NO_ACCESS_PATH = '/no-access'
@@ -64,5 +69,6 @@ export function firstManagerPath(capabilities: ManagerCapabilities | null | unde
   if (hasManagerCapability(capabilities, 'appversion.read')) return '/download'
   if (hasManagerCapability(capabilities, 'mcp.read')) return '/system-mcp'
   if (hasManagerCapability(capabilities, 'skill.read')) return '/skill-market'
+  if (hasManagerCapability(capabilities, 'expert.read')) return '/expert-market'
   return MANAGER_NO_ACCESS_PATH
 }

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -33,6 +33,8 @@ import skillMarketEN from './locales/en-US/skillMarket.json'
 import skillMarketZH from './locales/zh-CN/skillMarket.json'
 import systemSkillEN from './locales/en-US/systemSkill.json'
 import systemSkillZH from './locales/zh-CN/systemSkill.json'
+import expertMarketEN from './locales/en-US/expertMarket.json'
+import expertMarketZH from './locales/zh-CN/expertMarket.json'
 
 export const SUPPORTED_LANGUAGES = ['en-US', 'zh-CN'] as const
 export type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number]
@@ -62,6 +64,7 @@ i18n
         systemMcp: systemMcpEN,
         skillMarket: skillMarketEN,
         systemSkill: systemSkillEN,
+        expertMarket: expertMarketEN,
       },
       'zh-CN': {
         common: commonZH,
@@ -80,6 +83,7 @@ i18n
         systemMcp: systemMcpZH,
         skillMarket: skillMarketZH,
         systemSkill: systemSkillZH,
+        expertMarket: expertMarketZH,
       },
     },
     fallbackLng: FALLBACK_LANGUAGE,
@@ -102,6 +106,7 @@ i18n
       'systemMcp',
       'skillMarket',
       'systemSkill',
+      'expertMarket',
     ],
     interpolation: { escapeValue: false },
     detection: {

--- a/src/i18n/locales/en-US/expertMarket.json
+++ b/src/i18n/locales/en-US/expertMarket.json
@@ -45,7 +45,8 @@
     "partial": "{{ok}} imported, {{fail}} failed — failed items can be retried",
     "categoryPlaceholder": "Select a category (overrides the package value)",
     "tagsHint": "Type and press Enter to add",
-    "categoryRequired": "Select a category for this row first"
+    "categoryRequired": "Select a category for this row first",
+    "cancelled": "Import cancelled — remaining rows kept for later"
   },
   "list": {
     "name": "Name",
@@ -156,6 +157,7 @@
     "leaderCount": "squad must have exactly one leader",
     "skillFileMissing": "referenced skill file not found in package",
     "skillFileTooLarge": "skill package exceeds 20 MiB",
-    "memberRoleRequired": "member is missing role"
+    "memberRoleRequired": "member is missing role",
+    "containerTooLarge": "container exceeds 512 MiB"
   }
 }

--- a/src/i18n/locales/en-US/expertMarket.json
+++ b/src/i18n/locales/en-US/expertMarket.json
@@ -1,0 +1,161 @@
+{
+  "pageTitle": "Expert Market",
+  "pageDesc": "Manage platform-level experts and squads that all users can browse and install to Loop.",
+  "tab": {
+    "experts": "Experts",
+    "squads": "Squads",
+    "categories": "Categories"
+  },
+  "createExpert": "Upload expert",
+  "createSquad": "Upload squad",
+  "searchPlaceholder": "Search name or summary",
+  "loadFailed": "Failed to load",
+  "emptyExpert": "No experts yet — click \"Upload expert\" to add one",
+  "emptySquad": "No squads yet — click \"Upload squad\" to add one",
+  "table": {
+    "name": "Name",
+    "category": "Category",
+    "tags": "Tags",
+    "skills": "Skills",
+    "members": "Members",
+    "creator": "Creator",
+    "memberCount": "{{count}} members"
+  },
+  "actions": {
+    "delete": "Delete"
+  },
+  "aiHelp": {
+    "title": "No package yet? Generate one with AI",
+    "descExpert": "Copy the prompt into any AI chat (Claude, ChatGPT, …), add your requirement, and it will generate uploadable expert package zips — generate several and drop them all in for a batch import.",
+    "descSquad": "Copy the prompt into any AI chat (Claude, ChatGPT, …), add your requirement, and it will generate uploadable squad package zips — generate several and drop them all in for a batch import.",
+    "copy": "Copy prompt",
+    "copied": "Copied — paste it to an AI and add your requirement",
+    "copyFailed": "Copy failed, please copy manually"
+  },
+  "upload": {
+    "titleExpert": "Import experts",
+    "titleSquad": "Import squads",
+    "submit": "Import",
+    "submitCount": "Import {{count}}",
+    "zipHintExpert": "Drop or click to select one or more expert packages (zip with expert.json and skill packages)",
+    "zipHintSquad": "Drop or click to select one or more squad packages (zip with squad.json and skill packages)",
+    "zipRequired": "Add at least one importable package first",
+    "importing": "Importing {{done}}/{{total}}: {{name}}",
+    "successCount": "Imported {{count}}",
+    "partial": "{{ok}} imported, {{fail}} failed — failed items can be retried",
+    "categoryPlaceholder": "Select a category (overrides the package value)",
+    "tagsHint": "Type and press Enter to add",
+    "categoryRequired": "Select a category for this row first"
+  },
+  "list": {
+    "name": "Name",
+    "packages": "Packages",
+    "category": "Category",
+    "categoryPlaceholder": "Select category",
+    "tags": "Tags",
+    "tagsPlaceholder": "Enter to add",
+    "status": "Status",
+    "statusParsing": "Parsing",
+    "statusReady": "Ready",
+    "statusInvalid": "Parse failed",
+    "statusSaving": "Importing",
+    "statusDone": "Imported",
+    "statusFailed": "Import failed"
+  },
+  "reupload": {
+    "button": "Re-upload",
+    "success": "Content replaced"
+  },
+  "detail": {
+    "title": "Expert detail",
+    "titleSquad": "Squad detail",
+    "loadFailed": "Failed to load detail",
+    "instruction": "Instruction",
+    "mcpConfig": "MCP config",
+    "skills": "Skills",
+    "noSkills": "No skill packages",
+    "leader": "Leader",
+    "leaderBadge": "Leader",
+    "members": "Members",
+    "strategies": "Dispatch strategies",
+    "dependencies": "Dependencies",
+    "blocking": "Required",
+    "recommended": "Recommended",
+    "permission": "Permission",
+    "viewSkill": "View content",
+    "skillLoadFailed": "Failed to load skill content"
+  },
+  "delete": {
+    "confirmDesc": "Deleting removes it from all spaces. This cannot be undone.",
+    "ok": "Delete",
+    "cancel": "Cancel",
+    "success": "Deleted",
+    "failed": "Delete failed"
+  },
+  "category": {
+    "create": "New category",
+    "rename": "Edit",
+    "delete": "Delete",
+    "deleteConfirm": "Delete this category?",
+    "deleteInUse": "This category still has {{count}} experts and cannot be deleted",
+    "empty": "No categories yet",
+    "table": {
+      "name": "Name",
+      "count": "Count",
+      "sortOrder": "Order",
+      "actions": "Actions"
+    },
+    "modal": {
+      "createTitle": "New category",
+      "editTitle": "Edit category",
+      "name": "Name",
+      "nameRequired": "Name is required",
+      "sortOrder": "Order",
+      "sortOrderHint": "Lower numbers come first"
+    },
+    "success": {
+      "created": "Created",
+      "updated": "Updated",
+      "deleted": "Deleted"
+    },
+    "error": {
+      "nameExists": "Category name already exists",
+      "createFailed": "Create failed",
+      "updateFailed": "Update failed",
+      "deleteFailed": "Delete failed"
+    }
+  },
+  "container": {
+    "kindMismatch": "Package kind does not match this tab (expert / squad)",
+    "zipInvalid": "File is not a valid zip archive",
+    "manifestAmbiguous": "Package has both expert.json and squad.json",
+    "manifestMissing": "Package has no expert.json or squad.json",
+    "manifestParse": "Manifest JSON is malformed",
+    "manifestInvalid": "Manifest is not a valid JSON object",
+    "nameRequired": "name is required",
+    "nameTooLong": "name exceeds 128 chars",
+    "summaryRequired": "summary is required",
+    "summaryTooLong": "summary exceeds 512 chars",
+    "shortNameTooLong": "short_name exceeds 16 chars",
+    "tagsTooMany": "too many tags",
+    "instructionRequired": "instruction is required",
+    "mcpConfigType": "mcp_config must be a JSON string",
+    "mcpConfigTooLarge": "mcp_config exceeds 64 KiB",
+    "mcpConfigInvalid": "mcp_config is not valid JSON",
+    "skillsType": "skills must be an array",
+    "skillsTooMany": "too many skills",
+    "skillNameRequired": "skill is missing name",
+    "skillPathUnsafe": "unsafe skill package path",
+    "skillExtInvalid": "skill package must be .zip or .skill",
+    "membersRequired": "squad requires at least one member",
+    "membersTooMany": "too many members",
+    "strategiesTooMany": "too many strategies",
+    "memberNameRequired": "member is missing name",
+    "memberKeyDup": "duplicate member_key",
+    "memberInstructionRequired": "member is missing instruction",
+    "leaderCount": "squad must have exactly one leader",
+    "skillFileMissing": "referenced skill file not found in package",
+    "skillFileTooLarge": "skill package exceeds 20 MiB",
+    "memberRoleRequired": "member is missing role"
+  }
+}

--- a/src/i18n/locales/en-US/expertMarket.json
+++ b/src/i18n/locales/en-US/expertMarket.json
@@ -158,6 +158,8 @@
     "skillFileMissing": "referenced skill file not found in package",
     "skillFileTooLarge": "skill package exceeds 20 MiB",
     "memberRoleRequired": "member is missing role",
-    "containerTooLarge": "container exceeds 512 MiB"
+    "containerTooLarge": "container exceeds 512 MiB",
+    "manifestTooLarge": "manifest exceeds 1 MiB",
+    "entryMetaMissing": "zip entry metadata is missing; rejected"
   }
 }

--- a/src/i18n/locales/en-US/nav.json
+++ b/src/i18n/locales/en-US/nav.json
@@ -10,6 +10,7 @@
   "systemSetting": "System Settings",
   "systemMcp": "MCP Market",
   "skillMarket": "Skill Market",
+  "expertMarket": "Expert Market",
   "backup": "Backups",
   "download": "Downloads",
   "systemSkill": "Skill Market"

--- a/src/i18n/locales/zh-CN/expertMarket.json
+++ b/src/i18n/locales/zh-CN/expertMarket.json
@@ -1,0 +1,161 @@
+{
+  "pageTitle": "专家市场",
+  "pageDesc": "管理平台级专家与专家团，供全平台用户浏览与安装到回路。",
+  "tab": {
+    "experts": "专家",
+    "squads": "专家团",
+    "categories": "分类"
+  },
+  "createExpert": "上传新建专家",
+  "createSquad": "上传新建专家团",
+  "searchPlaceholder": "搜索名称或简介",
+  "loadFailed": "加载失败",
+  "emptyExpert": "还没有专家，点击右上角「上传新建专家」添加",
+  "emptySquad": "还没有专家团，点击右上角「上传新建专家团」添加",
+  "table": {
+    "name": "名称",
+    "category": "分类",
+    "tags": "标签",
+    "skills": "技能数",
+    "members": "成员数",
+    "creator": "创建者",
+    "memberCount": "{{count}} 名成员"
+  },
+  "actions": {
+    "delete": "删除"
+  },
+  "aiHelp": {
+    "title": "没有现成的包？用 AI 生成",
+    "descExpert": "复制提示词发给任意 AI（如 Claude、ChatGPT），补充你的需求描述，AI 会按格式生成可直接上传的专家包 zip；可一次生成多个，一起拖进来批量导入。",
+    "descSquad": "复制提示词发给任意 AI（如 Claude、ChatGPT），补充你的需求描述，AI 会按格式生成可直接上传的专家团包 zip；可一次生成多个，一起拖进来批量导入。",
+    "copy": "复制提示词",
+    "copied": "已复制，粘贴给 AI 并补充你的需求即可",
+    "copyFailed": "复制失败，请手动复制"
+  },
+  "upload": {
+    "titleExpert": "导入专家",
+    "titleSquad": "导入专家团",
+    "submit": "导入",
+    "submitCount": "导入 {{count}} 个",
+    "zipHintExpert": "拖入或点击选择一个或多个专家包（zip，含 expert.json 与技能包）",
+    "zipHintSquad": "拖入或点击选择一个或多个专家团包（zip，含 squad.json 与技能包）",
+    "zipRequired": "请先添加可导入的包",
+    "importing": "正在导入 {{done}}/{{total}}：{{name}}",
+    "successCount": "已导入 {{count}} 个",
+    "partial": "成功 {{ok}} 个，失败 {{fail}} 个，失败项可直接重试",
+    "categoryPlaceholder": "选择分类（可覆盖包内值）",
+    "tagsHint": "输入后回车添加",
+    "categoryRequired": "请先在该行选择分类"
+  },
+  "list": {
+    "name": "名称",
+    "packages": "技能包",
+    "category": "分类",
+    "categoryPlaceholder": "选择分类",
+    "tags": "标签",
+    "tagsPlaceholder": "回车添加",
+    "status": "状态",
+    "statusParsing": "解析中",
+    "statusReady": "待导入",
+    "statusInvalid": "解析失败",
+    "statusSaving": "导入中",
+    "statusDone": "已导入",
+    "statusFailed": "导入失败"
+  },
+  "reupload": {
+    "button": "重新上传",
+    "success": "已替换内容"
+  },
+  "detail": {
+    "title": "专家详情",
+    "titleSquad": "专家团详情",
+    "loadFailed": "加载详情失败",
+    "instruction": "指令",
+    "mcpConfig": "MCP 配置",
+    "skills": "技能包",
+    "noSkills": "暂无技能包",
+    "leader": "组长",
+    "leaderBadge": "组长",
+    "members": "成员",
+    "strategies": "调度规则",
+    "dependencies": "依赖",
+    "blocking": "必需",
+    "recommended": "推荐",
+    "permission": "权限说明",
+    "viewSkill": "查看内容",
+    "skillLoadFailed": "读取技能内容失败"
+  },
+  "delete": {
+    "confirmDesc": "删除后将从所有空间下架，操作不可撤销。",
+    "ok": "确认删除",
+    "cancel": "取消",
+    "success": "已删除",
+    "failed": "删除失败"
+  },
+  "category": {
+    "create": "新建分类",
+    "rename": "编辑",
+    "delete": "删除",
+    "deleteConfirm": "确认删除该分类？",
+    "deleteInUse": "该分类下还有 {{count}} 个专家，无法删除",
+    "empty": "还没有分类",
+    "table": {
+      "name": "名称",
+      "count": "数量",
+      "sortOrder": "排序",
+      "actions": "操作"
+    },
+    "modal": {
+      "createTitle": "新建分类",
+      "editTitle": "编辑分类",
+      "name": "名称",
+      "nameRequired": "请填写名称",
+      "sortOrder": "排序",
+      "sortOrderHint": "数字越小越靠前"
+    },
+    "success": {
+      "created": "已创建",
+      "updated": "已更新",
+      "deleted": "已删除"
+    },
+    "error": {
+      "nameExists": "分类名称已存在",
+      "createFailed": "创建失败",
+      "updateFailed": "更新失败",
+      "deleteFailed": "删除失败"
+    }
+  },
+  "container": {
+    "kindMismatch": "包类型与当前标签页不匹配（专家 / 专家团）",
+    "zipInvalid": "文件不是有效的 zip 压缩包",
+    "manifestAmbiguous": "包内同时存在 expert.json 与 squad.json，无法判断类型",
+    "manifestMissing": "包内缺少 expert.json 或 squad.json",
+    "manifestParse": "清单 JSON 格式错误",
+    "manifestInvalid": "清单不是合法的 JSON 对象",
+    "nameRequired": "缺少 name",
+    "nameTooLong": "name 超过 128 字",
+    "summaryRequired": "缺少 summary",
+    "summaryTooLong": "summary 超过 512 字",
+    "shortNameTooLong": "short_name 超过 16 字",
+    "tagsTooMany": "标签数量超过上限",
+    "instructionRequired": "缺少 instruction",
+    "mcpConfigType": "mcp_config 必须是 JSON 字符串",
+    "mcpConfigTooLarge": "mcp_config 超过 64 KiB",
+    "mcpConfigInvalid": "mcp_config 不是合法 JSON",
+    "skillsType": "skills 必须是数组",
+    "skillsTooMany": "技能数量超过上限",
+    "skillNameRequired": "技能缺少 name",
+    "skillPathUnsafe": "技能包路径非法",
+    "skillExtInvalid": "技能包必须是 .zip 或 .skill",
+    "membersRequired": "专家团至少需要一名成员",
+    "membersTooMany": "成员数量超过上限",
+    "strategiesTooMany": "调度规则数量超过上限",
+    "memberNameRequired": "成员缺少 name",
+    "memberKeyDup": "存在重复的 member_key",
+    "memberInstructionRequired": "成员缺少 instruction",
+    "leaderCount": "专家团必须且只能有一名组长",
+    "skillFileMissing": "包内缺少引用的技能文件",
+    "skillFileTooLarge": "技能包超过 20 MiB",
+    "memberRoleRequired": "成员缺少 role"
+  }
+}

--- a/src/i18n/locales/zh-CN/expertMarket.json
+++ b/src/i18n/locales/zh-CN/expertMarket.json
@@ -158,6 +158,8 @@
     "skillFileMissing": "包内缺少引用的技能文件",
     "skillFileTooLarge": "技能包超过 20 MiB",
     "memberRoleRequired": "成员缺少 role",
-    "containerTooLarge": "压缩包超过 512 MiB"
+    "containerTooLarge": "压缩包超过 512 MiB",
+    "manifestTooLarge": "清单文件超过 1 MiB",
+    "entryMetaMissing": "压缩包条目元数据缺失，已拒绝"
   }
 }

--- a/src/i18n/locales/zh-CN/expertMarket.json
+++ b/src/i18n/locales/zh-CN/expertMarket.json
@@ -45,7 +45,8 @@
     "partial": "成功 {{ok}} 个，失败 {{fail}} 个，失败项可直接重试",
     "categoryPlaceholder": "选择分类（可覆盖包内值）",
     "tagsHint": "输入后回车添加",
-    "categoryRequired": "请先在该行选择分类"
+    "categoryRequired": "请先在该行选择分类",
+    "cancelled": "已取消导入，剩余条目保留待导入"
   },
   "list": {
     "name": "名称",
@@ -156,6 +157,7 @@
     "leaderCount": "专家团必须且只能有一名组长",
     "skillFileMissing": "包内缺少引用的技能文件",
     "skillFileTooLarge": "技能包超过 20 MiB",
-    "memberRoleRequired": "成员缺少 role"
+    "memberRoleRequired": "成员缺少 role",
+    "containerTooLarge": "压缩包超过 512 MiB"
   }
 }

--- a/src/i18n/locales/zh-CN/nav.json
+++ b/src/i18n/locales/zh-CN/nav.json
@@ -10,6 +10,7 @@
   "systemSetting": "系统配置",
   "systemMcp": "MCP 市场",
   "skillMarket": "Skill 市场",
+  "expertMarket": "专家市场",
   "backup": "备份管理",
   "download": "下载配置",
   "systemSkill": "Skill 市场"

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -129,6 +129,9 @@ const MainLayout: React.FC = () => {
     if (hasManagerCapability(managerCapabilities, 'skill.read')) {
       list.push({ key: '/skill-market', icon: <ShopOutlined />, label: t('nav:skillMarket'), group: 'system' })
     }
+    if (hasManagerCapability(managerCapabilities, 'expert.read')) {
+      list.push({ key: '/expert-market', icon: <TeamOutlined />, label: t('nav:expertMarket'), group: 'system' })
+    }
     if (hasManagerCapability(managerCapabilities, 'backup')) {
       list.push({ key: '/backup', icon: <CloudUploadOutlined />, label: t('nav:backup'), group: 'system' })
     }

--- a/src/pages/ExpertMarket/CategoryTab.tsx
+++ b/src/pages/ExpertMarket/CategoryTab.tsx
@@ -1,0 +1,177 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Button, Form, Input, InputNumber, message, Modal, Popconfirm, Space, Table } from 'antd'
+import { PlusOutlined } from '@ant-design/icons'
+import { useTranslation } from 'react-i18next'
+import type { ColumnsType } from 'antd/es/table'
+import {
+  createExpertCategory,
+  deleteExpertCategory,
+  listExpertCategories,
+  updateExpertCategory,
+  type ExpertCategory,
+} from '../../api/expert'
+import { ApiError } from '../../api'
+import { hasManagerCapability } from '../../auth/capabilities'
+import { useAuthStore } from '../../store/auth'
+
+export default function CategoryTab() {
+  const { t } = useTranslation(['expertMarket', 'common'])
+  const canWrite = useAuthStore((s) => hasManagerCapability(s.managerCapabilities, 'expert.write'))
+
+  const [rows, setRows] = useState<ExpertCategory[]>([])
+  const [loading, setLoading] = useState(false)
+  const [modalOpen, setModalOpen] = useState(false)
+  const [editing, setEditing] = useState<ExpertCategory | null>(null)
+  const [form] = Form.useForm()
+  const [submitting, setSubmitting] = useState(false)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    try {
+      setRows(await listExpertCategories())
+    } catch (err) {
+      message.error(err instanceof ApiError ? err.message : t('loadFailed'))
+    } finally {
+      setLoading(false)
+    }
+  }, [t])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  const openCreate = () => {
+    setEditing(null)
+    form.resetFields()
+    form.setFieldsValue({ name: '', sort_order: 0 })
+    setModalOpen(true)
+  }
+
+  const openEdit = (record: ExpertCategory) => {
+    setEditing(record)
+    form.setFieldsValue({ name: record.name, sort_order: record.sort_order })
+    setModalOpen(true)
+  }
+
+  const handleSubmit = async () => {
+    const values = await form.validateFields()
+    setSubmitting(true)
+    try {
+      if (editing) {
+        // AdminCategoryRequest decodes a missing icon_key as "" and the
+        // backend overwrites all columns — echo the current icon_key back so
+        // renames/re-sorts don't wipe the seeded lucide icon.
+        await updateExpertCategory(editing.expert_category_id, {
+          name: values.name,
+          icon_key: editing.icon_key,
+          sort_order: values.sort_order ?? 0,
+        })
+        message.success(t('category.success.updated'))
+      } else {
+        await createExpertCategory({ name: values.name, sort_order: values.sort_order ?? 0 })
+        message.success(t('category.success.created'))
+      }
+      setModalOpen(false)
+      load()
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 409) {
+        message.error(t('category.error.nameExists'))
+      } else {
+        message.error(
+          editing ? t('category.error.updateFailed') : t('category.error.createFailed')
+        )
+      }
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const handleDelete = async (record: ExpertCategory) => {
+    try {
+      await deleteExpertCategory(record.expert_category_id)
+      message.success(t('category.success.deleted'))
+      load()
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 409) {
+        const count = (err.details?.count as number) ?? 0
+        message.error(t('category.deleteInUse', { count }))
+      } else {
+        message.error(t('category.error.deleteFailed'))
+      }
+    }
+  }
+
+  const columns: ColumnsType<ExpertCategory> = [
+    { title: t('category.table.name'), dataIndex: 'name', key: 'name' },
+    { title: t('category.table.count'), dataIndex: 'count', key: 'count', width: 100, render: (v?: number) => v ?? 0 },
+    { title: t('category.table.sortOrder'), dataIndex: 'sort_order', key: 'sort_order', width: 100 },
+    {
+      title: t('category.table.actions'),
+      key: 'actions',
+      width: 180,
+      render: (_, record) =>
+        canWrite ? (
+          <Space size="small">
+            <Button type="link" size="small" onClick={() => openEdit(record)}>
+              {t('category.rename')}
+            </Button>
+            <Popconfirm
+              title={t('category.deleteConfirm')}
+              onConfirm={() => handleDelete(record)}
+              okText={t('common:action.confirm')}
+              cancelText={t('common:action.cancel')}
+            >
+              <Button type="link" size="small" danger>
+                {t('category.delete')}
+              </Button>
+            </Popconfirm>
+          </Space>
+        ) : null,
+    },
+  ]
+
+  return (
+    <div>
+      {canWrite && (
+        <div style={{ marginBottom: 16 }}>
+          <Button type="primary" icon={<PlusOutlined />} onClick={openCreate}>
+            {t('category.create')}
+          </Button>
+        </div>
+      )}
+      <Table
+        rowKey="expert_category_id"
+        columns={columns}
+        dataSource={rows}
+        loading={loading}
+        pagination={false}
+        locale={{ emptyText: t('category.empty') }}
+      />
+      <Modal
+        open={modalOpen}
+        title={editing ? t('category.modal.editTitle') : t('category.modal.createTitle')}
+        onCancel={() => setModalOpen(false)}
+        onOk={handleSubmit}
+        confirmLoading={submitting}
+        destroyOnClose
+      >
+        <Form form={form} layout="vertical" preserve={false}>
+          <Form.Item
+            name="name"
+            label={t('category.modal.name')}
+            rules={[{ required: true, message: t('category.modal.nameRequired') }]}
+          >
+            <Input />
+          </Form.Item>
+          <Form.Item
+            name="sort_order"
+            label={t('category.modal.sortOrder')}
+            tooltip={t('category.modal.sortOrderHint')}
+          >
+            <InputNumber min={0} style={{ width: '100%' }} />
+          </Form.Item>
+        </Form>
+      </Modal>
+    </div>
+  )
+}

--- a/src/pages/ExpertMarket/ExpertDetailDrawer.tsx
+++ b/src/pages/ExpertMarket/ExpertDetailDrawer.tsx
@@ -1,0 +1,189 @@
+/**
+ * Read-only Expert detail drawer. Mirrors SystemMcp/DetailDrawer: fetch full
+ * detail on open, grouped read-only sections, footer with re-upload (replace
+ * spec) and inline delete confirm. Metadata is not hand-edited — content
+ * changes go through re-upload.
+ */
+
+import { useEffect, useState } from 'react'
+import { Button, Drawer, Skeleton, Tag, Typography, message } from 'antd'
+import { DeleteOutlined } from '@ant-design/icons'
+import { useTranslation } from 'react-i18next'
+import { ApiError } from '../../api'
+import {
+  deleteSystemExpert,
+  getSystemExpert,
+  getSystemExpertSkillMd,
+  patchSystemExpert,
+  type ExpertDetail,
+} from '../../api/expert'
+import { DetailSection, McpConfigBlock, SkillMdModal, SkillRefList } from './detailParts'
+import ReuploadButton from './ReuploadButton'
+import { buildExpertParams } from './submitContainer'
+import type { ParsedExpert } from './parseContainer'
+
+const { Text, Paragraph } = Typography
+
+interface Props {
+  expertId: string | null
+  open: boolean
+  canManage: boolean
+  onClose: () => void
+  onChanged: () => void
+  onDeleted: (id: string) => void
+}
+
+export default function ExpertDetailDrawer({
+  expertId,
+  open,
+  canManage,
+  onClose,
+  onChanged,
+  onDeleted,
+}: Props) {
+  const { t } = useTranslation(['expertMarket', 'common'])
+  const [detail, setDetail] = useState<ExpertDetail | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [confirmingDelete, setConfirmingDelete] = useState(false)
+  const [deleting, setDeleting] = useState(false)
+  const [viewingSkill, setViewingSkill] = useState<{ index: number; name: string } | null>(null)
+
+  const reload = (id: string) => {
+    let cancelled = false
+    setLoading(true)
+    getSystemExpert(id)
+      .then((d) => !cancelled && setDetail(d))
+      .catch((err) => {
+        if (!cancelled) {
+          message.error(err instanceof ApiError ? err.message : t('detail.loadFailed'))
+          onClose()
+        }
+      })
+      .finally(() => !cancelled && setLoading(false))
+    return () => {
+      cancelled = true
+    }
+  }
+
+  useEffect(() => {
+    if (!open || !expertId) {
+      setDetail(null)
+      return
+    }
+    setConfirmingDelete(false)
+    setDeleting(false)
+    setViewingSkill(null)
+    return reload(expertId)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, expertId])
+
+  const confirmDelete = async () => {
+    if (!detail || deleting) return
+    setDeleting(true)
+    try {
+      await deleteSystemExpert(detail.expert_id)
+      message.success(t('delete.success'))
+      onDeleted(detail.expert_id)
+    } catch (err) {
+      message.error(err instanceof ApiError ? err.message : t('delete.failed'))
+    } finally {
+      setDeleting(false)
+    }
+  }
+
+  const handleReupload = async (manifest: unknown, uploaded: Map<string, import('../../api/expert').SkillWrite>) => {
+    if (!detail) return
+    const { category, ...rest } = buildExpertParams(manifest as ParsedExpert, uploaded)
+    // resolveCategory rejects an empty name on PATCH too — when the container
+    // omits category, leave the record's current one untouched.
+    const updated = await patchSystemExpert(
+      detail.expert_id,
+      category ? { category, ...rest } : rest
+    )
+    setDetail(updated)
+    onChanged()
+  }
+
+  const footer = !detail || !canManage ? null : confirmingDelete ? (
+    <div className="exp-drawer-footer exp-drawer-footer--confirm">
+      <Text type="secondary" style={{ fontSize: 12 }}>
+        {t('delete.confirmDesc')}
+      </Text>
+      <Button onClick={() => setConfirmingDelete(false)} disabled={deleting}>
+        {t('delete.cancel')}
+      </Button>
+      <Button danger type="primary" loading={deleting} onClick={confirmDelete}>
+        {t('delete.ok')}
+      </Button>
+    </div>
+  ) : (
+    <div className="exp-drawer-footer">
+      <Button danger icon={<DeleteOutlined />} onClick={() => setConfirmingDelete(true)}>
+        {t('actions.delete')}
+      </Button>
+      <ReuploadButton expectKind="agent" onReady={handleReupload} />
+    </div>
+  )
+
+  return (
+    <Drawer
+      title={detail ? detail.name : t('detail.title')}
+      open={open}
+      onClose={onClose}
+      width={720}
+      destroyOnClose
+      className="admin-shell admin-drawer"
+      footer={footer}
+    >
+      {loading || !detail ? (
+        <Skeleton active paragraph={{ rows: 6 }} />
+      ) : (
+        <div className="exp-detail">
+          <div className="exp-detail__meta">
+            <span className="exp-detail__tile">{detail.short_name || detail.name.slice(0, 2)}</span>
+            <div className="exp-detail__meta-body">
+              <div className="exp-detail__summary">{detail.summary}</div>
+              <div className="exp-detail__sub">
+                {detail.category && <span className="pill-outline neutral">{detail.category}</span>}
+                {detail.creator_name && <span>@{detail.creator_name}</span>}
+              </div>
+              {detail.tags?.length > 0 && (
+                <div className="exp-detail__tags">
+                  {detail.tags.map((tag) => (
+                    <Tag key={tag} className="pill-outline brand" style={{ margin: 0 }}>
+                      {tag}
+                    </Tag>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+
+          <DetailSection title={t('detail.instruction')}>
+            <Paragraph style={{ whiteSpace: 'pre-wrap', margin: 0 }}>
+              {detail.instruction || '—'}
+            </Paragraph>
+          </DetailSection>
+
+          <DetailSection title={t('detail.mcpConfig')}>
+            <McpConfigBlock config={detail.mcp_config || '{}'} />
+          </DetailSection>
+
+          <DetailSection title={t('detail.skills')}>
+            <SkillRefList
+              skills={detail.skills}
+              onView={(index, s) => setViewingSkill({ index, name: s.name })}
+            />
+          </DetailSection>
+        </div>
+      )}
+
+      <SkillMdModal
+        open={viewingSkill !== null}
+        title={viewingSkill?.name ?? ''}
+        load={() => getSystemExpertSkillMd(detail!.expert_id, viewingSkill!.index)}
+        onClose={() => setViewingSkill(null)}
+      />
+    </Drawer>
+  )
+}

--- a/src/pages/ExpertMarket/ExpertDetailDrawer.tsx
+++ b/src/pages/ExpertMarket/ExpertDetailDrawer.tsx
@@ -19,7 +19,7 @@ import {
 } from '../../api/expert'
 import { DetailSection, McpConfigBlock, SkillMdModal, SkillRefList } from './detailParts'
 import ReuploadButton from './ReuploadButton'
-import { buildExpertParams } from './submitContainer'
+import { buildExpertPatch, uploadSkillWrites } from './submitContainer'
 import type { ParsedExpert } from './parseContainer'
 
 const { Text, Paragraph } = Typography
@@ -91,15 +91,14 @@ export default function ExpertDetailDrawer({
     }
   }
 
-  const handleReupload = async (manifest: unknown, uploaded: Map<string, import('../../api/expert').SkillWrite>) => {
+  const handleReupload = async (parsed: import('./parseContainer').ParsedContainer) => {
     if (!detail) return
-    const { category, ...rest } = buildExpertParams(manifest as ParsedExpert, uploaded)
-    // resolveCategory rejects an empty name on PATCH too — when the container
-    // omits category, leave the record's current one untouched.
-    const updated = await patchSystemExpert(
-      detail.expert_id,
-      category ? { category, ...rest } : rest
-    )
+    const m = parsed.manifest as ParsedExpert
+    // One upload per skill reference (server upload keys are single-use), and
+    // a PATCH body that omits fields the container doesn't declare — a
+    // present-but-empty category/tags would CLEAR the curated values.
+    const skills = await uploadSkillWrites(m.skills, parsed.skillFiles)
+    const updated = await patchSystemExpert(detail.expert_id, buildExpertPatch(m, skills))
     setDetail(updated)
     onChanged()
   }

--- a/src/pages/ExpertMarket/ExpertTab.tsx
+++ b/src/pages/ExpertMarket/ExpertTab.tsx
@@ -148,7 +148,16 @@ export default function ExpertTab() {
         <div className="toolbar-spacer" />
         <Button icon={<ReloadOutlined />} onClick={() => load(page, keyword)} loading={loading} />
         {canWrite && (
-          <Button type="primary" icon={<PlusOutlined />} onClick={() => setUploadOpen(true)}>
+          <Button
+            type="primary"
+            icon={<PlusOutlined />}
+            onClick={() => {
+              // Refresh the category options — they may have changed on the
+              // Categories tab since this tab mounted.
+              listExpertCategories().then(setCategories).catch(() => {})
+              setUploadOpen(true)
+            }}
+          >
             {t('createExpert')}
           </Button>
         )}

--- a/src/pages/ExpertMarket/ExpertTab.tsx
+++ b/src/pages/ExpertMarket/ExpertTab.tsx
@@ -1,0 +1,194 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Button, Input, Space as AntSpace, Table, Tag, message } from 'antd'
+import { PlusOutlined, ReloadOutlined, SearchOutlined } from '@ant-design/icons'
+import { useTranslation } from 'react-i18next'
+import type { ColumnsType } from 'antd/es/table'
+import {
+  listExpertCategories,
+  listSystemExperts,
+  type ExpertCategory,
+  type ExpertListItem,
+} from '../../api/expert'
+import { ApiError } from '../../api'
+import { hasManagerCapability } from '../../auth/capabilities'
+import { useAuthStore } from '../../store/auth'
+import ExpertDetailDrawer from './ExpertDetailDrawer'
+import UploadModal from './UploadModal'
+
+const PAGE_SIZE = 20
+
+export default function ExpertTab() {
+  const { t } = useTranslation(['expertMarket', 'common'])
+  const canWrite = useAuthStore((s) => hasManagerCapability(s.managerCapabilities, 'expert.write'))
+
+  const [rows, setRows] = useState<ExpertListItem[]>([])
+  const [total, setTotal] = useState(0)
+  const [page, setPage] = useState(1)
+  const [loading, setLoading] = useState(false)
+  const [keyword, setKeyword] = useState('')
+  const [pendingKeyword, setPendingKeyword] = useState('')
+  const [categories, setCategories] = useState<ExpertCategory[]>([])
+  const [drawerId, setDrawerId] = useState<string | null>(null)
+  const [uploadOpen, setUploadOpen] = useState(false)
+
+  const load = async (nextPage = page, kw = keyword) => {
+    setLoading(true)
+    try {
+      const resp = await listSystemExperts({
+        keyword: kw,
+        limit: PAGE_SIZE,
+        offset: (nextPage - 1) * PAGE_SIZE,
+      })
+      setRows(resp.items)
+      setTotal(resp.total)
+      setPage(nextPage)
+    } catch (err) {
+      message.error(err instanceof ApiError ? err.message : t('loadFailed'))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    load(1, '')
+    listExpertCategories()
+      .then(setCategories)
+      .catch(() => setCategories([]))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const handleSearch = () => {
+    const kw = pendingKeyword.trim()
+    setKeyword(kw)
+    load(1, kw)
+  }
+
+  const handleDeleted = (id: string) => {
+    setRows((prev) => prev.filter((r) => r.expert_id !== id))
+    setTotal((prev) => Math.max(0, prev - 1))
+    if (rows.length === 1 && page > 1) load(page - 1, keyword)
+    setDrawerId(null)
+  }
+
+  const columns = useMemo<ColumnsType<ExpertListItem>>(
+    () => [
+      {
+        title: t('table.name'),
+        dataIndex: 'name',
+        key: 'name',
+        render: (name: string, r) => (
+          <div className="exp-cell-name">
+            <span className="exp-cell-name__tile">{r.short_name || name.slice(0, 2)}</span>
+            <div className="exp-cell-name__text">
+              <span className="cell-primary">{name}</span>
+              {r.summary && <span className="exp-cell-name__sub">{r.summary}</span>}
+            </div>
+          </div>
+        ),
+      },
+      {
+        title: t('table.category'),
+        dataIndex: 'category',
+        key: 'category',
+        width: 140,
+        render: (v: string) => (v ? <Tag className="pill-outline neutral">{v}</Tag> : '—'),
+      },
+      {
+        title: t('table.tags'),
+        dataIndex: 'tags',
+        key: 'tags',
+        width: 200,
+        render: (tags: string[]) =>
+          tags?.length ? (
+            <AntSpace size={4} wrap>
+              {tags.slice(0, 3).map((tag) => (
+                <span key={tag} className="pill-outline brand">
+                  {tag}
+                </span>
+              ))}
+              {tags.length > 3 && <span className="exp-more">+{tags.length - 3}</span>}
+            </AntSpace>
+          ) : (
+            <span className="exp-more">—</span>
+          ),
+      },
+      {
+        title: t('table.skills'),
+        dataIndex: 'skill_count',
+        key: 'skill_count',
+        width: 80,
+        align: 'right',
+        render: (v?: number) => <span className="mono">{v ?? 0}</span>,
+      },
+      {
+        title: t('table.creator'),
+        dataIndex: 'creator_name',
+        key: 'creator_name',
+        width: 140,
+        render: (v: string) => v || '—',
+      },
+    ],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [t]
+  )
+
+  return (
+    <div>
+      <div className="toolbar">
+        <Input
+          allowClear
+          prefix={<SearchOutlined />}
+          placeholder={t('searchPlaceholder')}
+          value={pendingKeyword}
+          onChange={(e) => setPendingKeyword(e.target.value)}
+          onPressEnter={handleSearch}
+          onBlur={handleSearch}
+          style={{ width: 280 }}
+        />
+        <div className="toolbar-spacer" />
+        <Button icon={<ReloadOutlined />} onClick={() => load(page, keyword)} loading={loading} />
+        {canWrite && (
+          <Button type="primary" icon={<PlusOutlined />} onClick={() => setUploadOpen(true)}>
+            {t('createExpert')}
+          </Button>
+        )}
+      </div>
+
+      <Table<ExpertListItem>
+        rowKey="expert_id"
+        loading={loading}
+        columns={columns}
+        dataSource={rows}
+        locale={{ emptyText: t('emptyExpert') }}
+        onRow={(r) => ({
+          onClick: () => setDrawerId(r.expert_id),
+          style: { cursor: 'pointer' },
+        })}
+        pagination={{
+          current: page,
+          pageSize: PAGE_SIZE,
+          total,
+          showSizeChanger: false,
+          onChange: (p) => load(p, keyword),
+        }}
+      />
+
+      <ExpertDetailDrawer
+        expertId={drawerId}
+        open={drawerId !== null}
+        canManage={canWrite}
+        onClose={() => setDrawerId(null)}
+        onChanged={() => load(page, keyword)}
+        onDeleted={handleDeleted}
+      />
+
+      <UploadModal
+        open={uploadOpen}
+        expectKind="agent"
+        categories={categories}
+        onClose={() => setUploadOpen(false)}
+        onImported={() => load(1, keyword)}
+      />
+    </div>
+  )
+}

--- a/src/pages/ExpertMarket/ReuploadButton.tsx
+++ b/src/pages/ExpertMarket/ReuploadButton.tsx
@@ -1,0 +1,68 @@
+/**
+ * "Re-upload container" button used in both detail drawers. Picks a container
+ * zip, validates its kind, presign-uploads the bundled skill packages, and
+ * hands the parsed manifest + uploaded-key map back to the parent, which
+ * PATCHes the record to replace its spec. Upload plumbing lives here so both
+ * drawers share it; the kind-specific PATCH stays with the parent.
+ */
+
+import { useRef, useState } from 'react'
+import { Button, message } from 'antd'
+import { UploadOutlined } from '@ant-design/icons'
+import { useTranslation } from 'react-i18next'
+import { ApiError } from '../../api'
+import type { ExpertKind, SkillWrite } from '../../api/expert'
+import { ContainerError, parseExpertContainer, type ParsedManifest } from './parseContainer'
+import { uploadSkillFiles } from './submitContainer'
+
+interface Props {
+  expectKind: ExpertKind
+  onReady: (manifest: ParsedManifest, uploaded: Map<string, SkillWrite>) => Promise<void>
+}
+
+export default function ReuploadButton({ expectKind, onReady }: Props) {
+  const { t } = useTranslation(['expertMarket'])
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [busy, setBusy] = useState(false)
+
+  const handleFile = async (file: File) => {
+    setBusy(true)
+    try {
+      const parsed = await parseExpertContainer(file)
+      if (parsed.manifest.kind !== expectKind) {
+        message.error(t('container.kindMismatch', { defaultValue: 'Container kind does not match.' }))
+        return
+      }
+      const uploaded = await uploadSkillFiles(parsed.skillFiles)
+      await onReady(parsed.manifest, uploaded)
+      message.success(t('reupload.success'))
+    } catch (err) {
+      if (err instanceof ContainerError) {
+        message.error(t(`container.${err.code}`, { defaultValue: err.message }))
+      } else {
+        message.error(err instanceof ApiError ? err.message : (err as Error).message)
+      }
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <>
+      <input
+        ref={inputRef}
+        type="file"
+        accept=".zip,.skill"
+        style={{ display: 'none' }}
+        onChange={(e) => {
+          const f = e.target.files?.[0]
+          e.target.value = ''
+          if (f) void handleFile(f)
+        }}
+      />
+      <Button icon={<UploadOutlined />} loading={busy} onClick={() => inputRef.current?.click()}>
+        {t('reupload.button')}
+      </Button>
+    </>
+  )
+}

--- a/src/pages/ExpertMarket/ReuploadButton.tsx
+++ b/src/pages/ExpertMarket/ReuploadButton.tsx
@@ -1,9 +1,8 @@
 /**
  * "Re-upload container" button used in both detail drawers. Picks a container
- * zip, validates its kind, presign-uploads the bundled skill packages, and
- * hands the parsed manifest + uploaded-key map back to the parent, which
- * PATCHes the record to replace its spec. Upload plumbing lives here so both
- * drawers share it; the kind-specific PATCH stays with the parent.
+ * zip, validates its kind, and hands the parsed container to the parent —
+ * which presign-uploads the bundled packages (one object per skill reference)
+ * and PATCHes the record to replace its spec.
  */
 
 import { useRef, useState } from 'react'
@@ -11,13 +10,12 @@ import { Button, message } from 'antd'
 import { UploadOutlined } from '@ant-design/icons'
 import { useTranslation } from 'react-i18next'
 import { ApiError } from '../../api'
-import type { ExpertKind, SkillWrite } from '../../api/expert'
-import { ContainerError, parseExpertContainer, type ParsedManifest } from './parseContainer'
-import { uploadSkillFiles } from './submitContainer'
+import type { ExpertKind } from '../../api/expert'
+import { ContainerError, parseExpertContainer, type ParsedContainer } from './parseContainer'
 
 interface Props {
   expectKind: ExpertKind
-  onReady: (manifest: ParsedManifest, uploaded: Map<string, SkillWrite>) => Promise<void>
+  onReady: (parsed: ParsedContainer) => Promise<void>
 }
 
 export default function ReuploadButton({ expectKind, onReady }: Props) {
@@ -33,8 +31,7 @@ export default function ReuploadButton({ expectKind, onReady }: Props) {
         message.error(t('container.kindMismatch', { defaultValue: 'Container kind does not match.' }))
         return
       }
-      const uploaded = await uploadSkillFiles(parsed.skillFiles)
-      await onReady(parsed.manifest, uploaded)
+      await onReady(parsed)
       message.success(t('reupload.success'))
     } catch (err) {
       if (err instanceof ContainerError) {

--- a/src/pages/ExpertMarket/SquadDetailDrawer.tsx
+++ b/src/pages/ExpertMarket/SquadDetailDrawer.tsx
@@ -1,0 +1,252 @@
+/**
+ * Read-only Squad detail drawer. Same shape as ExpertDetailDrawer, plus
+ * squad-only sections: leader, dispatch strategies, dependencies, permission,
+ * and a member roster where each member expands to its own instruction /
+ * mcp_config / skills.
+ */
+
+import { useEffect, useState } from 'react'
+import { Button, Collapse, Drawer, Skeleton, Tag, Typography, message } from 'antd'
+import { DeleteOutlined } from '@ant-design/icons'
+import { useTranslation } from 'react-i18next'
+import { ApiError } from '../../api'
+import {
+  deleteSystemSquad,
+  getSystemSquad,
+  getSystemSquadSkillMd,
+  patchSystemSquad,
+  type SkillWrite,
+  type SquadDetail,
+} from '../../api/expert'
+import { DetailSection, McpConfigBlock, SkillMdModal, SkillRefList } from './detailParts'
+import ReuploadButton from './ReuploadButton'
+import { buildSquadParams } from './submitContainer'
+import type { ParsedSquad } from './parseContainer'
+
+const { Text, Paragraph } = Typography
+
+interface Props {
+  squadId: string | null
+  open: boolean
+  canManage: boolean
+  onClose: () => void
+  onChanged: () => void
+  onDeleted: (id: string) => void
+}
+
+export default function SquadDetailDrawer({
+  squadId,
+  open,
+  canManage,
+  onClose,
+  onChanged,
+  onDeleted,
+}: Props) {
+  const { t } = useTranslation(['expertMarket', 'common'])
+  const [detail, setDetail] = useState<SquadDetail | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [confirmingDelete, setConfirmingDelete] = useState(false)
+  const [deleting, setDeleting] = useState(false)
+  const [viewingSkill, setViewingSkill] = useState<{
+    memberKey: string
+    index: number
+    name: string
+  } | null>(null)
+
+  useEffect(() => {
+    if (!open || !squadId) {
+      setDetail(null)
+      return
+    }
+    setConfirmingDelete(false)
+    setDeleting(false)
+    setViewingSkill(null)
+    let cancelled = false
+    setLoading(true)
+    getSystemSquad(squadId)
+      .then((d) => !cancelled && setDetail(d))
+      .catch((err) => {
+        if (!cancelled) {
+          message.error(err instanceof ApiError ? err.message : t('detail.loadFailed'))
+          onClose()
+        }
+      })
+      .finally(() => !cancelled && setLoading(false))
+    return () => {
+      cancelled = true
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, squadId])
+
+  const confirmDelete = async () => {
+    if (!detail || deleting) return
+    setDeleting(true)
+    try {
+      await deleteSystemSquad(detail.squad_id)
+      message.success(t('delete.success'))
+      onDeleted(detail.squad_id)
+    } catch (err) {
+      message.error(err instanceof ApiError ? err.message : t('delete.failed'))
+    } finally {
+      setDeleting(false)
+    }
+  }
+
+  const handleReupload = async (manifest: unknown, uploaded: Map<string, SkillWrite>) => {
+    if (!detail) return
+    const { category, ...rest } = buildSquadParams(manifest as ParsedSquad, uploaded)
+    // resolveCategory rejects an empty name on PATCH too — when the container
+    // omits category, leave the record's current one untouched.
+    const updated = await patchSystemSquad(
+      detail.squad_id,
+      category ? { category, ...rest } : rest
+    )
+    setDetail(updated)
+    onChanged()
+  }
+
+  const footer = !detail || !canManage ? null : confirmingDelete ? (
+    <div className="exp-drawer-footer exp-drawer-footer--confirm">
+      <Text type="secondary" style={{ fontSize: 12 }}>
+        {t('delete.confirmDesc')}
+      </Text>
+      <Button onClick={() => setConfirmingDelete(false)} disabled={deleting}>
+        {t('delete.cancel')}
+      </Button>
+      <Button danger type="primary" loading={deleting} onClick={confirmDelete}>
+        {t('delete.ok')}
+      </Button>
+    </div>
+  ) : (
+    <div className="exp-drawer-footer">
+      <Button danger icon={<DeleteOutlined />} onClick={() => setConfirmingDelete(true)}>
+        {t('actions.delete')}
+      </Button>
+      <ReuploadButton expectKind="squad" onReady={handleReupload} />
+    </div>
+  )
+
+  return (
+    <Drawer
+      title={detail ? detail.name : t('detail.titleSquad')}
+      open={open}
+      onClose={onClose}
+      width={720}
+      destroyOnClose
+      className="admin-shell admin-drawer"
+      footer={footer}
+    >
+      {loading || !detail ? (
+        <Skeleton active paragraph={{ rows: 6 }} />
+      ) : (
+        <div className="exp-detail">
+          <div className="exp-detail__meta">
+            <span className="exp-detail__tile">{detail.short_name || detail.name.slice(0, 2)}</span>
+            <div className="exp-detail__meta-body">
+              <div className="exp-detail__summary">{detail.summary}</div>
+              <div className="exp-detail__sub">
+                {detail.category && <span className="pill-outline neutral">{detail.category}</span>}
+                <span>{t('table.memberCount', { count: detail.members?.length ?? 0 })}</span>
+                {detail.creator_name && <span>@{detail.creator_name}</span>}
+              </div>
+              {detail.tags?.length > 0 && (
+                <div className="exp-detail__tags">
+                  {detail.tags.map((tag) => (
+                    <Tag key={tag} className="pill-outline brand" style={{ margin: 0 }}>
+                      {tag}
+                    </Tag>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+
+          <DetailSection title={t('detail.leader')}>
+            <Text>{detail.leader || '—'}</Text>
+          </DetailSection>
+
+          {detail.strategies?.length > 0 && (
+            <DetailSection title={t('detail.strategies')}>
+              <ol className="exp-strategies">
+                {detail.strategies.map((s, i) => (
+                  <li key={i}>{s}</li>
+                ))}
+              </ol>
+            </DetailSection>
+          )}
+
+          {(detail.dependencies?.blocking?.length > 0 ||
+            detail.dependencies?.recommended?.length > 0) && (
+            <DetailSection title={t('detail.dependencies')}>
+              <dl className="exp-kv">
+                {detail.dependencies.blocking?.length > 0 && (
+                  <>
+                    <dt>{t('detail.blocking')}</dt>
+                    <dd>{detail.dependencies.blocking.join('、')}</dd>
+                  </>
+                )}
+                {detail.dependencies.recommended?.length > 0 && (
+                  <>
+                    <dt>{t('detail.recommended')}</dt>
+                    <dd>{detail.dependencies.recommended.join('、')}</dd>
+                  </>
+                )}
+              </dl>
+            </DetailSection>
+          )}
+
+          {detail.permission && (
+            <DetailSection title={t('detail.permission')}>
+              <Text>{detail.permission}</Text>
+            </DetailSection>
+          )}
+
+          <DetailSection title={t('detail.members')}>
+            <Collapse
+              items={(detail.members ?? []).map((m) => ({
+                key: m.member_key,
+                label: (
+                  <span>
+                    {m.name}
+                    {m.role ? <span className="exp-member__role"> · {m.role}</span> : ''}
+                    {m.is_leader && (
+                      <Tag className="pill-outline brand" style={{ marginLeft: 8 }}>
+                        {t('detail.leaderBadge')}
+                      </Tag>
+                    )}
+                  </span>
+                ),
+                children: (
+                  <div className="exp-member__body">
+                    <h5 className="exp-member__head">{t('detail.instruction')}</h5>
+                    <Paragraph style={{ whiteSpace: 'pre-wrap', margin: 0 }}>
+                      {m.instruction || '—'}
+                    </Paragraph>
+                    <h5 className="exp-member__head">{t('detail.mcpConfig')}</h5>
+                    <McpConfigBlock config={m.mcp_config || '{}'} />
+                    <h5 className="exp-member__head">{t('detail.skills')}</h5>
+                    <SkillRefList
+                      skills={m.skills}
+                      onView={(index, s) =>
+                        setViewingSkill({ memberKey: m.member_key, index, name: s.name })
+                      }
+                    />
+                  </div>
+                ),
+              }))}
+            />
+          </DetailSection>
+        </div>
+      )}
+
+      <SkillMdModal
+        open={viewingSkill !== null}
+        title={viewingSkill?.name ?? ''}
+        load={() =>
+          getSystemSquadSkillMd(detail!.squad_id, viewingSkill!.memberKey, viewingSkill!.index)
+        }
+        onClose={() => setViewingSkill(null)}
+      />
+    </Drawer>
+  )
+}

--- a/src/pages/ExpertMarket/SquadDetailDrawer.tsx
+++ b/src/pages/ExpertMarket/SquadDetailDrawer.tsx
@@ -15,12 +15,11 @@ import {
   getSystemSquad,
   getSystemSquadSkillMd,
   patchSystemSquad,
-  type SkillWrite,
   type SquadDetail,
 } from '../../api/expert'
 import { DetailSection, McpConfigBlock, SkillMdModal, SkillRefList } from './detailParts'
 import ReuploadButton from './ReuploadButton'
-import { buildSquadParams } from './submitContainer'
+import { buildSquadPatch, uploadSquadSkillWrites } from './submitContainer'
 import type { ParsedSquad } from './parseContainer'
 
 const { Text, Paragraph } = Typography
@@ -92,15 +91,15 @@ export default function SquadDetailDrawer({
     }
   }
 
-  const handleReupload = async (manifest: unknown, uploaded: Map<string, SkillWrite>) => {
+  const handleReupload = async (parsed: import('./parseContainer').ParsedContainer) => {
     if (!detail) return
-    const { category, ...rest } = buildSquadParams(manifest as ParsedSquad, uploaded)
-    // resolveCategory rejects an empty name on PATCH too — when the container
-    // omits category, leave the record's current one untouched.
-    const updated = await patchSystemSquad(
-      detail.squad_id,
-      category ? { category, ...rest } : rest
-    )
+    const m = parsed.manifest as ParsedSquad
+    // One upload per skill reference (server upload keys are single-use), and
+    // a PATCH body that omits fields the container doesn't declare — a
+    // present-but-empty tags/strategies/dependencies/permission would CLEAR
+    // the stored values.
+    const memberSkills = await uploadSquadSkillWrites(m, parsed.skillFiles)
+    const updated = await patchSystemSquad(detail.squad_id, buildSquadPatch(m, memberSkills))
     setDetail(updated)
     onChanged()
   }

--- a/src/pages/ExpertMarket/SquadTab.tsx
+++ b/src/pages/ExpertMarket/SquadTab.tsx
@@ -148,7 +148,16 @@ export default function SquadTab() {
         <div className="toolbar-spacer" />
         <Button icon={<ReloadOutlined />} onClick={() => load(page, keyword)} loading={loading} />
         {canWrite && (
-          <Button type="primary" icon={<PlusOutlined />} onClick={() => setUploadOpen(true)}>
+          <Button
+            type="primary"
+            icon={<PlusOutlined />}
+            onClick={() => {
+              // Refresh the category options — they may have changed on the
+              // Categories tab since this tab mounted.
+              listExpertCategories().then(setCategories).catch(() => {})
+              setUploadOpen(true)
+            }}
+          >
             {t('createSquad')}
           </Button>
         )}

--- a/src/pages/ExpertMarket/SquadTab.tsx
+++ b/src/pages/ExpertMarket/SquadTab.tsx
@@ -1,0 +1,194 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Button, Input, Space as AntSpace, Table, Tag, message } from 'antd'
+import { PlusOutlined, ReloadOutlined, SearchOutlined } from '@ant-design/icons'
+import { useTranslation } from 'react-i18next'
+import type { ColumnsType } from 'antd/es/table'
+import {
+  listExpertCategories,
+  listSystemSquads,
+  type ExpertCategory,
+  type SquadListItem,
+} from '../../api/expert'
+import { ApiError } from '../../api'
+import { hasManagerCapability } from '../../auth/capabilities'
+import { useAuthStore } from '../../store/auth'
+import SquadDetailDrawer from './SquadDetailDrawer'
+import UploadModal from './UploadModal'
+
+const PAGE_SIZE = 20
+
+export default function SquadTab() {
+  const { t } = useTranslation(['expertMarket', 'common'])
+  const canWrite = useAuthStore((s) => hasManagerCapability(s.managerCapabilities, 'expert.write'))
+
+  const [rows, setRows] = useState<SquadListItem[]>([])
+  const [total, setTotal] = useState(0)
+  const [page, setPage] = useState(1)
+  const [loading, setLoading] = useState(false)
+  const [keyword, setKeyword] = useState('')
+  const [pendingKeyword, setPendingKeyword] = useState('')
+  const [categories, setCategories] = useState<ExpertCategory[]>([])
+  const [drawerId, setDrawerId] = useState<string | null>(null)
+  const [uploadOpen, setUploadOpen] = useState(false)
+
+  const load = async (nextPage = page, kw = keyword) => {
+    setLoading(true)
+    try {
+      const resp = await listSystemSquads({
+        keyword: kw,
+        limit: PAGE_SIZE,
+        offset: (nextPage - 1) * PAGE_SIZE,
+      })
+      setRows(resp.items)
+      setTotal(resp.total)
+      setPage(nextPage)
+    } catch (err) {
+      message.error(err instanceof ApiError ? err.message : t('loadFailed'))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    load(1, '')
+    listExpertCategories()
+      .then(setCategories)
+      .catch(() => setCategories([]))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const handleSearch = () => {
+    const kw = pendingKeyword.trim()
+    setKeyword(kw)
+    load(1, kw)
+  }
+
+  const handleDeleted = (id: string) => {
+    setRows((prev) => prev.filter((r) => r.squad_id !== id))
+    setTotal((prev) => Math.max(0, prev - 1))
+    if (rows.length === 1 && page > 1) load(page - 1, keyword)
+    setDrawerId(null)
+  }
+
+  const columns = useMemo<ColumnsType<SquadListItem>>(
+    () => [
+      {
+        title: t('table.name'),
+        dataIndex: 'name',
+        key: 'name',
+        render: (name: string, r) => (
+          <div className="exp-cell-name">
+            <span className="exp-cell-name__tile">{r.short_name || name.slice(0, 2)}</span>
+            <div className="exp-cell-name__text">
+              <span className="cell-primary">{name}</span>
+              {r.summary && <span className="exp-cell-name__sub">{r.summary}</span>}
+            </div>
+          </div>
+        ),
+      },
+      {
+        title: t('table.category'),
+        dataIndex: 'category',
+        key: 'category',
+        width: 140,
+        render: (v: string) => (v ? <Tag className="pill-outline neutral">{v}</Tag> : '—'),
+      },
+      {
+        title: t('table.tags'),
+        dataIndex: 'tags',
+        key: 'tags',
+        width: 200,
+        render: (tags: string[]) =>
+          tags?.length ? (
+            <AntSpace size={4} wrap>
+              {tags.slice(0, 3).map((tag) => (
+                <span key={tag} className="pill-outline brand">
+                  {tag}
+                </span>
+              ))}
+              {tags.length > 3 && <span className="exp-more">+{tags.length - 3}</span>}
+            </AntSpace>
+          ) : (
+            <span className="exp-more">—</span>
+          ),
+      },
+      {
+        title: t('table.members'),
+        dataIndex: 'member_count',
+        key: 'member_count',
+        width: 80,
+        align: 'right',
+        render: (v?: number) => <span className="mono">{v ?? 0}</span>,
+      },
+      {
+        title: t('table.creator'),
+        dataIndex: 'creator_name',
+        key: 'creator_name',
+        width: 140,
+        render: (v: string) => v || '—',
+      },
+    ],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [t]
+  )
+
+  return (
+    <div>
+      <div className="toolbar">
+        <Input
+          allowClear
+          prefix={<SearchOutlined />}
+          placeholder={t('searchPlaceholder')}
+          value={pendingKeyword}
+          onChange={(e) => setPendingKeyword(e.target.value)}
+          onPressEnter={handleSearch}
+          onBlur={handleSearch}
+          style={{ width: 280 }}
+        />
+        <div className="toolbar-spacer" />
+        <Button icon={<ReloadOutlined />} onClick={() => load(page, keyword)} loading={loading} />
+        {canWrite && (
+          <Button type="primary" icon={<PlusOutlined />} onClick={() => setUploadOpen(true)}>
+            {t('createSquad')}
+          </Button>
+        )}
+      </div>
+
+      <Table<SquadListItem>
+        rowKey="squad_id"
+        loading={loading}
+        columns={columns}
+        dataSource={rows}
+        locale={{ emptyText: t('emptySquad') }}
+        onRow={(r) => ({
+          onClick: () => setDrawerId(r.squad_id),
+          style: { cursor: 'pointer' },
+        })}
+        pagination={{
+          current: page,
+          pageSize: PAGE_SIZE,
+          total,
+          showSizeChanger: false,
+          onChange: (p) => load(p, keyword),
+        }}
+      />
+
+      <SquadDetailDrawer
+        squadId={drawerId}
+        open={drawerId !== null}
+        canManage={canWrite}
+        onClose={() => setDrawerId(null)}
+        onChanged={() => load(page, keyword)}
+        onDeleted={handleDeleted}
+      />
+
+      <UploadModal
+        open={uploadOpen}
+        expectKind="squad"
+        categories={categories}
+        onClose={() => setUploadOpen(false)}
+        onImported={() => load(1, keyword)}
+      />
+    </div>
+  )
+}

--- a/src/pages/ExpertMarket/UploadModal.tsx
+++ b/src/pages/ExpertMarket/UploadModal.tsx
@@ -11,7 +11,7 @@
  * continues with the next. Container zips are never uploaded.
  */
 
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { Alert, Button, message, Modal, Select, Table, Tag, Typography, Upload } from 'antd'
 import { CopyOutlined, DeleteOutlined, InboxOutlined } from '@ant-design/icons'
 import { useTranslation } from 'react-i18next'
@@ -21,6 +21,7 @@ import { ApiError } from '../../api'
 import {
   createSystemExpert,
   createSystemSquad,
+  uploadExpertSkill,
   type ExpertCategory,
   type ExpertKind,
 } from '../../api/expert'
@@ -34,7 +35,9 @@ import {
 import {
   buildExpertParams,
   buildSquadParams,
-  uploadSkillFiles,
+  uploadSkillWrites,
+  uploadSquadSkillWrites,
+  type SkillUploader,
 } from './submitContainer'
 import { buildAiPrompt } from './aiPrompt'
 
@@ -98,6 +101,7 @@ export default function UploadModal({
   const [entries, setEntries] = useState<ImportEntry[]>([])
   const [submitting, setSubmitting] = useState(false)
   const [progress, setProgress] = useState<string | null>(null)
+  const abortRef = useRef<AbortController | null>(null)
   const errText = useContainerErrorText()
 
   const updateEntry = (key: string, patch: Partial<ImportEntry>) => {
@@ -110,7 +114,12 @@ export default function UploadModal({
   }
 
   const handleClose = () => {
-    if (submitting) return
+    // While a batch is in flight, Cancel/X aborts the current upload instead
+    // of closing (a hung PUT would otherwise wedge the modal until timeout).
+    if (submitting) {
+      abortRef.current?.abort()
+      return
+    }
     reset()
     onClose()
   }
@@ -162,10 +171,15 @@ export default function UploadModal({
       return
     }
     setSubmitting(true)
+    const ctl = new AbortController()
+    abortRef.current = ctl
+    const upload: SkillUploader = (name, blob, fileName) =>
+      uploadExpertSkill(name, blob, fileName, { signal: ctl.signal })
     let ok = 0
     let fail = 0
     for (let i = 0; i < pending.length; i++) {
       const entry = pending[i]
+      if (ctl.signal.aborted) break
       // The backend rejects an empty category on every write path
       // (resolveCategory('') → 400), so fail the row up front instead of
       // uploading its skill packages first.
@@ -185,22 +199,34 @@ export default function UploadModal({
       // Row edits are authoritative.
       const override = { category: entry.category, tags: entry.tags }
       try {
-        const uploaded = await uploadSkillFiles(entry.parsed.skillFiles)
-        if (entry.parsed.manifest.kind === 'squad') {
-          await createSystemSquad(buildSquadParams(entry.parsed.manifest, uploaded, override))
+        const m = entry.parsed.manifest
+        if (m.kind === 'squad') {
+          const memberSkills = await uploadSquadSkillWrites(m, entry.parsed.skillFiles, upload)
+          await createSystemSquad(buildSquadParams(m, memberSkills, override))
         } else {
-          await createSystemExpert(buildExpertParams(entry.parsed.manifest, uploaded, override))
+          const skills = await uploadSkillWrites(m.skills, entry.parsed.skillFiles, upload)
+          await createSystemExpert(buildExpertParams(m, skills, override))
         }
         updateEntry(entry.key, { status: 'done' })
         ok += 1
       } catch (err) {
+        if (ctl.signal.aborted) {
+          // Nothing was committed for this entry — put it back in line.
+          updateEntry(entry.key, { status: 'ready', error: null })
+          break
+        }
         updateEntry(entry.key, { status: 'failed', error: errText(err) })
         fail += 1
       }
     }
+    abortRef.current = null
     setSubmitting(false)
     setProgress(null)
     if (ok > 0) onImported()
+    if (ctl.signal.aborted) {
+      message.info(t('upload.cancelled'))
+      return
+    }
     if (fail === 0) {
       message.success(t('upload.successCount', { count: ok }))
       reset()
@@ -323,7 +349,7 @@ export default function UploadModal({
           : t('upload.submit')
       }
       okButtonProps={{ disabled: importableCount === 0 || parsingCount > 0 }}
-      cancelButtonProps={{ disabled: submitting }}
+      cancelButtonProps={{ danger: submitting }}
       width={800}
       destroyOnClose
     >

--- a/src/pages/ExpertMarket/UploadModal.tsx
+++ b/src/pages/ExpertMarket/UploadModal.tsx
@@ -1,0 +1,476 @@
+/**
+ * Batch upload-to-create modal shared by the Expert and Squad tabs.
+ *
+ * Accepts one or many container zips in a single session. `expectKind` binds
+ * the modal to its tab: a file whose manifest kind doesn't match is marked
+ * invalid (never blocks the rest). Every file is parsed client-side
+ * (parseExpertContainer) into a review table where each row carries its own
+ * editable category/tags (initialized from the manifest). Confirming imports
+ * the valid entries sequentially (presign-upload bundled skill packages, then
+ * POST the manifest); a per-entry failure marks that row retryable and
+ * continues with the next. Container zips are never uploaded.
+ */
+
+import { useState } from 'react'
+import { Alert, Button, message, Modal, Select, Table, Tag, Typography, Upload } from 'antd'
+import { CopyOutlined, DeleteOutlined, InboxOutlined } from '@ant-design/icons'
+import { useTranslation } from 'react-i18next'
+import type { ColumnsType } from 'antd/es/table'
+import type { RcFile } from 'antd/es/upload'
+import { ApiError } from '../../api'
+import {
+  createSystemExpert,
+  createSystemSquad,
+  type ExpertCategory,
+  type ExpertKind,
+} from '../../api/expert'
+import {
+  ContainerError,
+  parseExpertContainer,
+  type ParsedContainer,
+  type ParsedExpert,
+  type ParsedSquad,
+} from './parseContainer'
+import {
+  buildExpertParams,
+  buildSquadParams,
+  uploadSkillFiles,
+} from './submitContainer'
+import { buildAiPrompt } from './aiPrompt'
+
+const { Dragger } = Upload
+const { Text, Paragraph } = Typography
+
+type EntryStatus = 'parsing' | 'ready' | 'invalid' | 'saving' | 'done' | 'failed'
+
+interface ImportEntry {
+  key: string
+  fileName: string
+  parsed: ParsedContainer | null
+  status: EntryStatus
+  /** Parse or import failure reason, shown under the status tag. */
+  error: string | null
+  /** Per-row overrides, initialized from the manifest. */
+  category?: string
+  tags: string[]
+}
+
+interface Props {
+  open: boolean
+  expectKind: ExpertKind
+  categories: ExpertCategory[]
+  onClose: () => void
+  /** Fired once ≥1 entry was created, so the tab list refreshes even on a
+   *  partial failure (the modal stays open for retrying the rest). */
+  onImported: () => void
+}
+
+/** Resolve a ContainerError to a localized string, falling back to its raw
+ *  message when a key isn't translated yet. */
+function useContainerErrorText() {
+  const { t } = useTranslation(['expertMarket'])
+  return (err: unknown): string => {
+    if (err instanceof ContainerError) {
+      return t(`container.${err.code}`, { defaultValue: err.message })
+    }
+    if (err instanceof ApiError) return err.message
+    return (err as Error)?.message ?? String(err)
+  }
+}
+
+const STATUS_TAG: Record<EntryStatus, { color: string; key: string }> = {
+  parsing: { color: 'processing', key: 'list.statusParsing' },
+  ready: { color: 'blue', key: 'list.statusReady' },
+  invalid: { color: 'red', key: 'list.statusInvalid' },
+  saving: { color: 'processing', key: 'list.statusSaving' },
+  done: { color: 'green', key: 'list.statusDone' },
+  failed: { color: 'red', key: 'list.statusFailed' },
+}
+
+export default function UploadModal({
+  open,
+  expectKind,
+  categories,
+  onClose,
+  onImported,
+}: Props) {
+  const { t, i18n } = useTranslation(['expertMarket', 'common'])
+  const [entries, setEntries] = useState<ImportEntry[]>([])
+  const [submitting, setSubmitting] = useState(false)
+  const [progress, setProgress] = useState<string | null>(null)
+  const errText = useContainerErrorText()
+
+  const updateEntry = (key: string, patch: Partial<ImportEntry>) => {
+    setEntries((prev) => prev.map((e) => (e.key === key ? { ...e, ...patch } : e)))
+  }
+
+  const reset = () => {
+    setEntries([])
+    setProgress(null)
+  }
+
+  const handleClose = () => {
+    if (submitting) return
+    reset()
+    onClose()
+  }
+
+  const copyAiPrompt = async () => {
+    try {
+      await navigator.clipboard.writeText(buildAiPrompt(expectKind, i18n.language))
+      message.success(t('aiHelp.copied'))
+    } catch {
+      message.error(t('aiHelp.copyFailed'))
+    }
+  }
+
+  const addFile = async (file: RcFile) => {
+    const key = file.uid
+    setEntries((prev) => [
+      ...prev,
+      { key, fileName: file.name, parsed: null, status: 'parsing', error: null, tags: [] },
+    ])
+    try {
+      const parsed = await parseExpertContainer(file)
+      if (parsed.manifest.kind !== expectKind) {
+        updateEntry(key, {
+          status: 'invalid',
+          error: t('container.kindMismatch', {
+            defaultValue: 'Container kind does not match this tab.',
+          }),
+        })
+        return
+      }
+      updateEntry(key, {
+        parsed,
+        status: 'ready',
+        category: parsed.manifest.category || undefined,
+        tags: parsed.manifest.tags,
+      })
+    } catch (err) {
+      updateEntry(key, { status: 'invalid', error: errText(err) })
+    }
+  }
+
+  const handleSubmit = async () => {
+    const pending = entries.filter(
+      (e): e is ImportEntry & { parsed: ParsedContainer } =>
+        (e.status === 'ready' || e.status === 'failed') && e.parsed !== null
+    )
+    if (pending.length === 0) {
+      message.error(t('upload.zipRequired'))
+      return
+    }
+    setSubmitting(true)
+    let ok = 0
+    let fail = 0
+    for (let i = 0; i < pending.length; i++) {
+      const entry = pending[i]
+      // The backend rejects an empty category on every write path
+      // (resolveCategory('') → 400), so fail the row up front instead of
+      // uploading its skill packages first.
+      if (!entry.category) {
+        updateEntry(entry.key, { status: 'failed', error: t('upload.categoryRequired') })
+        fail += 1
+        continue
+      }
+      updateEntry(entry.key, { status: 'saving', error: null })
+      setProgress(
+        t('upload.importing', {
+          done: i + 1,
+          total: pending.length,
+          name: entry.parsed.manifest.name,
+        })
+      )
+      // Row edits are authoritative.
+      const override = { category: entry.category, tags: entry.tags }
+      try {
+        const uploaded = await uploadSkillFiles(entry.parsed.skillFiles)
+        if (entry.parsed.manifest.kind === 'squad') {
+          await createSystemSquad(buildSquadParams(entry.parsed.manifest, uploaded, override))
+        } else {
+          await createSystemExpert(buildExpertParams(entry.parsed.manifest, uploaded, override))
+        }
+        updateEntry(entry.key, { status: 'done' })
+        ok += 1
+      } catch (err) {
+        updateEntry(entry.key, { status: 'failed', error: errText(err) })
+        fail += 1
+      }
+    }
+    setSubmitting(false)
+    setProgress(null)
+    if (ok > 0) onImported()
+    if (fail === 0) {
+      message.success(t('upload.successCount', { count: ok }))
+      reset()
+      onClose()
+    } else {
+      message.warning(t('upload.partial', { ok, fail }))
+    }
+  }
+
+  const importableCount = entries.filter(
+    (e) => e.status === 'ready' || e.status === 'failed'
+  ).length
+  // Submitting while a file is still unzipping would silently drop it on the
+  // all-success close path — hold the button until every parse settles.
+  const parsingCount = entries.filter((e) => e.status === 'parsing').length
+
+  const columns: ColumnsType<ImportEntry> = [
+    {
+      title: t('list.name'),
+      key: 'name',
+      render: (_, e) => (
+        <div>
+          <div>{e.parsed?.manifest.name ?? e.fileName}</div>
+          {e.parsed && (
+            <Text type="secondary" style={{ fontSize: 12 }}>
+              {e.fileName}
+            </Text>
+          )}
+        </div>
+      ),
+    },
+    {
+      title: t('list.packages'),
+      key: 'packages',
+      width: 70,
+      align: 'right',
+      render: (_, e) => <span className="mono">{e.parsed?.skillFiles.size ?? '—'}</span>,
+    },
+    {
+      title: t('list.category'),
+      key: 'category',
+      width: 150,
+      render: (_, e) =>
+        e.parsed && (
+          <Select
+            allowClear
+            size="small"
+            style={{ width: '100%' }}
+            placeholder={t('list.categoryPlaceholder')}
+            value={e.category}
+            disabled={submitting || e.status === 'done'}
+            onChange={(v) => updateEntry(e.key, { category: v })}
+            options={categories.map((c) => ({ value: c.name, label: c.name }))}
+          />
+        ),
+    },
+    {
+      title: t('list.tags'),
+      key: 'tags',
+      width: 190,
+      render: (_, e) =>
+        e.parsed && (
+          <Select
+            mode="tags"
+            size="small"
+            style={{ width: '100%' }}
+            placeholder={t('list.tagsPlaceholder')}
+            value={e.tags}
+            disabled={submitting || e.status === 'done'}
+            onChange={(v) => updateEntry(e.key, { tags: v })}
+          />
+        ),
+    },
+    {
+      title: t('list.status'),
+      key: 'status',
+      width: 110,
+      render: (_, e) => (
+        <div>
+          <Tag color={STATUS_TAG[e.status].color} style={{ margin: 0 }}>
+            {t(STATUS_TAG[e.status].key)}
+          </Tag>
+          {e.error && (
+            <div>
+              <Text type="danger" style={{ fontSize: 12 }}>
+                {e.error}
+              </Text>
+            </div>
+          )}
+        </div>
+      ),
+    },
+    {
+      key: 'actions',
+      width: 48,
+      render: (_, e) =>
+        e.status !== 'done' && (
+          <Button
+            type="text"
+            size="small"
+            danger
+            icon={<DeleteOutlined />}
+            disabled={submitting}
+            onClick={() => setEntries((prev) => prev.filter((x) => x.key !== e.key))}
+          />
+        ),
+    },
+  ]
+
+  return (
+    <Modal
+      open={open}
+      title={t(expectKind === 'squad' ? 'upload.titleSquad' : 'upload.titleExpert')}
+      onCancel={handleClose}
+      onOk={handleSubmit}
+      confirmLoading={submitting}
+      okText={
+        importableCount > 0
+          ? t('upload.submitCount', { count: importableCount })
+          : t('upload.submit')
+      }
+      okButtonProps={{ disabled: importableCount === 0 || parsingCount > 0 }}
+      cancelButtonProps={{ disabled: submitting }}
+      width={800}
+      destroyOnClose
+    >
+      {entries.length === 0 && (
+        <Alert
+          type="info"
+          showIcon
+          message={t('aiHelp.title')}
+          description={t(expectKind === 'squad' ? 'aiHelp.descSquad' : 'aiHelp.descExpert')}
+          action={
+            <Button size="small" icon={<CopyOutlined />} onClick={() => void copyAiPrompt()}>
+              {t('aiHelp.copy')}
+            </Button>
+          }
+          style={{ marginBottom: 16 }}
+        />
+      )}
+
+      <Dragger
+        accept=".zip,.skill"
+        multiple
+        showUploadList={false}
+        disabled={submitting}
+        beforeUpload={(file) => {
+          void addFile(file)
+          return false
+        }}
+      >
+        <p className="ant-upload-drag-icon">
+          <InboxOutlined />
+        </p>
+        <p className="ant-upload-hint">
+          {t(expectKind === 'squad' ? 'upload.zipHintSquad' : 'upload.zipHintExpert')}
+        </p>
+      </Dragger>
+
+      {entries.length > 0 && (
+        <Table<ImportEntry>
+          rowKey="key"
+          size="small"
+          columns={columns}
+          dataSource={entries}
+          pagination={false}
+          style={{ marginTop: 16 }}
+          expandable={{
+            expandedRowRender: (e) =>
+              e.parsed ? <ContainerPreview parsed={e.parsed} /> : null,
+            rowExpandable: (e) => e.parsed !== null,
+          }}
+        />
+      )}
+
+      {progress && (
+        <Text type="secondary" style={{ fontSize: 12 }}>
+          {progress}
+        </Text>
+      )}
+    </Modal>
+  )
+}
+
+function ContainerPreview({ parsed }: { parsed: ParsedContainer }) {
+  const m = parsed.manifest
+  return (
+    <div className="exp-preview">
+      <div className="exp-preview__head">
+        <span className="exp-preview__tile">{m.short_name || m.name.slice(0, 2)}</span>
+        <div className="exp-preview__meta">
+          <div className="exp-preview__name">{m.name}</div>
+          <div className="exp-preview__summary">{m.summary}</div>
+        </div>
+      </div>
+      {m.kind === 'agent' ? (
+        <ExpertPreviewBody m={m} />
+      ) : (
+        <SquadPreviewBody m={m} />
+      )}
+    </div>
+  )
+}
+
+function SkillNames({ skills }: { skills: { name: string; file?: string }[] }) {
+  const { t } = useTranslation(['expertMarket'])
+  if (!skills.length) return <Text type="secondary">{t('detail.noSkills')}</Text>
+  return (
+    <div className="exp-preview__tags">
+      {skills.map((s, i) => (
+        <Tag key={`${s.name}-${i}`} className="pill-outline neutral" style={{ margin: 0 }}>
+          {s.name}
+          {s.file ? ' 📦' : ''}
+        </Tag>
+      ))}
+    </div>
+  )
+}
+
+function ExpertPreviewBody({ m }: { m: ParsedExpert }) {
+  const { t } = useTranslation(['expertMarket'])
+  return (
+    <dl className="exp-kv">
+      <dt>{t('detail.instruction')}</dt>
+      <dd>
+        <Paragraph ellipsis={{ rows: 3 }} style={{ margin: 0 }}>
+          {m.instruction}
+        </Paragraph>
+      </dd>
+      <dt>{t('detail.skills')}</dt>
+      <dd>
+        <SkillNames skills={m.skills} />
+      </dd>
+    </dl>
+  )
+}
+
+function SquadPreviewBody({ m }: { m: ParsedSquad }) {
+  const { t } = useTranslation(['expertMarket'])
+  return (
+    <dl className="exp-kv">
+      <dt>{t('detail.leader')}</dt>
+      <dd>{m.leader}</dd>
+      <dt>{t('detail.members')}</dt>
+      <dd>
+        <div className="exp-preview__tags">
+          {m.members.map((mem) => (
+            <Tag
+              key={mem.member_key}
+              className={mem.is_leader ? 'pill-outline brand' : 'pill-outline neutral'}
+              style={{ margin: 0 }}
+            >
+              {mem.name}
+              {mem.role ? ` · ${mem.role}` : ''}
+            </Tag>
+          ))}
+        </div>
+      </dd>
+      {m.strategies.length > 0 && (
+        <>
+          <dt>{t('detail.strategies')}</dt>
+          <dd>
+            <ol className="exp-strategies">
+              {m.strategies.map((s, i) => (
+                <li key={i}>{s}</li>
+              ))}
+            </ol>
+          </dd>
+        </>
+      )}
+    </dl>
+  )
+}

--- a/src/pages/ExpertMarket/aiPrompt.ts
+++ b/src/pages/ExpertMarket/aiPrompt.ts
@@ -1,0 +1,228 @@
+/**
+ * Copy-to-clipboard prompt templates for the upload modal: a user pastes one
+ * into any LLM chat (plus their own requirement) and gets back a container
+ * zip that parseContainer accepts. Keep the format rules here in sync with
+ * parseContainer.ts limits — the prompt is the user-facing spec of that
+ * parser.
+ */
+
+import type { ExpertKind } from '../../api/expert'
+
+const EXPERT_PROMPT_ZH = `请为我生成一个可直接导入「专家市场」的专家包 zip 文件。
+
+# 我的需求
+<在这里描述你想要的专家，例如：一个精通 Python 性能优化的专家，擅长 profiling 与异步改造>
+
+# 专家包格式（严格遵守）
+zip 根目录必须直接包含 expert.json（不要在外面多套一层文件夹）；技能包（可选）放在 skills/ 目录：
+
+my-expert.zip
+├── expert.json
+└── skills/
+    └── my-skill.zip
+
+# expert.json 字段说明
+{
+  "name": "专家名称",                        // 必填，≤128 字符
+  "summary": "一句话简介",                   // 必填，≤512 字符
+  "category": "",                           // 可留空，但导入时必须在界面选择一个已存在的分类
+  "tags": ["标签1", "标签2"],                // 可选，≤20 个
+  "instruction": "专家的系统提示词……",        // 必填，核心字段
+  "mcp_config": "{\\"mcpServers\\":{}}",      // 可选，必须是 JSON 字符串（注意转义），≤64KB
+  "skills": [                               // 可选，≤20 个
+    { "name": "技能名", "file": "skills/my-skill.zip" },
+    { "name": "仅名称、不带文件的技能" }
+  ]
+}
+
+# 技能包格式（skills/ 目录下的每个 zip）
+每个技能包是独立的 Agent-Skill 压缩包：根目录必须有 SKILL.md，文件开头是 YAML frontmatter（含 name 和 description 两个字段），正文写这个技能的使用方法；可附带脚本或参考文件。单个技能包 ≤20MB。
+
+SKILL.md 示例：
+---
+name: my-skill
+description: 一句话说明这个技能做什么、什么时候用
+---
+
+# 使用说明
+……
+
+# instruction 写作要求
+- 明确角色定位与专业领域，用第二人称（"你是……"）
+- 给出具体的工作流程或方法论
+- 说明输出格式与质量标准
+
+# 输出
+生成所有文件后打包（确保 expert.json 位于 zip 根目录）：
+zip -r my-expert.zip expert.json skills/
+`
+
+const EXPERT_PROMPT_EN = `Generate an expert package zip that can be imported directly into the Expert Market.
+
+# My requirement
+<describe the expert you want here, e.g. a Python performance-tuning expert skilled at profiling and async refactoring>
+
+# Package format (follow strictly)
+The zip root must contain expert.json directly (no extra wrapping folder); optional skill packages go under skills/:
+
+my-expert.zip
+├── expert.json
+└── skills/
+    └── my-skill.zip
+
+# expert.json fields
+{
+  "name": "Expert name",                    // required, ≤128 chars
+  "summary": "One-line summary",            // required, ≤512 chars
+  "category": "",                           // may be empty; a category MUST be picked in the import dialog
+  "tags": ["tag1", "tag2"],                 // optional, ≤20
+  "instruction": "The expert's system prompt…",  // required, the core field
+  "mcp_config": "{\\"mcpServers\\":{}}",      // optional, must be a JSON STRING (escaped), ≤64KB
+  "skills": [                               // optional, ≤20
+    { "name": "Skill name", "file": "skills/my-skill.zip" },
+    { "name": "A name-only skill without a file" }
+  ]
+}
+
+# Skill package format (each zip under skills/)
+Each skill package is a standalone Agent-Skill zip: SKILL.md must sit at its root, starting with YAML frontmatter (name and description), followed by usage instructions; scripts and reference files may be bundled. Each package ≤20MB.
+
+SKILL.md example:
+---
+name: my-skill
+description: One line on what this skill does and when to use it
+---
+
+# Usage
+…
+
+# instruction writing guidelines
+- State the role and domain clearly, in second person ("You are…")
+- Give a concrete workflow or methodology
+- Specify output format and quality bar
+
+# Output
+After generating all files, package them (expert.json must be at the zip root):
+zip -r my-expert.zip expert.json skills/
+`
+
+const SQUAD_PROMPT_ZH = `请为我生成一个可直接导入「专家市场」的专家团包 zip 文件。
+
+# 我的需求
+<在这里描述你想要的专家团，例如：一个全栈交付小组，含产品、后端、前端、测试四名成员，由产品担任组长>
+
+# 专家团包格式（严格遵守）
+zip 根目录必须直接包含 squad.json（不要在外面多套一层文件夹）；技能包（可选）放在 skills/ 目录：
+
+my-squad.zip
+├── squad.json
+└── skills/
+    └── my-skill.zip
+
+# squad.json 字段说明
+{
+  "name": "专家团名称",                      // 必填，≤128 字符
+  "summary": "一句话简介",                   // 必填，≤512 字符
+  "category": "",                           // 可留空，但导入时必须在界面选择一个已存在的分类
+  "tags": ["标签1", "标签2"],                // 可选，≤20 个
+  "leader": "组长成员的 name",               // 可选，默认取 is_leader 成员的 name
+  "strategies": [                           // 可选，≤30 条，组长的调度规则
+    "先由产品澄清需求，再分派给对应成员",
+    "所有成员产出经组长汇总后统一答复"
+  ],
+  "dependencies": {                         // 可选
+    "blocking": ["必须先满足的前置条件"],
+    "recommended": ["建议但非必需的条件"]
+  },
+  "permission": "权限说明（可选）",
+  "members": [                              // 必填，1~30 名成员
+    {
+      "member_key": "pm",                   // 唯一键，不可重复
+      "name": "产品经理",                    // 必填
+      "role": "需求澄清与验收",               // 必填，一句话描述职责
+      "is_leader": true,                    // 必须且只能有一名成员为 true
+      "instruction": "你是产品经理……",        // 必填，该成员的系统提示词
+      "mcp_config": "{\\"mcpServers\\":{}}",  // 可选，JSON 字符串，≤64KB
+      "skills": [                           // 可选，每人 ≤20 个
+        { "name": "技能名", "file": "skills/my-skill.zip" }
+      ]
+    }
+  ]
+}
+
+# 技能包格式（skills/ 目录下的每个 zip）
+每个技能包是独立的 Agent-Skill 压缩包：根目录必须有 SKILL.md，文件开头是 YAML frontmatter（含 name 和 description 两个字段），正文写这个技能的使用方法。单个技能包 ≤20MB。多名成员可引用同一个技能文件。
+
+# instruction 写作要求
+- 每名成员的 instruction 明确角色分工，用第二人称（"你是……"）
+- 组长的 instruction 侧重任务拆解、分派与汇总
+- strategies 描述成员之间的协作顺序与规则
+
+# 输出
+生成所有文件后打包（确保 squad.json 位于 zip 根目录）：
+zip -r my-squad.zip squad.json skills/
+`
+
+const SQUAD_PROMPT_EN = `Generate a squad package zip that can be imported directly into the Expert Market.
+
+# My requirement
+<describe the squad you want here, e.g. a full-stack delivery squad with PM, backend, frontend and QA members, led by the PM>
+
+# Package format (follow strictly)
+The zip root must contain squad.json directly (no extra wrapping folder); optional skill packages go under skills/:
+
+my-squad.zip
+├── squad.json
+└── skills/
+    └── my-skill.zip
+
+# squad.json fields
+{
+  "name": "Squad name",                     // required, ≤128 chars
+  "summary": "One-line summary",            // required, ≤512 chars
+  "category": "",                           // may be empty; a category MUST be picked in the import dialog
+  "tags": ["tag1", "tag2"],                 // optional, ≤20
+  "leader": "name of the leader member",    // optional, defaults to the is_leader member's name
+  "strategies": [                           // optional, ≤30, the leader's dispatch rules
+    "PM clarifies the requirement first, then dispatches to members",
+    "The leader aggregates every member's output into one reply"
+  ],
+  "dependencies": {                         // optional
+    "blocking": ["hard prerequisites"],
+    "recommended": ["nice-to-have prerequisites"]
+  },
+  "permission": "permission notes (optional)",
+  "members": [                              // required, 1–30 members
+    {
+      "member_key": "pm",                   // unique key, no duplicates
+      "name": "Product Manager",            // required
+      "role": "Requirement clarification & acceptance",  // required
+      "is_leader": true,                    // exactly ONE member must be true
+      "instruction": "You are a product manager…",       // required, this member's system prompt
+      "mcp_config": "{\\"mcpServers\\":{}}",  // optional, JSON STRING, ≤64KB
+      "skills": [                           // optional, ≤20 per member
+        { "name": "Skill name", "file": "skills/my-skill.zip" }
+      ]
+    }
+  ]
+}
+
+# Skill package format (each zip under skills/)
+Each skill package is a standalone Agent-Skill zip: SKILL.md must sit at its root, starting with YAML frontmatter (name and description), followed by usage instructions. Each package ≤20MB. Multiple members may reference the same skill file.
+
+# instruction writing guidelines
+- Each member's instruction states their role clearly, in second person ("You are…")
+- The leader's instruction focuses on task decomposition, dispatching and aggregation
+- strategies describe the collaboration order and rules between members
+
+# Output
+After generating all files, package them (squad.json must be at the zip root):
+zip -r my-squad.zip squad.json skills/
+`
+
+/** The paste-into-any-LLM prompt for generating a container zip of `kind`. */
+export function buildAiPrompt(kind: ExpertKind, language: string): string {
+  const zh = language.toLowerCase().startsWith('zh')
+  if (kind === 'squad') return zh ? SQUAD_PROMPT_ZH : SQUAD_PROMPT_EN
+  return zh ? EXPERT_PROMPT_ZH : EXPERT_PROMPT_EN
+}

--- a/src/pages/ExpertMarket/detailParts.tsx
+++ b/src/pages/ExpertMarket/detailParts.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useState, type ReactNode } from 'react'
+import { Alert, Modal, Skeleton, Typography } from 'antd'
+import { useTranslation } from 'react-i18next'
+import type { SkillRef } from '../../api/expert'
+
+const { Text, Link } = Typography
+
+export function DetailSection({ title, children }: { title: ReactNode; children: ReactNode }) {
+  return (
+    <section className="exp-detail__section">
+      <h4 className="exp-detail__section-title">{title}</h4>
+      {children}
+    </section>
+  )
+}
+
+/** Read-only list of skills bundled on an expert or squad member. When
+ *  `onView` is given, skills with stored content get a "view" link that
+ *  opens the SKILL.md viewer. */
+export function SkillRefList({
+  skills,
+  onView,
+}: {
+  skills: SkillRef[]
+  onView?: (index: number, skill: SkillRef) => void
+}) {
+  const { t } = useTranslation(['expertMarket'])
+  if (!skills?.length) return <Text type="secondary">{t('detail.noSkills')}</Text>
+  return (
+    <ul className="exp-list">
+      {skills.map((s, i) => (
+        <li className="exp-list__item" key={`${s.name}-${i}`}>
+          <span className="exp-list__title">
+            {s.name}
+            {onView && s.has_content && (
+              <Link onClick={() => onView(i, s)} style={{ marginLeft: 8, fontSize: 12 }}>
+                {t('detail.viewSkill')}
+              </Link>
+            )}
+          </span>
+          {(s.file_name || s.can_download) && (
+            <span className="exp-list__sub">
+              {s.file_name}
+              {typeof s.file_size === 'number' ? ` · ${formatBytes(s.file_size)}` : ''}
+            </span>
+          )}
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+/** Fetch-and-show modal for one skill's stored SKILL.md text. `load` is
+ *  called on each open; identity changes are ignored mid-flight. */
+export function SkillMdModal({
+  open,
+  title,
+  load,
+  onClose,
+}: {
+  open: boolean
+  title: string
+  load: () => Promise<string>
+  onClose: () => void
+}) {
+  const { t } = useTranslation(['expertMarket'])
+  const [content, setContent] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!open) return
+    setContent(null)
+    setError(null)
+    let cancelled = false
+    load()
+      .then((c) => !cancelled && setContent(c))
+      .catch((err: unknown) => {
+        if (!cancelled) setError((err as Error)?.message ?? String(err))
+      })
+    return () => {
+      cancelled = true
+    }
+    // `load` is a fresh closure every parent render; re-fetch only on open.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open])
+
+  return (
+    <Modal open={open} title={title} footer={null} onCancel={onClose} width={640}>
+      {error ? (
+        <Alert type="error" showIcon message={t('detail.skillLoadFailed')} description={error} />
+      ) : content === null ? (
+        <Skeleton active paragraph={{ rows: 4 }} />
+      ) : (
+        <pre className="exp-pre" style={{ maxHeight: '60vh', overflow: 'auto' }}>
+          {content}
+        </pre>
+      )}
+    </Modal>
+  )
+}
+
+/** Render an mcp_config JSON string, pretty-printed when parseable. */
+export function McpConfigBlock({ config }: { config: string }) {
+  let text = config
+  try {
+    text = JSON.stringify(JSON.parse(config), null, 2)
+  } catch {
+    /* show raw when not valid JSON */
+  }
+  return <pre className="exp-pre">{text}</pre>
+}
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`
+  return `${(n / 1024 / 1024).toFixed(1)} MB`
+}

--- a/src/pages/ExpertMarket/expertMarket.css
+++ b/src/pages/ExpertMarket/expertMarket.css
@@ -1,0 +1,240 @@
+/* Expert market admin — visual add-ons on top of the console's admin.css.
+   Uses the same --a-* tokens as .admin-shell. Mirrors systemMcp.css naming
+   with an `exp-` prefix so the two modules stay independent. */
+
+/* ── Table name cell ─────────────────────────────────────────────────────── */
+.admin-shell .exp-cell-name {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.admin-shell .exp-cell-name__tile,
+.admin-shell .exp-preview__tile,
+.admin-shell .exp-detail__tile {
+  flex: none;
+  border-radius: 8px;
+  background: var(--a-bg-muted);
+  color: var(--a-text-secondary);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  overflow: hidden;
+}
+.admin-shell .exp-cell-name__tile {
+  width: 32px;
+  height: 32px;
+  font-size: 12px;
+}
+.admin-shell .exp-cell-name__text {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+.admin-shell .exp-cell-name__sub {
+  font-size: 12px;
+  color: var(--a-text-tertiary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 420px;
+}
+.admin-shell .exp-more {
+  color: var(--a-text-quaternary);
+  font-size: 12px;
+}
+
+/* ── Upload preview ──────────────────────────────────────────────────────── */
+.admin-shell .exp-preview {
+  padding: 12px 14px;
+  margin-bottom: 16px;
+  background: var(--a-bg-subtle);
+  border: 1px solid var(--a-border-default);
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.admin-shell .exp-preview__head {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+}
+.admin-shell .exp-preview__tile {
+  width: 44px;
+  height: 44px;
+  font-size: 14px;
+}
+.admin-shell .exp-preview__meta {
+  min-width: 0;
+}
+.admin-shell .exp-preview__name {
+  font-weight: 600;
+  color: var(--a-text-primary);
+}
+.admin-shell .exp-preview__summary {
+  font-size: 12px;
+  color: var(--a-text-tertiary);
+  line-height: 1.5;
+}
+.admin-shell .exp-preview__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+/* ── Detail drawer ───────────────────────────────────────────────────────── */
+.admin-shell .exp-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+.admin-shell .exp-detail__meta {
+  display: flex;
+  gap: 14px;
+  align-items: flex-start;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--a-border-default);
+}
+.admin-shell .exp-detail__tile {
+  width: 52px;
+  height: 52px;
+  font-size: 18px;
+  border-radius: 10px;
+}
+.admin-shell .exp-detail__meta-body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.admin-shell .exp-detail__summary {
+  color: var(--a-text-secondary);
+  font-size: 13px;
+  line-height: 1.5;
+}
+.admin-shell .exp-detail__sub {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  color: var(--a-text-tertiary);
+  font-size: 12px;
+}
+.admin-shell .exp-detail__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 2px;
+}
+.admin-shell .exp-detail__section {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.admin-shell .exp-detail__section-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--a-text-secondary);
+  margin: 0;
+  letter-spacing: 0.01em;
+}
+
+/* ── Key-value list + strategies ─────────────────────────────────────────── */
+.admin-shell .exp-kv {
+  display: grid;
+  grid-template-columns: 96px 1fr;
+  row-gap: 8px;
+  column-gap: 12px;
+  margin: 0;
+  font-size: 13px;
+}
+.admin-shell .exp-kv dt {
+  color: var(--a-text-tertiary);
+  font-weight: 400;
+}
+.admin-shell .exp-kv dd {
+  color: var(--a-text-primary);
+  margin: 0;
+  word-break: break-word;
+}
+.admin-shell .exp-strategies {
+  margin: 0;
+  padding-left: 18px;
+  font-size: 13px;
+  color: var(--a-text-secondary);
+  line-height: 1.6;
+}
+
+/* ── mcp_config / json block ─────────────────────────────────────────────── */
+.admin-shell .exp-pre {
+  margin: 0;
+  padding: 8px 10px;
+  background: var(--a-bg-subtle);
+  border-radius: 6px;
+  font-family: 'SF Mono', Monaco, Consolas, monospace;
+  font-size: 12px;
+  color: var(--a-text-primary);
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 240px;
+  overflow: auto;
+}
+
+/* ── Skill list ──────────────────────────────────────────────────────────── */
+.admin-shell .exp-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.admin-shell .exp-list__item {
+  padding: 10px 12px;
+  background: var(--a-bg-subtle);
+  border-radius: 6px;
+}
+.admin-shell .exp-list__title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--a-text-primary);
+}
+.admin-shell .exp-list__sub {
+  display: block;
+  margin-top: 2px;
+  font-size: 12px;
+  color: var(--a-text-tertiary);
+}
+
+/* ── Squad member collapse ───────────────────────────────────────────────── */
+.admin-shell .exp-member__role {
+  color: var(--a-text-tertiary);
+  font-size: 12px;
+}
+.admin-shell .exp-member__body {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.admin-shell .exp-member__head {
+  margin: 8px 0 0;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--a-text-tertiary);
+}
+.admin-shell .exp-member__head:first-child {
+  margin-top: 0;
+}
+
+/* ── Drawer footer ───────────────────────────────────────────────────────── */
+.admin-shell .exp-drawer-footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+}
+.admin-shell .exp-drawer-footer--confirm > *:first-child {
+  margin-right: auto;
+}

--- a/src/pages/ExpertMarket/index.tsx
+++ b/src/pages/ExpertMarket/index.tsx
@@ -1,0 +1,25 @@
+import { Tabs } from 'antd'
+import { useTranslation } from 'react-i18next'
+import CategoryTab from './CategoryTab'
+import ExpertTab from './ExpertTab'
+import SquadTab from './SquadTab'
+import './expertMarket.css'
+
+export default function ExpertMarket() {
+  const { t } = useTranslation(['expertMarket'])
+
+  return (
+    <div>
+      <h1 className="page-title">{t('pageTitle')}</h1>
+      <p className="page-subtitle">{t('pageDesc')}</p>
+      <Tabs
+        defaultActiveKey="experts"
+        items={[
+          { key: 'experts', label: t('tab.experts'), children: <ExpertTab /> },
+          { key: 'squads', label: t('tab.squads'), children: <SquadTab /> },
+          { key: 'categories', label: t('tab.categories'), children: <CategoryTab /> },
+        ]}
+      />
+    </div>
+  )
+}

--- a/src/pages/ExpertMarket/parseContainer.test.ts
+++ b/src/pages/ExpertMarket/parseContainer.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Coverage for the pure manifest validator (parseManifest) and the container
+ * path-safety helper. These carry all the branchy correctness logic — required
+ * fields, size caps, exactly-one-leader, and archive-safety — that a malformed
+ * upload could otherwise sneak past. The JSZip I/O shell (parseExpertContainer)
+ * is thin glue and left to manual verification.
+ */
+
+import { describe, expect, it } from 'vitest'
+import JSZip from 'jszip'
+import {
+  ContainerError,
+  isUnsafeEntryPath,
+  parseExpertContainer,
+  parseManifest,
+  MAX_MCP_CONFIG_BYTES,
+  type ParsedExpert,
+  type ParsedSquad,
+} from './parseContainer'
+
+const validExpert = {
+  name: '后端架构师',
+  short_name: '架构',
+  summary: '评审服务边界、数据模型和可靠性方案。',
+  category: '研发工具',
+  tags: ['架构评审', '可靠性'],
+  instruction: '你是资深后端架构师……',
+  mcp_config: '{"mcpServers":{}}',
+  skills: [{ name: '架构评审清单', file: 'skills/checklist.zip' }],
+}
+
+function validSquad() {
+  return {
+    name: '增长小组',
+    summary: '负责增长实验设计与执行。',
+    category: '营销策划',
+    leader: '组长',
+    strategies: ['先由组长拆解任务'],
+    dependencies: { blocking: [], recommended: ['数据看板'] },
+    members: [
+      { member_key: 'lead', name: '组长', role: 'leader', is_leader: true, instruction: '统筹', mcp_config: '{}' },
+      { member_key: 'ic', name: '执行', role: 'ic', is_leader: false, instruction: '执行任务', mcp_config: '{}' },
+    ],
+  }
+}
+
+function code(fn: () => unknown): string {
+  try {
+    fn()
+  } catch (e) {
+    if (e instanceof ContainerError) return e.code
+    throw e
+  }
+  throw new Error('expected ContainerError, none thrown')
+}
+
+describe('isUnsafeEntryPath', () => {
+  it('accepts a plain relative path', () => {
+    expect(isUnsafeEntryPath('skills/x.zip')).toBe(false)
+  })
+  it('rejects absolute, drive, traversal, and empty', () => {
+    expect(isUnsafeEntryPath('/etc/passwd')).toBe(true)
+    expect(isUnsafeEntryPath('C:/x.zip')).toBe(true)
+    expect(isUnsafeEntryPath('skills/../../secret.zip')).toBe(true)
+    expect(isUnsafeEntryPath('')).toBe(true)
+  })
+})
+
+describe('parseManifest — expert', () => {
+  it('normalizes a valid expert manifest', () => {
+    const m = parseManifest('agent', validExpert) as ParsedExpert
+    expect(m.kind).toBe('agent')
+    expect(m.name).toBe('后端架构师')
+    expect(m.short_name).toBe('架构')
+    expect(m.skills).toEqual([{ name: '架构评审清单', file: 'skills/checklist.zip' }])
+  })
+
+  it('requires name, summary, instruction', () => {
+    expect(code(() => parseManifest('agent', { ...validExpert, name: '' }))).toBe('nameRequired')
+    expect(code(() => parseManifest('agent', { ...validExpert, summary: '  ' }))).toBe('summaryRequired')
+    expect(code(() => parseManifest('agent', { ...validExpert, instruction: '' }))).toBe('instructionRequired')
+  })
+
+  it('defaults an omitted mcp_config to an empty server map', () => {
+    const m = parseManifest('agent', { ...validExpert, mcp_config: undefined }) as ParsedExpert
+    expect(JSON.parse(m.mcp_config)).toEqual({ mcpServers: {} })
+  })
+
+  it('rejects invalid and oversized mcp_config', () => {
+    expect(code(() => parseManifest('agent', { ...validExpert, mcp_config: '{not json' }))).toBe('mcpConfigInvalid')
+    const huge = '{"x":"' + 'a'.repeat(MAX_MCP_CONFIG_BYTES) + '"}'
+    expect(code(() => parseManifest('agent', { ...validExpert, mcp_config: huge }))).toBe('mcpConfigTooLarge')
+  })
+
+  it('accepts a name-only skill and rejects unsafe / wrong-ext files', () => {
+    const m = parseManifest('agent', { ...validExpert, skills: [{ name: '仅名称' }] }) as ParsedExpert
+    expect(m.skills[0]).toEqual({ name: '仅名称' })
+    expect(code(() => parseManifest('agent', { ...validExpert, skills: [{ name: 'x', file: '../evil.zip' }] }))).toBe('skillPathUnsafe')
+    expect(code(() => parseManifest('agent', { ...validExpert, skills: [{ name: 'x', file: 'skills/x.txt' }] }))).toBe('skillExtInvalid')
+    expect(code(() => parseManifest('agent', { ...validExpert, skills: [{ file: 'skills/x.zip' }] }))).toBe('skillNameRequired')
+  })
+})
+
+describe('parseManifest — squad', () => {
+  it('normalizes a valid squad manifest', () => {
+    const m = parseManifest('squad', validSquad()) as ParsedSquad
+    expect(m.kind).toBe('squad')
+    expect(m.members).toHaveLength(2)
+    expect(m.leader).toBe('组长')
+    expect(m.dependencies.recommended).toEqual(['数据看板'])
+  })
+
+  it('requires at least one member', () => {
+    expect(code(() => parseManifest('squad', { ...validSquad(), members: [] }))).toBe('membersRequired')
+  })
+
+  it('requires exactly one leader', () => {
+    const two = validSquad()
+    two.members[1].is_leader = true
+    expect(code(() => parseManifest('squad', two))).toBe('leaderCount')
+    const none = validSquad()
+    none.members[0].is_leader = false
+    expect(code(() => parseManifest('squad', none))).toBe('leaderCount')
+  })
+
+  it('falls back leader label to the leader member name when omitted', () => {
+    const s = validSquad()
+    delete (s as Record<string, unknown>).leader
+    const m = parseManifest('squad', s) as ParsedSquad
+    expect(m.leader).toBe('组长')
+  })
+
+  it('rejects duplicate member keys and missing member instruction', () => {
+    const dup = validSquad()
+    dup.members[1].member_key = 'lead'
+    expect(code(() => parseManifest('squad', dup))).toBe('memberKeyDup')
+    const noInstr = validSquad()
+    noInstr.members[1].instruction = ''
+    expect(code(() => parseManifest('squad', noInstr))).toBe('memberInstructionRequired')
+  })
+
+  it('rejects a member with an empty role (backend requires it)', () => {
+    const noRole = validSquad()
+    noRole.members[1].role = ''
+    expect(code(() => parseManifest('squad', noRole))).toBe('memberRoleRequired')
+  })
+})
+
+describe('parseManifest — shape guards', () => {
+  it('rejects a non-object manifest', () => {
+    expect(code(() => parseManifest('agent', null))).toBe('manifestInvalid')
+    expect(code(() => parseManifest('agent', 'nope'))).toBe('manifestInvalid')
+  })
+})
+
+async function buildZip(files: Record<string, string | Uint8Array>): Promise<Blob> {
+  const zip = new JSZip()
+  for (const [path, content] of Object.entries(files)) zip.file(path, content)
+  return zip.generateAsync({ type: 'blob' })
+}
+
+async function codeAsync(fn: () => Promise<unknown>): Promise<string> {
+  try {
+    await fn()
+  } catch (e) {
+    if (e instanceof ContainerError) return e.code
+    throw e
+  }
+  throw new Error('expected ContainerError, none thrown')
+}
+
+describe('parseExpertContainer — real zip', () => {
+  it('parses an expert container and resolves the bundled skill blob', async () => {
+    const zip = await buildZip({
+      'expert.json': JSON.stringify(validExpert),
+      'skills/checklist.zip': new Uint8Array([1, 2, 3, 4]),
+    })
+    const parsed = await parseExpertContainer(zip)
+    expect(parsed.manifest.kind).toBe('agent')
+    expect(parsed.skillFiles.size).toBe(1)
+    const file = parsed.skillFiles.get('skills/checklist.zip')!
+    expect(file.fileName).toBe('checklist.zip')
+    expect(file.skillName).toBe('架构评审清单')
+    expect(file.blob.size).toBe(4)
+  })
+
+  it('parses a squad container', async () => {
+    const zip = await buildZip({ 'squad.json': JSON.stringify(validSquad()) })
+    const parsed = await parseExpertContainer(zip)
+    expect(parsed.manifest.kind).toBe('squad')
+    expect(parsed.skillFiles.size).toBe(0)
+  })
+
+  it('rejects a container with both manifests', async () => {
+    const zip = await buildZip({
+      'expert.json': JSON.stringify(validExpert),
+      'squad.json': JSON.stringify(validSquad()),
+    })
+    expect(await codeAsync(() => parseExpertContainer(zip))).toBe('manifestAmbiguous')
+  })
+
+  it('rejects a container missing any manifest', async () => {
+    const zip = await buildZip({ 'readme.txt': 'nope' })
+    expect(await codeAsync(() => parseExpertContainer(zip))).toBe('manifestMissing')
+  })
+
+  it('rejects when a referenced skill file is absent', async () => {
+    const zip = await buildZip({ 'expert.json': JSON.stringify(validExpert) })
+    expect(await codeAsync(() => parseExpertContainer(zip))).toBe('skillFileMissing')
+  })
+
+  it('rejects a non-zip file', async () => {
+    const notZip = new Blob([new Uint8Array([0, 1, 2, 3])])
+    expect(await codeAsync(() => parseExpertContainer(notZip))).toBe('zipInvalid')
+  })
+})

--- a/src/pages/ExpertMarket/parseContainer.test.ts
+++ b/src/pages/ExpertMarket/parseContainer.test.ts
@@ -214,3 +214,30 @@ describe('parseExpertContainer — real zip', () => {
     expect(await codeAsync(() => parseExpertContainer(notZip))).toBe('zipInvalid')
   })
 })
+
+describe('parseExpertContainer — zip-bomb guards', () => {
+  // A tiny compressed container whose entries inflate huge: DEFLATE turns
+  // megabytes of zeros into a few KB, which is exactly the bomb shape.
+  async function buildDeflated(files: Record<string, string | Uint8Array>): Promise<Blob> {
+    const zip = new JSZip()
+    for (const [path, content] of Object.entries(files)) zip.file(path, content)
+    return zip.generateAsync({ type: 'blob', compression: 'DEFLATE' })
+  }
+
+  it('rejects an oversized manifest from metadata, before parsing it', async () => {
+    const padded = { ...validExpert, summary: 'x'.repeat(2 * 1024 * 1024) }
+    const zip = await buildDeflated({ 'expert.json': JSON.stringify(padded) })
+    expect(zip.size).toBeLessThan(100 * 1024) // the outer file itself is tiny
+    expect(await codeAsync(() => parseExpertContainer(zip))).toBe('manifestTooLarge')
+  })
+
+  it('rejects an over-cap skill entry from metadata, before inflating it', async () => {
+    const zip = await buildDeflated({
+      'expert.json': JSON.stringify(validExpert),
+      // 21 MiB of zeros — compresses to ~20 KB but inflates past the 20 MiB cap.
+      'skills/checklist.zip': new Uint8Array(21 * 1024 * 1024),
+    })
+    expect(zip.size).toBeLessThan(200 * 1024)
+    expect(await codeAsync(() => parseExpertContainer(zip))).toBe('skillFileTooLarge')
+  })
+})

--- a/src/pages/ExpertMarket/parseContainer.ts
+++ b/src/pages/ExpertMarket/parseContainer.ts
@@ -482,7 +482,10 @@ export async function parseExpertContainer(file: File | Blob): Promise<ParsedCon
       'skillFileTooLarge',
       `package "${skill.file}" exceeds 20 MiB`
     )
-    const blob = new Blob([bytes])
+    // TS 5.9 types Uint8Array<ArrayBufferLike>, which no longer satisfies
+    // BlobPart directly; the joined array is exactly sized, so its buffer is
+    // the payload.
+    const blob = new Blob([bytes.buffer as ArrayBuffer])
     skillFiles.set(skill.file, {
       skillName: skill.name,
       path: skill.file,

--- a/src/pages/ExpertMarket/parseContainer.ts
+++ b/src/pages/ExpertMarket/parseContainer.ts
@@ -30,6 +30,10 @@ export const MAX_STRATEGIES = 30
 export const MAX_TAGS = 20
 export const MAX_MCP_CONFIG_BYTES = 64 * 1024
 export const MAX_SKILL_PACKAGE_BYTES = 20 * 1024 * 1024
+/** Whole-container ceiling, checked BEFORE JSZip inflates anything: the max
+ *  legal payload is ~20 packages × 20 MiB, so anything past 512 MiB can only
+ *  be malformed and would otherwise freeze the tab mid-extraction. */
+export const MAX_CONTAINER_BYTES = 512 * 1024 * 1024
 
 /** A parse/validation failure. `code` is a stable i18n key suffix; `message`
  *  is a human-readable fallback. */
@@ -318,6 +322,9 @@ type ExpertKindLike = 'agent' | 'squad'
  * referenced skill package into a Blob. Throws ContainerError on any problem.
  */
 export async function parseExpertContainer(file: File | Blob): Promise<ParsedContainer> {
+  if (file.size > MAX_CONTAINER_BYTES) {
+    throw new ContainerError('containerTooLarge', 'container exceeds 512 MiB')
+  }
   let zip: JSZip
   try {
     zip = await JSZip.loadAsync(file)

--- a/src/pages/ExpertMarket/parseContainer.ts
+++ b/src/pages/ExpertMarket/parseContainer.ts
@@ -317,9 +317,98 @@ type ExpertKindLike = 'agent' | 'squad'
 
 // ─── Async container (zip) parsing ───────────────────────────────────────────
 
+/** Manifest ceiling: the field limits above bound a legal manifest to well
+ *  under this, so anything bigger is malformed or hostile. */
+export const MAX_MANIFEST_BYTES = 1 * 1024 * 1024
+
+/** Uncompressed size recorded in the entry's central-directory header.
+ *  jszip keeps it on the internal compressed-data record; absent/negative
+ *  metadata is treated as suspicious by the callers (fail early). */
+function declaredSize(entry: JSZip.JSZipObject): number | null {
+  const data = (entry as unknown as { _data?: { uncompressedSize?: number } })._data
+  const n = data?.uncompressedSize
+  return typeof n === 'number' && Number.isFinite(n) && n >= 0 ? n : null
+}
+
+/** jszip's StreamHelper — present at runtime (zipObject.js) but absent from
+ *  its index.d.ts, so typed locally. */
+interface ZipStream {
+  on(event: 'data', cb: (chunk: Uint8Array) => void): ZipStream
+  on(event: 'error', cb: (err: Error) => void): ZipStream
+  on(event: 'end', cb: () => void): ZipStream
+  pause(): void
+  resume(): void
+}
+
+/** Inflate one entry while counting actual bytes, rejecting the moment the
+ *  cap is crossed — the central-directory size is attacker-controlled, so a
+ *  zip bomb whose header lies is stopped here instead of exhausting the tab. */
+function inflateCapped(
+  entry: JSZip.JSZipObject,
+  cap: number,
+  code: string,
+  message: string
+): Promise<Uint8Array> {
+  return new Promise((resolve, reject) => {
+    const chunks: Uint8Array[] = []
+    let total = 0
+    let settled = false
+    const stream = (
+      entry as unknown as { internalStream(type: 'uint8array'): ZipStream }
+    ).internalStream('uint8array')
+    stream.on('data', (chunk: Uint8Array) => {
+      if (settled) return
+      total += chunk.length
+      if (total > cap) {
+        settled = true
+        stream.pause()
+        reject(new ContainerError(code, message))
+        return
+      }
+      chunks.push(chunk)
+    })
+    stream.on('error', (err: Error) => {
+      if (!settled) {
+        settled = true
+        reject(new ContainerError('zipInvalid', err.message))
+      }
+    })
+    stream.on('end', () => {
+      if (!settled) {
+        settled = true
+        const joined = new Uint8Array(total)
+        let offset = 0
+        for (const c of chunks) {
+          joined.set(c, offset)
+          offset += c.length
+        }
+        resolve(joined)
+      }
+    })
+    stream.resume()
+  })
+}
+
+/** Reject an entry whose declared uncompressed size is missing or over `cap`
+ *  BEFORE any inflation happens. */
+function assertDeclaredSize(entry: JSZip.JSZipObject, cap: number, code: string, what: string): void {
+  const size = declaredSize(entry)
+  if (size == null) {
+    throw new ContainerError('entryMetaMissing', `${what}: zip entry metadata is missing`)
+  }
+  if (size > cap) {
+    throw new ContainerError(code, `${what} exceeds ${Math.floor(cap / 1024 / 1024)} MiB`)
+  }
+}
+
 /**
  * Unzip a container, locate its manifest, validate it, and resolve every
  * referenced skill package into a Blob. Throws ContainerError on any problem.
+ *
+ * Zip-bomb posture: the outer file size is capped, every entry's DECLARED
+ * uncompressed size is checked before inflation, a running total bounds the
+ * whole container, and the actual inflation is byte-counted against the same
+ * caps in case the headers lie.
  */
 export async function parseExpertContainer(file: File | Blob): Promise<ParsedContainer> {
   if (file.size > MAX_CONTAINER_BYTES) {
@@ -343,9 +432,16 @@ export async function parseExpertContainer(file: File | Blob): Promise<ParsedCon
   }
   const kind: ExpertKindLike = squadJson ? 'squad' : 'agent'
 
+  assertDeclaredSize(manifestFile, MAX_MANIFEST_BYTES, 'manifestTooLarge', 'manifest')
+  const manifestBytes = await inflateCapped(
+    manifestFile,
+    MAX_MANIFEST_BYTES,
+    'manifestTooLarge',
+    'manifest exceeds 1 MiB'
+  )
   let rawManifest: unknown
   try {
-    rawManifest = JSON.parse(await manifestFile.async('string'))
+    rawManifest = JSON.parse(new TextDecoder().decode(manifestBytes))
   } catch {
     throw new ContainerError('manifestParse', 'manifest JSON is malformed')
   }
@@ -358,17 +454,35 @@ export async function parseExpertContainer(file: File | Blob): Promise<ParsedCon
       ? manifest.members.flatMap((m) => m.skills)
       : manifest.skills
 
-  const skillFiles = new Map<string, ResolvedSkillFile>()
+  // Pre-flight every referenced entry from metadata alone — per-entry cap and
+  // a total-uncompressed cap — before inflating anything.
+  const uniquePaths: string[] = []
+  let declaredTotal = 0
   for (const skill of refs) {
-    if (!skill.file || skillFiles.has(skill.file)) continue
+    if (!skill.file || uniquePaths.includes(skill.file)) continue
     const entry = zip.file(skill.file)
     if (!entry) {
       throw new ContainerError('skillFileMissing', `bundled package "${skill.file}" not found in container`)
     }
-    const blob = await entry.async('blob')
-    if (blob.size > MAX_SKILL_PACKAGE_BYTES) {
-      throw new ContainerError('skillFileTooLarge', `package "${skill.file}" exceeds 20 MiB`)
+    assertDeclaredSize(entry, MAX_SKILL_PACKAGE_BYTES, 'skillFileTooLarge', `package "${skill.file}"`)
+    declaredTotal += declaredSize(entry) ?? 0
+    if (declaredTotal > MAX_CONTAINER_BYTES) {
+      throw new ContainerError('containerTooLarge', 'container exceeds 512 MiB uncompressed')
     }
+    uniquePaths.push(skill.file)
+  }
+
+  const skillFiles = new Map<string, ResolvedSkillFile>()
+  for (const skill of refs) {
+    if (!skill.file || skillFiles.has(skill.file)) continue
+    const entry = zip.file(skill.file)!
+    const bytes = await inflateCapped(
+      entry,
+      MAX_SKILL_PACKAGE_BYTES,
+      'skillFileTooLarge',
+      `package "${skill.file}" exceeds 20 MiB`
+    )
+    const blob = new Blob([bytes])
     skillFiles.set(skill.file, {
       skillName: skill.name,
       path: skill.file,

--- a/src/pages/ExpertMarket/parseContainer.ts
+++ b/src/pages/ExpertMarket/parseContainer.ts
@@ -1,0 +1,374 @@
+/**
+ * Client-side expert/squad container parser.
+ *
+ * A container zip is a plain archive holding one manifest — `expert.json` or
+ * `squad.json` (which of the two decides the kind) — at its root, plus the
+ * bundled Agent-Skill packages it references (each a whole `.zip`/`.skill`),
+ * conventionally under `skills/`. The manifest's `skills[]` reference a package
+ * by container path: `{ "name": "…", "file": "skills/x.zip" }`. A name-only
+ * entry `{ "name": "…" }` carries no package.
+ *
+ * The browser unzips and validates the container here; it is NEVER uploaded.
+ * Only the bundled skill packages later go to object storage (presigned). This
+ * mirrors octo-cli `marketplace expert create` (skills/octo-marketplace/expert.md).
+ *
+ * Manifest validation/normalization is pure (parseManifest) so it can be unit
+ * tested without JSZip; blob resolution (parseExpertContainer) is the async I/O
+ * shell around it.
+ */
+
+import JSZip from 'jszip'
+
+// Limits mirror octo-marketplace internal/model/expert.go so the client rejects
+// oversized input before any upload/create round-trip.
+export const MAX_NAME_LEN = 128
+export const MAX_SUMMARY_LEN = 512
+export const MAX_SHORT_NAME_LEN = 16
+export const MAX_SKILLS = 20
+export const MAX_MEMBERS = 30
+export const MAX_STRATEGIES = 30
+export const MAX_TAGS = 20
+export const MAX_MCP_CONFIG_BYTES = 64 * 1024
+export const MAX_SKILL_PACKAGE_BYTES = 20 * 1024 * 1024
+
+/** A parse/validation failure. `code` is a stable i18n key suffix; `message`
+ *  is a human-readable fallback. */
+export class ContainerError extends Error {
+  code: string
+  constructor(code: string, message: string) {
+    super(message)
+    this.name = 'ContainerError'
+    this.code = code
+  }
+}
+
+export interface ParsedSkill {
+  name: string
+  /** Container-relative path of the bundled package, if any. */
+  file?: string
+}
+
+export interface ParsedExpert {
+  kind: 'agent'
+  name: string
+  short_name?: string
+  summary: string
+  category: string
+  tags: string[]
+  instruction: string
+  mcp_config: string
+  skills: ParsedSkill[]
+}
+
+export interface ParsedSquadMember {
+  member_key: string
+  name: string
+  role: string
+  is_leader: boolean
+  instruction: string
+  mcp_config: string
+  skills: ParsedSkill[]
+}
+
+export interface ParsedSquad {
+  kind: 'squad'
+  name: string
+  short_name?: string
+  summary: string
+  category: string
+  tags: string[]
+  leader: string
+  strategies: string[]
+  dependencies: { blocking: string[]; recommended: string[] }
+  permission: string
+  members: ParsedSquadMember[]
+}
+
+export type ParsedManifest = ParsedExpert | ParsedSquad
+
+/** A skill package resolved out of the container, ready to presign-upload. */
+export interface ResolvedSkillFile {
+  /** Manifest skill name it belongs to. */
+  skillName: string
+  /** Container path (unique key). */
+  path: string
+  fileName: string
+  blob: Blob
+}
+
+export interface ParsedContainer {
+  manifest: ParsedManifest
+  /** Bundled packages keyed by container path. */
+  skillFiles: Map<string, ResolvedSkillFile>
+}
+
+// ─── Path safety ──────────────────────────────────────────────────────────
+
+/** Reject absolute paths, drive letters, and `..` traversal in a container
+ *  reference — same archive-safety rule as Skill install. */
+export function isUnsafeEntryPath(p: string): boolean {
+  if (!p) return true
+  if (p.startsWith('/') || p.startsWith('\\')) return true
+  if (/^[a-zA-Z]:/.test(p)) return true
+  return p
+    .split(/[\\/]/)
+    .some((seg) => seg === '..')
+}
+
+function hasSkillExtension(p: string): boolean {
+  const lower = p.toLowerCase()
+  return lower.endsWith('.zip') || lower.endsWith('.skill')
+}
+
+function basename(p: string): string {
+  const parts = p.split(/[\\/]/)
+  return parts[parts.length - 1] || p
+}
+
+function byteLength(s: string): number {
+  return new TextEncoder().encode(s).length
+}
+
+// ─── Pure manifest normalization + validation ───────────────────────────────
+
+function asString(v: unknown): string {
+  return typeof v === 'string' ? v : ''
+}
+
+function asStringArray(v: unknown): string[] {
+  if (!Array.isArray(v)) return []
+  return v.filter((x): x is string => typeof x === 'string' && x.trim() !== '')
+}
+
+function validateMcpConfig(raw: unknown, where: string): string {
+  // Default to an empty server map when omitted.
+  const s = raw == null || raw === '' ? '{"mcpServers":{}}' : raw
+  if (typeof s !== 'string') {
+    throw new ContainerError('mcpConfigType', `${where}: mcp_config must be a JSON string`)
+  }
+  if (byteLength(s) > MAX_MCP_CONFIG_BYTES) {
+    throw new ContainerError('mcpConfigTooLarge', `${where}: mcp_config exceeds 64 KiB`)
+  }
+  try {
+    JSON.parse(s)
+  } catch {
+    throw new ContainerError('mcpConfigInvalid', `${where}: mcp_config is not valid JSON`)
+  }
+  return s
+}
+
+function normalizeSkills(raw: unknown, where: string): ParsedSkill[] {
+  if (raw == null) return []
+  if (!Array.isArray(raw)) {
+    throw new ContainerError('skillsType', `${where}: skills must be an array`)
+  }
+  if (raw.length > MAX_SKILLS) {
+    throw new ContainerError('skillsTooMany', `${where}: at most ${MAX_SKILLS} skills`)
+  }
+  return raw.map((item, i) => {
+    const rec = (item ?? {}) as Record<string, unknown>
+    const name = asString(rec.name).trim()
+    if (!name) {
+      throw new ContainerError('skillNameRequired', `${where}: skills[${i}].name is required`)
+    }
+    const file = asString(rec.file).trim()
+    if (file) {
+      if (isUnsafeEntryPath(file)) {
+        throw new ContainerError('skillPathUnsafe', `${where}: unsafe skill path "${file}"`)
+      }
+      if (!hasSkillExtension(file)) {
+        throw new ContainerError('skillExtInvalid', `${where}: skill "${file}" must be .zip/.skill`)
+      }
+      return { name, file }
+    }
+    return { name }
+  })
+}
+
+function validateCommonMeta(rec: Record<string, unknown>): {
+  name: string
+  short_name?: string
+  summary: string
+  category: string
+  tags: string[]
+} {
+  const name = asString(rec.name).trim()
+  if (!name) throw new ContainerError('nameRequired', 'name is required')
+  if (name.length > MAX_NAME_LEN) {
+    throw new ContainerError('nameTooLong', `name exceeds ${MAX_NAME_LEN} chars`)
+  }
+  const summary = asString(rec.summary).trim()
+  if (!summary) throw new ContainerError('summaryRequired', 'summary is required')
+  if (summary.length > MAX_SUMMARY_LEN) {
+    throw new ContainerError('summaryTooLong', `summary exceeds ${MAX_SUMMARY_LEN} chars`)
+  }
+  const shortName = asString(rec.short_name).trim()
+  if (shortName.length > MAX_SHORT_NAME_LEN) {
+    throw new ContainerError('shortNameTooLong', `short_name exceeds ${MAX_SHORT_NAME_LEN} chars`)
+  }
+  const tags = asStringArray(rec.tags)
+  if (tags.length > MAX_TAGS) {
+    throw new ContainerError('tagsTooMany', `at most ${MAX_TAGS} tags`)
+  }
+  return {
+    name,
+    short_name: shortName || undefined,
+    summary,
+    category: asString(rec.category).trim(),
+    tags,
+  }
+}
+
+function parseExpertManifest(rec: Record<string, unknown>): ParsedExpert {
+  const meta = validateCommonMeta(rec)
+  const instruction = asString(rec.instruction).trim()
+  if (!instruction) {
+    throw new ContainerError('instructionRequired', 'instruction is required')
+  }
+  return {
+    kind: 'agent',
+    ...meta,
+    instruction,
+    mcp_config: validateMcpConfig(rec.mcp_config, 'expert'),
+    skills: normalizeSkills(rec.skills, 'expert'),
+  }
+}
+
+function parseSquadManifest(rec: Record<string, unknown>): ParsedSquad {
+  const meta = validateCommonMeta(rec)
+  const rawMembers = rec.members
+  if (!Array.isArray(rawMembers) || rawMembers.length === 0) {
+    throw new ContainerError('membersRequired', 'squad requires at least one member')
+  }
+  if (rawMembers.length > MAX_MEMBERS) {
+    throw new ContainerError('membersTooMany', `at most ${MAX_MEMBERS} members`)
+  }
+  const strategies = asStringArray(rec.strategies)
+  if (strategies.length > MAX_STRATEGIES) {
+    throw new ContainerError('strategiesTooMany', `at most ${MAX_STRATEGIES} strategies`)
+  }
+  const seenKeys = new Set<string>()
+  const members: ParsedSquadMember[] = rawMembers.map((m, i) => {
+    const rmem = (m ?? {}) as Record<string, unknown>
+    const name = asString(rmem.name).trim()
+    if (!name) throw new ContainerError('memberNameRequired', `members[${i}].name is required`)
+    const memberKey = asString(rmem.member_key).trim() || `member-${i + 1}`
+    if (seenKeys.has(memberKey)) {
+      throw new ContainerError('memberKeyDup', `duplicate member_key "${memberKey}"`)
+    }
+    seenKeys.add(memberKey)
+    const instruction = asString(rmem.instruction).trim()
+    if (!instruction) {
+      throw new ContainerError('memberInstructionRequired', `members[${i}].instruction is required`)
+    }
+    // The backend's buildMembers rejects an empty role (ErrInvalidMembers),
+    // so surface it here instead of after the skill packages have uploaded.
+    const role = asString(rmem.role).trim()
+    if (!role) {
+      throw new ContainerError('memberRoleRequired', `members[${i}].role is required`)
+    }
+    return {
+      member_key: memberKey,
+      name,
+      role,
+      is_leader: rmem.is_leader === true,
+      instruction,
+      mcp_config: validateMcpConfig(rmem.mcp_config, `members[${i}]`),
+      skills: normalizeSkills(rmem.skills, `members[${i}]`),
+    }
+  })
+  const leaderCount = members.filter((m) => m.is_leader).length
+  if (leaderCount !== 1) {
+    throw new ContainerError(
+      'leaderCount',
+      `squad must have exactly one leader (found ${leaderCount})`
+    )
+  }
+  const leaderMember = members.find((m) => m.is_leader)!
+  const depsRaw = (rec.dependencies ?? {}) as Record<string, unknown>
+  return {
+    kind: 'squad',
+    ...meta,
+    leader: asString(rec.leader).trim() || leaderMember.name,
+    strategies,
+    dependencies: {
+      blocking: asStringArray(depsRaw.blocking),
+      recommended: asStringArray(depsRaw.recommended),
+    },
+    permission: asString(rec.permission).trim(),
+    members,
+  }
+}
+
+/** Parse + validate a manifest object of the given kind. Pure — no I/O. */
+export function parseManifest(kind: ExpertKindLike, raw: unknown): ParsedManifest {
+  if (raw == null || typeof raw !== 'object') {
+    throw new ContainerError('manifestInvalid', 'manifest is not a JSON object')
+  }
+  const rec = raw as Record<string, unknown>
+  return kind === 'squad' ? parseSquadManifest(rec) : parseExpertManifest(rec)
+}
+
+type ExpertKindLike = 'agent' | 'squad'
+
+// ─── Async container (zip) parsing ───────────────────────────────────────────
+
+/**
+ * Unzip a container, locate its manifest, validate it, and resolve every
+ * referenced skill package into a Blob. Throws ContainerError on any problem.
+ */
+export async function parseExpertContainer(file: File | Blob): Promise<ParsedContainer> {
+  let zip: JSZip
+  try {
+    zip = await JSZip.loadAsync(file)
+  } catch {
+    throw new ContainerError('zipInvalid', 'file is not a valid zip archive')
+  }
+
+  const expertJson = zip.file('expert.json')
+  const squadJson = zip.file('squad.json')
+  if (expertJson && squadJson) {
+    throw new ContainerError('manifestAmbiguous', 'container has both expert.json and squad.json')
+  }
+  const manifestFile = expertJson ?? squadJson
+  if (!manifestFile) {
+    throw new ContainerError('manifestMissing', 'container has no expert.json or squad.json')
+  }
+  const kind: ExpertKindLike = squadJson ? 'squad' : 'agent'
+
+  let rawManifest: unknown
+  try {
+    rawManifest = JSON.parse(await manifestFile.async('string'))
+  } catch {
+    throw new ContainerError('manifestParse', 'manifest JSON is malformed')
+  }
+
+  const manifest = parseManifest(kind, rawManifest)
+
+  // Collect the set of referenced skill files (expert or all squad members).
+  const refs: ParsedSkill[] =
+    manifest.kind === 'squad'
+      ? manifest.members.flatMap((m) => m.skills)
+      : manifest.skills
+
+  const skillFiles = new Map<string, ResolvedSkillFile>()
+  for (const skill of refs) {
+    if (!skill.file || skillFiles.has(skill.file)) continue
+    const entry = zip.file(skill.file)
+    if (!entry) {
+      throw new ContainerError('skillFileMissing', `bundled package "${skill.file}" not found in container`)
+    }
+    const blob = await entry.async('blob')
+    if (blob.size > MAX_SKILL_PACKAGE_BYTES) {
+      throw new ContainerError('skillFileTooLarge', `package "${skill.file}" exceeds 20 MiB`)
+    }
+    skillFiles.set(skill.file, {
+      skillName: skill.name,
+      path: skill.file,
+      fileName: basename(skill.file),
+      blob,
+    })
+  }
+
+  return { manifest, skillFiles }
+}

--- a/src/pages/ExpertMarket/submitContainer.test.ts
+++ b/src/pages/ExpertMarket/submitContainer.test.ts
@@ -1,17 +1,43 @@
 /**
- * Coverage for the pure manifest → create-request builders, in particular the
- * shared-package name-collision fix: two skills referencing the same bundled
- * file must each keep their own name while reusing one upload_object_key.
+ * Coverage for the upload orchestration + pure request builders. The
+ * load-bearing contract: the server consumes each upload_object_key while
+ * storing it (single-use), so two skills referencing the same bundled file
+ * must produce TWO uploads with distinct keys — and re-upload PATCH bodies
+ * must omit fields the container doesn't declare (present-but-empty clears
+ * server-side).
  */
 
 import { describe, expect, it } from 'vitest'
 import type { SkillWrite } from '../../api/expert'
-import { buildExpertParams, buildSquadParams } from './submitContainer'
-import type { ParsedExpert, ParsedSquad } from './parseContainer'
+import {
+  buildExpertParams,
+  buildExpertPatch,
+  buildSquadParams,
+  buildSquadPatch,
+  uploadSkillWrites,
+  uploadSquadSkillWrites,
+  type SkillUploader,
+} from './submitContainer'
+import type { ParsedExpert, ParsedSquad, ResolvedSkillFile } from './parseContainer'
 
-const uploaded = new Map<string, SkillWrite>([
-  ['skills/x.zip', { name: '清单A', upload_object_key: 'k-x', file_name: 'x.zip', file_size: 10 }],
+const skillFiles = new Map<string, ResolvedSkillFile>([
+  [
+    'skills/x.zip',
+    { skillName: '清单A', path: 'skills/x.zip', fileName: 'x.zip', blob: new Blob(['zip']) },
+  ],
 ])
+
+/** Fake presign+PUT that returns a fresh key per call. */
+function fakeUploader(): { upload: SkillUploader; calls: string[] } {
+  const calls: string[] = []
+  return {
+    calls,
+    upload: async (name, _blob, fileName) => {
+      calls.push(name)
+      return { name, upload_object_key: `k-${calls.length}`, file_name: fileName, file_size: 3 }
+    },
+  }
+}
 
 function expert(skills: ParsedExpert['skills']): ParsedExpert {
   return {
@@ -26,23 +52,64 @@ function expert(skills: ParsedExpert['skills']): ParsedExpert {
   }
 }
 
-describe('buildExpertParams', () => {
-  it('gives each skill sharing one package its own name + the shared key', () => {
-    const params = buildExpertParams(
-      expert([
+function squad(overrides: Partial<ParsedSquad> = {}): ParsedSquad {
+  return {
+    kind: 'squad',
+    name: 'sq',
+    summary: 's',
+    category: '营销策划',
+    tags: [],
+    leader: 'L',
+    strategies: ['a'],
+    dependencies: { blocking: [], recommended: [] },
+    permission: '',
+    members: [
+      { member_key: 'l', name: 'L', role: 'leader', is_leader: true, instruction: 'i', mcp_config: '{}', skills: [{ name: '清单A', file: 'skills/x.zip' }] },
+      { member_key: 'm', name: 'M', role: 'ic', is_leader: false, instruction: 'i', mcp_config: '{}', skills: [] },
+    ],
+    ...overrides,
+  }
+}
+
+describe('uploadSkillWrites', () => {
+  it('uploads once PER REFERENCE — a shared package gets distinct keys', async () => {
+    const { upload, calls } = fakeUploader()
+    const writes = await uploadSkillWrites(
+      [
         { name: '清单A', file: 'skills/x.zip' },
         { name: '清单B', file: 'skills/x.zip' },
-      ]),
-      uploaded
+      ],
+      skillFiles,
+      upload
     )
-    expect(params.skills).toEqual([
-      { name: '清单A', upload_object_key: 'k-x', file_name: 'x.zip', file_size: 10 },
-      { name: '清单B', upload_object_key: 'k-x', file_name: 'x.zip', file_size: 10 },
-    ])
+    expect(calls).toEqual(['清单A', '清单B'])
+    expect(writes.map((w) => w.upload_object_key)).toEqual(['k-1', 'k-2'])
+    expect(writes.map((w) => w.name)).toEqual(['清单A', '清单B'])
   })
 
-  it('keeps name-only skills as name-only, and applies meta overrides', () => {
-    const params = buildExpertParams(expert([{ name: 'solo' }]), new Map(), {
+  it('passes name-only skills through without uploading', async () => {
+    const { upload, calls } = fakeUploader()
+    const writes = await uploadSkillWrites([{ name: 'solo' }], skillFiles, upload)
+    expect(calls).toEqual([])
+    expect(writes).toEqual([{ name: 'solo' }])
+  })
+})
+
+describe('uploadSquadSkillWrites', () => {
+  it('uploads per member reference, even across members sharing one package', async () => {
+    const { upload, calls } = fakeUploader()
+    const s = squad()
+    s.members[1].skills = [{ name: '清单A', file: 'skills/x.zip' }]
+    const memberSkills = await uploadSquadSkillWrites(s, skillFiles, upload)
+    expect(calls).toHaveLength(2)
+    expect(memberSkills.get('l')![0].upload_object_key).toBe('k-1')
+    expect(memberSkills.get('m')![0].upload_object_key).toBe('k-2')
+  })
+})
+
+describe('buildExpertParams / buildSquadParams', () => {
+  it('embeds resolved skills and applies meta overrides', () => {
+    const params = buildExpertParams(expert([]), [{ name: 'solo' }], {
       category: '数据洞察',
       tags: ['override'],
     })
@@ -52,34 +119,58 @@ describe('buildExpertParams', () => {
   })
 
   it('falls back to the manifest category/tags when no override', () => {
-    const params = buildExpertParams(expert([]), new Map())
+    const params = buildExpertParams(expert([]), [])
     expect(params.category).toBe('研发工具')
     expect(params.tags).toEqual(['t'])
   })
-})
 
-describe('buildSquadParams', () => {
-  it('resolves each member’s skills independently', () => {
-    const squad: ParsedSquad = {
-      kind: 'squad',
-      name: 'sq',
-      summary: 's',
-      category: '营销策划',
-      tags: [],
-      leader: 'L',
-      strategies: ['a'],
-      dependencies: { blocking: [], recommended: [] },
-      permission: '',
-      members: [
-        { member_key: 'l', name: 'L', role: 'leader', is_leader: true, instruction: 'i', mcp_config: '{}', skills: [{ name: '清单A', file: 'skills/x.zip' }] },
-        { member_key: 'm', name: 'M', role: 'ic', is_leader: false, instruction: 'i', mcp_config: '{}', skills: [] },
-      ],
-    }
-    const params = buildSquadParams(squad, uploaded)
-    expect(params.members[0].skills).toEqual([
-      { name: '清单A', upload_object_key: 'k-x', file_name: 'x.zip', file_size: 10 },
+  it('resolves each member’s skills from the per-member map', () => {
+    const memberSkills = new Map<string, SkillWrite[]>([
+      ['l', [{ name: '清单A', upload_object_key: 'k-1', file_name: 'x.zip', file_size: 3 }]],
+      ['m', []],
     ])
+    const params = buildSquadParams(squad(), memberSkills)
+    expect(params.members[0].skills).toEqual(memberSkills.get('l'))
     expect(params.members[1].skills).toEqual([])
     expect(params.leader).toBe('L')
+  })
+})
+
+describe('patch builders omit undeclared fields', () => {
+  it('buildExpertPatch drops empty category/tags (present-but-empty clears server-side)', () => {
+    const m = expert([])
+    m.category = ''
+    m.tags = []
+    const p = buildExpertPatch(m, [])
+    expect('category' in p).toBe(false)
+    expect('tags' in p).toBe(false)
+    expect(p.name).toBe('e')
+    expect(p.skills).toEqual([])
+  })
+
+  it('buildExpertPatch keeps declared category/tags', () => {
+    const p = buildExpertPatch(expert([]), [])
+    expect(p.category).toBe('研发工具')
+    expect(p.tags).toEqual(['t'])
+  })
+
+  it('buildSquadPatch drops empty tags/strategies/dependencies/permission but keeps members', () => {
+    const s = squad({ category: '', strategies: [], permission: '' })
+    const p = buildSquadPatch(s, new Map())
+    expect('category' in p).toBe(false)
+    expect('tags' in p).toBe(false)
+    expect('strategies' in p).toBe(false)
+    expect('dependencies' in p).toBe(false)
+    expect('permission' in p).toBe(false)
+    expect(p.members).toHaveLength(2)
+    expect(p.leader).toBe('L')
+  })
+
+  it('buildSquadPatch keeps declared squad-only fields', () => {
+    const s = squad({ permission: '读写', dependencies: { blocking: ['git'], recommended: [] } })
+    const p = buildSquadPatch(s, new Map())
+    expect(p.strategies).toEqual(['a'])
+    expect(p.permission).toBe('读写')
+    expect(p.dependencies).toEqual({ blocking: ['git'], recommended: [] })
   })
 })

--- a/src/pages/ExpertMarket/submitContainer.test.ts
+++ b/src/pages/ExpertMarket/submitContainer.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Coverage for the pure manifest → create-request builders, in particular the
+ * shared-package name-collision fix: two skills referencing the same bundled
+ * file must each keep their own name while reusing one upload_object_key.
+ */
+
+import { describe, expect, it } from 'vitest'
+import type { SkillWrite } from '../../api/expert'
+import { buildExpertParams, buildSquadParams } from './submitContainer'
+import type { ParsedExpert, ParsedSquad } from './parseContainer'
+
+const uploaded = new Map<string, SkillWrite>([
+  ['skills/x.zip', { name: '清单A', upload_object_key: 'k-x', file_name: 'x.zip', file_size: 10 }],
+])
+
+function expert(skills: ParsedExpert['skills']): ParsedExpert {
+  return {
+    kind: 'agent',
+    name: 'e',
+    summary: 's',
+    category: '研发工具',
+    tags: ['t'],
+    instruction: 'i',
+    mcp_config: '{}',
+    skills,
+  }
+}
+
+describe('buildExpertParams', () => {
+  it('gives each skill sharing one package its own name + the shared key', () => {
+    const params = buildExpertParams(
+      expert([
+        { name: '清单A', file: 'skills/x.zip' },
+        { name: '清单B', file: 'skills/x.zip' },
+      ]),
+      uploaded
+    )
+    expect(params.skills).toEqual([
+      { name: '清单A', upload_object_key: 'k-x', file_name: 'x.zip', file_size: 10 },
+      { name: '清单B', upload_object_key: 'k-x', file_name: 'x.zip', file_size: 10 },
+    ])
+  })
+
+  it('keeps name-only skills as name-only, and applies meta overrides', () => {
+    const params = buildExpertParams(expert([{ name: 'solo' }]), new Map(), {
+      category: '数据洞察',
+      tags: ['override'],
+    })
+    expect(params.skills).toEqual([{ name: 'solo' }])
+    expect(params.category).toBe('数据洞察')
+    expect(params.tags).toEqual(['override'])
+  })
+
+  it('falls back to the manifest category/tags when no override', () => {
+    const params = buildExpertParams(expert([]), new Map())
+    expect(params.category).toBe('研发工具')
+    expect(params.tags).toEqual(['t'])
+  })
+})
+
+describe('buildSquadParams', () => {
+  it('resolves each member’s skills independently', () => {
+    const squad: ParsedSquad = {
+      kind: 'squad',
+      name: 'sq',
+      summary: 's',
+      category: '营销策划',
+      tags: [],
+      leader: 'L',
+      strategies: ['a'],
+      dependencies: { blocking: [], recommended: [] },
+      permission: '',
+      members: [
+        { member_key: 'l', name: 'L', role: 'leader', is_leader: true, instruction: 'i', mcp_config: '{}', skills: [{ name: '清单A', file: 'skills/x.zip' }] },
+        { member_key: 'm', name: 'M', role: 'ic', is_leader: false, instruction: 'i', mcp_config: '{}', skills: [] },
+      ],
+    }
+    const params = buildSquadParams(squad, uploaded)
+    expect(params.members[0].skills).toEqual([
+      { name: '清单A', upload_object_key: 'k-x', file_name: 'x.zip', file_size: 10 },
+    ])
+    expect(params.members[1].skills).toEqual([])
+    expect(params.leader).toBe('L')
+  })
+})

--- a/src/pages/ExpertMarket/submitContainer.ts
+++ b/src/pages/ExpertMarket/submitContainer.ts
@@ -1,14 +1,21 @@
 /**
- * Turns a parsed container into a create request: presign-upload every bundled
- * skill package, then assemble the flat manifest the admin API expects. The
- * build* functions are pure (given the uploaded-key map) so the wiring stays
- * testable and the modal only orchestrates.
+ * Turns a parsed container into create/patch requests.
+ *
+ * Upload orchestration performs ONE presign+PUT per file-bearing skill
+ * REFERENCE: the server consumes and deletes each upload_object_key while
+ * storing the package (single-use temp object), so two skills referencing the
+ * same bundled file need two uploaded objects — the Blob itself is still
+ * unzipped/deduped once per container path by parseContainer. The build*
+ * functions stay pure (given resolved SkillWrite lists) so the wiring is
+ * testable and callers only orchestrate.
  */
 
 import {
   uploadExpertSkill,
   type CreateExpertParams,
   type CreateSquadParams,
+  type PatchExpertParams,
+  type PatchSquadParams,
   type SkillWrite,
 } from '../../api/expert'
 import type {
@@ -18,36 +25,40 @@ import type {
   ResolvedSkillFile,
 } from './parseContainer'
 
-/** Presign + PUT each bundled package. Returns a container-path → SkillWrite
- *  map. `onProgress(done,total)` fires after each upload for a progress line. */
-export async function uploadSkillFiles(
+/** Injected so tests can fake the presign+PUT round-trip, and so callers can
+ *  thread an AbortSignal through uploadExpertSkill. */
+export type SkillUploader = (
+  name: string,
+  blob: Blob,
+  fileName: string
+) => Promise<SkillWrite>
+
+/** Presign + PUT one object per file-bearing reference in `skills`; name-only
+ *  references pass through as `{name}`. */
+export async function uploadSkillWrites(
+  skills: ParsedSkill[],
   skillFiles: Map<string, ResolvedSkillFile>,
-  onProgress?: (done: number, total: number) => void
-): Promise<Map<string, SkillWrite>> {
-  const out = new Map<string, SkillWrite>()
-  const total = skillFiles.size
-  let done = 0
-  for (const [path, f] of skillFiles) {
-    const written = await uploadExpertSkill(f.skillName, f.blob, f.fileName)
-    out.set(path, written)
-    done += 1
-    onProgress?.(done, total)
+  upload: SkillUploader = uploadExpertSkill
+): Promise<SkillWrite[]> {
+  const out: SkillWrite[] = []
+  for (const s of skills) {
+    const f = s.file ? skillFiles.get(s.file) : undefined
+    out.push(f ? await upload(s.name, f.blob, f.fileName) : { name: s.name })
   }
   return out
 }
 
-function resolveSkills(
-  skills: ParsedSkill[],
-  uploaded: Map<string, SkillWrite>
-): SkillWrite[] {
-  return skills.map((s) => {
-    if (!s.file) return { name: s.name }
-    const up = uploaded.get(s.file)
-    // Two skills may reference the same bundled package (uploaded once, keyed by
-    // path). Reuse its upload_object_key but keep THIS skill's own name — the
-    // uploaded entry carries only the first referencing skill's name.
-    return up ? { ...up, name: s.name } : { name: s.name }
-  })
+/** Squad twin: per-member SkillWrite lists keyed by member_key. */
+export async function uploadSquadSkillWrites(
+  m: ParsedSquad,
+  skillFiles: Map<string, ResolvedSkillFile>,
+  upload: SkillUploader = uploadExpertSkill
+): Promise<Map<string, SkillWrite[]>> {
+  const out = new Map<string, SkillWrite[]>()
+  for (const mem of m.members) {
+    out.set(mem.member_key, await uploadSkillWrites(mem.skills, skillFiles, upload))
+  }
+  return out
 }
 
 export interface MetaOverride {
@@ -57,7 +68,7 @@ export interface MetaOverride {
 
 export function buildExpertParams(
   m: ParsedExpert,
-  uploaded: Map<string, SkillWrite>,
+  skills: SkillWrite[],
   override: MetaOverride = {}
 ): CreateExpertParams {
   // short_name is server-owned (derived from name) — never sent on write.
@@ -68,13 +79,13 @@ export function buildExpertParams(
     tags: override.tags ?? m.tags,
     instruction: m.instruction,
     mcp_config: m.mcp_config,
-    skills: resolveSkills(m.skills, uploaded),
+    skills,
   }
 }
 
 export function buildSquadParams(
   m: ParsedSquad,
-  uploaded: Map<string, SkillWrite>,
+  memberSkills: Map<string, SkillWrite[]>,
   override: MetaOverride = {}
 ): CreateSquadParams {
   return {
@@ -93,7 +104,56 @@ export function buildSquadParams(
       is_leader: mem.is_leader,
       instruction: mem.instruction,
       mcp_config: mem.mcp_config,
-      skills: resolveSkills(mem.skills, uploaded),
+      skills: memberSkills.get(mem.member_key) ?? [],
     })),
   }
+}
+
+// ─── PATCH builders (re-upload) ──────────────────────────────────────────────
+//
+// The server's patch semantics are pointer-based: a present-but-empty value
+// CLEARS the stored field. parseContainer normalizes missing manifest fields
+// to empty values, so a container that simply omits tags/strategies/… must
+// not wipe curated data — omit those fields from the PATCH body instead.
+
+export function buildExpertPatch(m: ParsedExpert, skills: SkillWrite[]): PatchExpertParams {
+  const p: PatchExpertParams = {
+    name: m.name,
+    summary: m.summary,
+    instruction: m.instruction,
+    mcp_config: m.mcp_config,
+    skills,
+  }
+  if (m.category) p.category = m.category
+  if (m.tags.length > 0) p.tags = m.tags
+  return p
+}
+
+export function buildSquadPatch(
+  m: ParsedSquad,
+  memberSkills: Map<string, SkillWrite[]>
+): PatchSquadParams {
+  const p: PatchSquadParams = {
+    name: m.name,
+    summary: m.summary,
+    leader: m.leader,
+    // Members always replace wholesale — that is the point of a re-upload.
+    members: m.members.map((mem) => ({
+      member_key: mem.member_key,
+      name: mem.name,
+      role: mem.role,
+      is_leader: mem.is_leader,
+      instruction: mem.instruction,
+      mcp_config: mem.mcp_config,
+      skills: memberSkills.get(mem.member_key) ?? [],
+    })),
+  }
+  if (m.category) p.category = m.category
+  if (m.tags.length > 0) p.tags = m.tags
+  if (m.strategies.length > 0) p.strategies = m.strategies
+  if (m.dependencies.blocking.length > 0 || m.dependencies.recommended.length > 0) {
+    p.dependencies = m.dependencies
+  }
+  if (m.permission) p.permission = m.permission
+  return p
 }

--- a/src/pages/ExpertMarket/submitContainer.ts
+++ b/src/pages/ExpertMarket/submitContainer.ts
@@ -1,0 +1,99 @@
+/**
+ * Turns a parsed container into a create request: presign-upload every bundled
+ * skill package, then assemble the flat manifest the admin API expects. The
+ * build* functions are pure (given the uploaded-key map) so the wiring stays
+ * testable and the modal only orchestrates.
+ */
+
+import {
+  uploadExpertSkill,
+  type CreateExpertParams,
+  type CreateSquadParams,
+  type SkillWrite,
+} from '../../api/expert'
+import type {
+  ParsedExpert,
+  ParsedSkill,
+  ParsedSquad,
+  ResolvedSkillFile,
+} from './parseContainer'
+
+/** Presign + PUT each bundled package. Returns a container-path → SkillWrite
+ *  map. `onProgress(done,total)` fires after each upload for a progress line. */
+export async function uploadSkillFiles(
+  skillFiles: Map<string, ResolvedSkillFile>,
+  onProgress?: (done: number, total: number) => void
+): Promise<Map<string, SkillWrite>> {
+  const out = new Map<string, SkillWrite>()
+  const total = skillFiles.size
+  let done = 0
+  for (const [path, f] of skillFiles) {
+    const written = await uploadExpertSkill(f.skillName, f.blob, f.fileName)
+    out.set(path, written)
+    done += 1
+    onProgress?.(done, total)
+  }
+  return out
+}
+
+function resolveSkills(
+  skills: ParsedSkill[],
+  uploaded: Map<string, SkillWrite>
+): SkillWrite[] {
+  return skills.map((s) => {
+    if (!s.file) return { name: s.name }
+    const up = uploaded.get(s.file)
+    // Two skills may reference the same bundled package (uploaded once, keyed by
+    // path). Reuse its upload_object_key but keep THIS skill's own name — the
+    // uploaded entry carries only the first referencing skill's name.
+    return up ? { ...up, name: s.name } : { name: s.name }
+  })
+}
+
+export interface MetaOverride {
+  category?: string
+  tags?: string[]
+}
+
+export function buildExpertParams(
+  m: ParsedExpert,
+  uploaded: Map<string, SkillWrite>,
+  override: MetaOverride = {}
+): CreateExpertParams {
+  // short_name is server-owned (derived from name) — never sent on write.
+  return {
+    name: m.name,
+    summary: m.summary,
+    category: override.category ?? m.category,
+    tags: override.tags ?? m.tags,
+    instruction: m.instruction,
+    mcp_config: m.mcp_config,
+    skills: resolveSkills(m.skills, uploaded),
+  }
+}
+
+export function buildSquadParams(
+  m: ParsedSquad,
+  uploaded: Map<string, SkillWrite>,
+  override: MetaOverride = {}
+): CreateSquadParams {
+  return {
+    name: m.name,
+    summary: m.summary,
+    category: override.category ?? m.category,
+    tags: override.tags ?? m.tags,
+    leader: m.leader,
+    strategies: m.strategies,
+    dependencies: m.dependencies,
+    permission: m.permission,
+    members: m.members.map((mem) => ({
+      member_key: mem.member_key,
+      name: mem.name,
+      role: mem.role,
+      is_leader: mem.is_leader,
+      instruction: mem.instruction,
+      mcp_config: mem.mcp_config,
+      skills: resolveSkills(mem.skills, uploaded),
+    })),
+  }
+}

--- a/src/pages/SkillMarket/CategoryTab.tsx
+++ b/src/pages/SkillMarket/CategoryTab.tsx
@@ -128,8 +128,8 @@ export default function CategoryTab() {
             <Popconfirm
               title={t('category.deleteConfirm')}
               onConfirm={() => handleDelete(record)}
-              okText={t('common:confirm')}
-              cancelText={t('common:cancel')}
+              okText={t('common:action.confirm')}
+              cancelText={t('common:action.cancel')}
             >
               <Button type="link" size="small" danger>
                 {t('category.delete')}

--- a/src/pages/SkillMarket/SkillTab.tsx
+++ b/src/pages/SkillMarket/SkillTab.tsx
@@ -215,8 +215,8 @@ export default function SkillTab() {
               <Popconfirm
                 title={t('skill.deleteConfirm')}
                 onConfirm={() => handleDelete(record)}
-                okText={t('common:confirm')}
-                cancelText={t('common:cancel')}
+                okText={t('common:action.confirm')}
+                cancelText={t('common:action.cancel')}
               >
                 <Button type="link" size="small" danger>
                   {t('skill.delete')}


### PR DESCRIPTION
## Summary

Adds the 专家市场 (Expert Market) admin page, managing platform-provided (`visibility=system`) experts and squads against octo-marketplace's new `/api/v1/admin/{experts,squads,expert_categories,expert_tags}` surface:

- **Batch import**: drop one or many container zips; each parses client-side (`expert.json`/`squad.json` + bundled Agent-Skill packages) into a review table with per-row category/tags, per-row status, and retryable failures. Container zips are never uploaded — only bundled skill packages, via the presigned PUT flow.
- **Detail drawers** with SKILL.md content viewers (expert skills and squad member skills), container re-upload (spec replacement), and inline delete.
- **Category management** (create/rename/sort; `icon_key` echoed back so renames don't wipe seeded icons).
- **AI prompts**: copyable per-kind prompts so any LLM can generate an importable package; format rules mirror `parseContainer.ts` validation.
- A second commit fixes two pre-existing bugs surfaced by review: `mcp.ts` sent `limit/offset` to a `page/page_size` handler (page 2 returned page 1), and SkillMarket's delete confirms used nonexistent `common:confirm/cancel` i18n keys.

## Linked Spec

octo-marketplace [`.octospec/tasks/expert-catalog-v1/brief.md`](https://github.com/l-s-c/octo-marketplace/blob/feat/expert-marketplace/.octospec/tasks/expert-catalog-v1/brief.md) (admin surface implemented in octo-marketplace branch `feat/expert-marketplace`, contract in [`docs/api/expert-v1.md` §9](https://github.com/l-s-c/octo-marketplace/blob/feat/expert-marketplace/docs/api/expert-v1.md); the dedicated expert-admin follow-up brief is still to be written).

## How verified

- `tsc --noEmit` clean; full vitest suite **107/107 passing**, including 24 unit tests for the container parser/submitter (manifest validation, kind mismatch, member role/leader rules, path-safety, skill blob resolution, override semantics).
- End-to-end against local octo-marketplace (`127.0.0.1:8092`, dev auth): imported generated expert + squad example zips (bundled skill packages presign-uploaded, records created), viewed SKILL.md via the new admin `skill_md` endpoints, verified `skill_count` in the list, deleted and re-imported.
- An 8-angle adversarial review (line-by-line, removed-behavior, cross-file, reuse, simplification, efficiency, altitude, conventions) with per-finding verification ran over this diff; all 9 confirmed findings are fixed in this PR (pagination, capability gate, empty-category dead end, icon_key wipe, parse-race file discard, member-role contract, i18n keys, pnpm build approval, stale skill-viewer state).

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?** Before: the admin console had no surface for system experts/squads; the capability model didn't include `expert.*`. After: a new `expert.read`/`expert.write`-gated route drives marketplace's SuperAdmin-gated `/admin` endpoints through the shared `marketplaceApi` client (token + Accept-Language + error envelope). Writes follow marketplace's strict-decoder contract exactly: no `short_name` (server-derived), category must resolve to an existing name, squad members need non-empty `name/role/instruction` and exactly one leader. The only shared-code change with blast radius outside the new page is `putPresignedFile`: in dev builds it rewrites marketplace built-in-storage presign URLs (`http://127.0.0.1/…/_storage/…`) through the `/market` vite proxy; https/OSS URLs and prod builds are untouched.
2. **What could break?** MCP icon upload and system-skill upload share `putPresignedFile` — the rewrite is scoped to `import.meta.env.DEV` + localhost + the `/api/v1/_storage/` path prefix, and falls back to the raw URL otherwise, so prod behavior is byte-identical. The `mcp.ts` pagination fix changes the wire query for the system-MCP list; the handler defaulted to page 1 before, so the only observable change is that page N now actually returns page N. The capability gate means managers without `expert.read` no longer see the nav entry — intended.
3. **How do you know it works?** The container parser/submitter carry unit tests for every rejection path the server enforces; the import/skill-view/delete flows were exercised end-to-end against a locally running octo-marketplace with real presigned uploads (records visible in octo-web's market afterwards); the review findings each carry a verifier-confirmed failure scenario and the fix was re-tested (107-test suite green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #137
