### PR TITLE
feat(changelog): offer the desktop installers above the timeline

### DIFF
--- a/src/pages/Changelog/DesktopDownloadBar.test.tsx
+++ b/src/pages/Changelog/DesktopDownloadBar.test.tsx
@@ -1,0 +1,90 @@
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { DesktopDownload } from './utils'
+
+// The page imports antd for its shell; the band itself uses none of it.
+vi.mock('antd', async () => {
+  const React = await vi.importActual<typeof import('react')>('react')
+  const Passthrough = ({ children }: { children?: React.ReactNode }) => React.createElement('div', null, children)
+  return {
+    Tabs: Passthrough,
+    Spin: Passthrough,
+    Empty: Passthrough,
+    Tag: Passthrough,
+    Tooltip: Passthrough,
+    ConfigProvider: Passthrough,
+    theme: { darkAlgorithm: {}, defaultAlgorithm: {} },
+  }
+})
+
+const { DesktopDownloadBar } = await import('./index')
+
+const build = (os: string, app_version: string, download_url = `https://cdn.example.com/${os}`): DesktopDownload => ({
+  os,
+  app_version,
+  download_url,
+  created_at: '2026-08-20 16:00:00',
+  is_force: 0,
+  update_desc: '',
+})
+
+describe('DesktopDownloadBar', () => {
+  let host: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    ;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+    host = document.createElement('div')
+    document.body.appendChild(host)
+    root = createRoot(host)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    host.remove()
+  })
+
+  const render = (downloads: DesktopDownload[]) => {
+    act(() => root.render(<DesktopDownloadBar downloads={downloads} />))
+    return host.textContent ?? ''
+  }
+
+  it('labels a version every offered installer shares', () => {
+    expect(render([build('windows', '1.0.0'), build('macos', '1.0.0')])).toContain('v1.0.0 · 支持')
+  })
+
+  it('says no version when one platform is on a prerelease and another is not', () => {
+    // Both format to 1.0.0, so a formatted comparison would badge the RC as stable
+    // above the button that hands it over.
+    for (const offers of [
+      [build('windows', '1.0.0'), build('macos', '1.0.0-rc1')],
+      [build('windows', '1.0.0-rc1'), build('macos', '1.0.0')],
+    ]) {
+      const text = render(offers)
+      expect(text).not.toContain('v1.0.0')
+      expect(text).toContain('支持')
+    }
+  })
+
+  it('keeps a lone prerelease verbatim', () => {
+    expect(render([build('macos', '1.0.1-rc1')])).toContain('1.0.1-rc1 · 支持 macOS')
+  })
+
+  it('renders one link per installer, and nothing at all without one', () => {
+    render([build('windows', '1.0.0'), build('macos', '1.0.0')])
+    expect(Array.from(host.querySelectorAll('a')).map((a) => a.getAttribute('href'))).toEqual([
+      'https://cdn.example.com/windows',
+      'https://cdn.example.com/macos',
+    ])
+
+    expect(render([])).toBe('')
+  })
+
+  it('drops an installer whose URL should never reach an href', () => {
+    render([build('windows', '1.0.0', 'javascript:alert(1)'), build('macos', '1.0.0')])
+    expect(Array.from(host.querySelectorAll('a')).map((a) => a.getAttribute('href'))).toEqual([
+      'https://cdn.example.com/macos',
+    ])
+  })
+})

--- a/src/pages/Changelog/index.tsx
+++ b/src/pages/Changelog/index.tsx
@@ -79,6 +79,11 @@ const tabItems = [
 ]
 
 const css = `
+.download-link:focus-visible {
+  outline: 2px solid var(--brand-solid);
+  outline-offset: 2px;
+  border-radius: 6px;
+}
 @keyframes fadeSlideIn {
   from { opacity: 0; transform: translateY(12px); }
   to   { opacity: 1; transform: translateY(0); }
@@ -583,7 +588,7 @@ function DesktopDownloads({ builds, compact, large }: { builds: DesktopBuild[]; 
               : { ...base, color: 'var(--brand-solid)', border: '1px solid var(--brand-solid)', padding: large ? '9px 20px' : '4px 12px', borderRadius: large ? radius.md : radius.sm }
 
         return (
-          <a key={build.os} href={build.href} target="_blank" rel="noopener noreferrer" style={style}>
+          <a key={build.os} className="download-link" href={build.href} target="_blank" rel="noopener noreferrer" style={style}>
             <DownloadOutlined />
             下载 {platformConfig[build.os]?.label ?? build.os}
           </a>
@@ -742,11 +747,13 @@ function StructuredChanges({ desc }: { desc: string }) {
  * deploys within days, so the installer cannot only live where its release sits —
  * one button per OS that has a build, the visitor's own promoted.
  */
-function DesktopDownloadBar({ downloads }: { downloads: DesktopDownload[] }) {
+export function DesktopDownloadBar({ downloads }: { downloads: DesktopDownload[] }) {
   if (downloads.length === 0) return null
 
   const versionLabel = offerVersionLabel(downloads)
-  const platforms = downloads.map((build) => platformConfig[build.os]?.label ?? build.os).join('、')
+  // Same order the buttons take, so the line does not read "Windows、macOS" above a
+  // macOS-first row.
+  const platforms = orderBuilds(downloads, viewerOS).map((build) => platformConfig[build.os]?.label ?? build.os).join('、')
 
   return (
     // Labelled: these are the first focusable things on the page, ahead of its <h1>.
@@ -776,7 +783,8 @@ function DesktopDownloadBar({ downloads }: { downloads: DesktopDownload[] }) {
       </span>
 
       <div style={{ minWidth: 0 }}>
-        <div style={{
+        <h2 style={{
+          margin: 0,
           fontSize: font.size.lg,
           fontWeight: font.weight.bold,
           color: colors.text.primary,
@@ -784,7 +792,7 @@ function DesktopDownloadBar({ downloads }: { downloads: DesktopDownload[] }) {
           lineHeight: 1.3,
         }}>
           Octo 桌面端
-        </div>
+        </h2>
         <div style={{ fontSize: font.size.base, color: colors.text.secondary, marginTop: 2 }}>
           {versionLabel && `${versionLabel} · `}支持 {platforms}
         </div>
@@ -1130,6 +1138,7 @@ function LatestReleaseSpotlight({ item, severity, hideDownloads }: { item: Relea
         <ReleaseNotes blocks={blocks} />
       </div>
 
+      {(stats.added > 0 || stats.fixed > 0 || stats.changed > 0 || !hideDownloads) && (
       <div style={{
         display: 'flex',
         alignItems: 'center',
@@ -1183,6 +1192,7 @@ function LatestReleaseSpotlight({ item, severity, hideDownloads }: { item: Relea
           </a>
         ) : null}
       </div>
+      )}
     </div>
   )
 }

--- a/src/pages/Changelog/index.tsx
+++ b/src/pages/Changelog/index.tsx
@@ -30,8 +30,8 @@ import 'dayjs/locale/zh-cn'
 import relativeTime from 'dayjs/plugin/relativeTime'
 import api from '../../api'
 import { colors, radius, space, font } from '../../styles/tokens'
-import { parseUpdateDesc, getVersionSeverity, formatVersion, parseContributors, detectViewerOS, groupReleases, orderBuilds, noteBlocks, safeDownloadUrl, desktopPlatforms } from './utils'
-import type { VersionSeverity, ChangeCategory, Contributor, ViewerOS, AppVersion, DesktopBuild, NoteBlock, ReleaseEntry } from './utils'
+import { parseUpdateDesc, getVersionSeverity, formatVersion, parseContributors, detectViewerOS, groupReleases, orderBuilds, noteBlocks, latestDesktopDownloads, offeredAbove, safeDownloadUrl, desktopPlatforms } from './utils'
+import type { VersionSeverity, ChangeCategory, Contributor, ViewerOS, AppVersion, DesktopBuild, DesktopDownload, NoteBlock, ReleaseEntry } from './utils'
 import type { PlatformKey } from '../../styles/tokens'
 import { AnalyticsPanel } from './AnalyticsPanel'
 import { useTheme } from '../../hooks/useTheme'
@@ -541,7 +541,7 @@ function EntryBadges({ entry }: { entry: ReleaseEntry }) {
  * leads and is the only filled button; otherwise every build is offered with
  * equal weight rather than guessing at them.
  */
-function DesktopDownloads({ builds, compact }: { builds: DesktopBuild[]; compact?: boolean }) {
+function DesktopDownloads({ builds, compact, large }: { builds: DesktopBuild[]; compact?: boolean; large?: boolean }) {
   const ordered = orderBuilds(builds, viewerOS)
     .map((build) => ({ ...build, href: safeDownloadUrl(build.download_url) }))
     .filter((build): build is typeof build & { href: string } => build.href !== null)
@@ -561,22 +561,26 @@ function DesktopDownloads({ builds, compact }: { builds: DesktopBuild[]; compact
         const base: React.CSSProperties = {
           display: 'inline-flex',
           alignItems: 'center',
-          gap: 4,
-          fontSize: font.size.sm,
+          gap: large ? 6 : 4,
+          fontSize: large ? font.size.base : font.size.sm,
           fontWeight: isLead ? font.weight.semibold : font.weight.medium,
           textDecoration: 'none',
           whiteSpace: 'nowrap',
         }
-        const quiet: React.CSSProperties = { color: colors.text.secondary, textDecoration: 'underline' }
+        // Underline carries the affordance inline; at button size a border reads
+        // better next to the filled one.
+        const quiet: React.CSSProperties = large
+          ? { color: colors.text.secondary, background: colors.surface.card, border: `1px solid ${colors.surface.border}`, borderRadius: radius.md }
+          : { color: colors.text.secondary, textDecoration: 'underline' }
         const style: React.CSSProperties = compact
           ? isLead || !knowsViewer
             ? { ...base, color: 'var(--brand-solid)' }
             : { ...base, ...quiet }
           : isLead
-            ? { ...base, color: 'var(--brand-contrast)', background: 'var(--brand-solid)', border: '1px solid var(--brand-solid)', padding: '5px 14px', borderRadius: radius.sm }
+            ? { ...base, color: 'var(--brand-contrast)', background: 'var(--brand-solid)', border: '1px solid var(--brand-solid)', padding: large ? '10px 22px' : '5px 14px', borderRadius: large ? radius.md : radius.sm }
             : knowsViewer
-              ? { ...base, ...quiet, padding: '5px 10px' }
-              : { ...base, color: 'var(--brand-solid)', border: '1px solid var(--brand-solid)', padding: '4px 12px', borderRadius: radius.sm }
+              ? { ...base, ...quiet, padding: large ? '10px 14px' : '5px 10px' }
+              : { ...base, color: 'var(--brand-solid)', border: '1px solid var(--brand-solid)', padding: large ? '9px 20px' : '4px 12px', borderRadius: large ? radius.md : radius.sm }
 
         return (
           <a key={build.os} href={build.href} target="_blank" rel="noopener noreferrer" style={style}>
@@ -729,6 +733,65 @@ function StructuredChanges({ desc }: { desc: string }) {
           </div>
         )
       })}
+    </div>
+  )
+}
+
+/**
+ * Get-the-app strip above the timeline. The desktop card sinks below a week of web
+ * deploys within days, so the installer cannot only live where its release sits —
+ * one button per OS that has a build, the visitor's own promoted.
+ */
+function DesktopDownloadBar({ downloads }: { downloads: DesktopDownload[] }) {
+  if (downloads.length === 0) return null
+
+  const versions = Array.from(new Set(downloads.map((build) => build.app_version)))
+  const sharedVersion = versions.length === 1 ? versions[0] : null
+  const platforms = downloads.map((build) => platformConfig[build.os]?.label ?? build.os).join('、')
+
+  return (
+    <div style={{
+      display: 'flex',
+      alignItems: 'center',
+      gap: space[5],
+      flexWrap: 'wrap',
+      padding: `${space[6]}px ${space[6]}px`,
+      marginBottom: space[8],
+      background: 'var(--brand-bg)',
+      border: '1px solid color-mix(in srgb, var(--brand) 24%, transparent)',
+      borderRadius: radius.xl,
+    }}>
+      <span style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        width: 48,
+        height: 48,
+        flexShrink: 0,
+        borderRadius: radius.lg,
+        background: colors.surface.card,
+        border: '1px solid color-mix(in srgb, var(--brand) 18%, transparent)',
+      }}>
+        <DesktopOutlined style={{ fontSize: 22, color: 'var(--brand-text-on-bg)' }} />
+      </span>
+
+      <div style={{ minWidth: 0 }}>
+        <div style={{
+          fontSize: font.size.lg,
+          fontWeight: font.weight.bold,
+          color: colors.text.primary,
+          letterSpacing: '-0.01em',
+          lineHeight: 1.3,
+        }}>
+          Octo 桌面端
+        </div>
+        <div style={{ fontSize: font.size.base, color: colors.text.secondary, marginTop: 2 }}>
+          {sharedVersion && `v${formatVersion(sharedVersion)} · `}支持 {platforms}
+        </div>
+      </div>
+
+      <span style={{ flex: 1, minWidth: space[4] }} />
+      <DesktopDownloads builds={downloads} large />
     </div>
   )
 }
@@ -990,7 +1053,7 @@ function ChangelogItem({ item, isFirst, prevVersion, prevTimeLabel }: { item: Re
   )
 }
 
-function LatestReleaseSpotlight({ item, severity }: { item: ReleaseEntry; severity: VersionSeverity }) {
+function LatestReleaseSpotlight({ item, severity, hideDownloads }: { item: ReleaseEntry; severity: VersionSeverity; hideDownloads?: boolean }) {
   const isWeb = item.os === 'web'
   const dateObj = dayjs(item.created_at)
   const blocks = useMemo(() => noteBlocks(item, viewerOS), [item])
@@ -1094,7 +1157,7 @@ function LatestReleaseSpotlight({ item, severity }: { item: ReleaseEntry; severi
           </span>
         )}
         <span style={{ flex: 1 }} />
-        {item.builds ? (
+        {hideDownloads ? null : item.builds ? (
           <DesktopDownloads builds={item.builds} />
         ) : downloadHref ? (
           <a
@@ -1153,8 +1216,19 @@ export default function Changelog() {
     return groupReleases(raw)
   }, [data, activePlatform])
 
+  // Deliberately from `data`, not `filtered`: switching to the iOS tab should not
+  // take the desktop installer away.
+  const desktopDownloads = useMemo(() => latestDesktopDownloads(data), [data])
+
   const latestItem = filtered[0] ?? null
   const restItems = filtered.slice(1)
+
+  // When the newest release is the one the bar above is already offering, the card
+  // would repeat the same two buttons half a screen apart.
+  const spotlightOfferedAbove = useMemo(
+    () => (latestItem ? offeredAbove(latestItem, desktopDownloads) : false),
+    [latestItem, desktopDownloads],
+  )
 
   const prevVersionMap = useMemo(() => {
     const map = new Map<number, string>()
@@ -1238,6 +1312,8 @@ export default function Changelog() {
 
         <main style={{ width: '100%', maxWidth: 1040, margin: '0 auto', padding: `${space[8]}px ${space[6]}px ${space[8]}px`, boxSizing: 'border-box' }}>
 
+          {!loading && <DesktopDownloadBar downloads={desktopDownloads} />}
+
           <div style={{ marginBottom: space[6] }}>
             <h1 style={{
               fontSize: font.size['2xl'],
@@ -1258,6 +1334,7 @@ export default function Changelog() {
             <LatestReleaseSpotlight
               item={latestItem}
               severity={getVersionSeverity(latestItem.app_version, prevVersionMap.get(0))}
+              hideDownloads={spotlightOfferedAbove}
             />
           )}
 

--- a/src/pages/Changelog/index.tsx
+++ b/src/pages/Changelog/index.tsx
@@ -30,7 +30,7 @@ import 'dayjs/locale/zh-cn'
 import relativeTime from 'dayjs/plugin/relativeTime'
 import api from '../../api'
 import { colors, radius, space, font } from '../../styles/tokens'
-import { parseUpdateDesc, getVersionSeverity, formatVersion, parseContributors, detectViewerOS, groupReleases, orderBuilds, noteBlocks, latestDesktopDownloads, offeredAbove, safeDownloadUrl, desktopPlatforms } from './utils'
+import { parseUpdateDesc, getVersionSeverity, formatVersion, parseContributors, detectViewerOS, groupReleases, orderBuilds, noteBlocks, latestDesktopDownloads, offerVersionLabel, offeredAbove, safeDownloadUrl, desktopPlatforms } from './utils'
 import type { VersionSeverity, ChangeCategory, Contributor, ViewerOS, AppVersion, DesktopBuild, DesktopDownload, NoteBlock, ReleaseEntry } from './utils'
 import type { PlatformKey } from '../../styles/tokens'
 import { AnalyticsPanel } from './AnalyticsPanel'
@@ -745,17 +745,17 @@ function StructuredChanges({ desc }: { desc: string }) {
 function DesktopDownloadBar({ downloads }: { downloads: DesktopDownload[] }) {
   if (downloads.length === 0) return null
 
-  const versions = Array.from(new Set(downloads.map((build) => build.app_version)))
-  const sharedVersion = versions.length === 1 ? versions[0] : null
+  const versionLabel = offerVersionLabel(downloads)
   const platforms = downloads.map((build) => platformConfig[build.os]?.label ?? build.os).join('、')
 
   return (
-    <div style={{
+    // Labelled: these are the first focusable things on the page, ahead of its <h1>.
+    <section aria-label="下载 Octo 桌面端" style={{
       display: 'flex',
       alignItems: 'center',
       gap: space[5],
       flexWrap: 'wrap',
-      padding: `${space[6]}px ${space[6]}px`,
+      padding: space[6],
       marginBottom: space[8],
       background: 'var(--brand-bg)',
       border: '1px solid color-mix(in srgb, var(--brand) 24%, transparent)',
@@ -786,13 +786,13 @@ function DesktopDownloadBar({ downloads }: { downloads: DesktopDownload[] }) {
           Octo 桌面端
         </div>
         <div style={{ fontSize: font.size.base, color: colors.text.secondary, marginTop: 2 }}>
-          {sharedVersion && `v${formatVersion(sharedVersion)} · `}支持 {platforms}
+          {versionLabel && `${versionLabel} · `}支持 {platforms}
         </div>
       </div>
 
       <span style={{ flex: 1, minWidth: space[4] }} />
       <DesktopDownloads builds={downloads} large />
-    </div>
+    </section>
   )
 }
 

--- a/src/pages/Changelog/utils.test.ts
+++ b/src/pages/Changelog/utils.test.ts
@@ -385,6 +385,20 @@ describe('latestDesktopDownloads', () => {
     expect(offers.map((build) => build.app_version)).toEqual(['1.1.0'])
   })
 
+  it('does not let a prerelease displace the stable release it shares a number with', () => {
+    const stable = release({ os: 'windows', app_version: '2.0.0', download_url: 'https://x/stable.exe', created_at: '2026-09-01 10:00:00' })
+    const beta = release({ os: 'windows', app_version: '2.0.0-beta', download_url: 'https://x/beta.exe', created_at: '2026-09-10 10:00:00' })
+
+    for (const feed of [[beta, stable], [stable, beta]]) {
+      expect(latestDesktopDownloads(feed).map((build) => build.app_version)).toEqual(['2.0.0'])
+    }
+  })
+
+  it('still offers a prerelease when it is the only build there is', () => {
+    const offers = latestDesktopDownloads([release({ os: 'macos', app_version: '1.0.0-rc1', download_url: 'https://x/rc.dmg' })])
+    expect(offers.map((build) => build.app_version)).toEqual(['1.0.0-rc1'])
+  })
+
   it('skips a build whose URL should never reach an href, rather than offering a dead button', () => {
     const offers = latestDesktopDownloads([
       release({ os: 'windows', app_version: '1.1.0', download_url: 'javascript:alert(1)', created_at: '2026-09-01 10:00:00' }),

--- a/src/pages/Changelog/utils.test.ts
+++ b/src/pages/Changelog/utils.test.ts
@@ -439,6 +439,24 @@ describe('latestDesktopDownloads', () => {
     }
   })
 
+  it('ranks only a recognised suffix as a prerelease', () => {
+    // 1.2.3-x64 is an arch, not a release candidate; ranking it below a stable would
+    // offer the older 1.2.2 installer instead of the newer build it names.
+    const offers = latestDesktopDownloads([
+      release({ os: 'windows', app_version: '1.2.3-x64', download_url: 'https://x/new.exe', created_at: '2026-09-01 00:00:00' }),
+      release({ os: 'windows', app_version: '1.2.2', download_url: 'https://x/old.exe', created_at: '2026-01-01 00:00:00' }),
+    ])
+
+    expect(offers.map((build) => build.download_url)).toEqual(['https://x/new.exe'])
+  })
+
+  it('settles rows alike down to the second on something other than arrival order', () => {
+    const a = release({ os: 'windows', app_version: '1.0.0', download_url: 'https://x/a.exe', created_at: '2026-01-01 00:00:00' })
+    const b = release({ os: 'windows', app_version: '1.0.0', download_url: 'https://x/b.exe', created_at: '2026-01-01 00:00:00' })
+
+    expect(latestDesktopDownloads([a, b])).toEqual(latestDesktopDownloads([b, a]))
+  })
+
   it('still offers a prerelease when it is the only build there is', () => {
     const offers = latestDesktopDownloads([release({ os: 'macos', app_version: '1.0.0-rc1', download_url: 'https://x/rc.dmg' })])
     expect(offers.map((build) => build.app_version)).toEqual(['1.0.0-rc1'])
@@ -495,6 +513,17 @@ describe('offerVersionLabel', () => {
     // formatVersion drops the suffix, so this would otherwise read "v1.0.0" above a
     // button handing over the release candidate.
     expect(offerVersionLabel([offer('1.0.0-rc1')])).toBe('1.0.0-rc1')
+  })
+
+  it('says nothing when one platform is on a prerelease and another is not', () => {
+    // Both format to 1.0.0, so a formatted comparison would badge the RC as stable.
+    // Asserted in both platform orders, since the label reads from the offer list.
+    expect(offerVersionLabel([offer('1.0.0'), { ...offer('1.0.0-rc1'), os: 'macos' }])).toBeNull()
+    expect(offerVersionLabel([offer('1.0.0-rc1'), { ...offer('1.0.0'), os: 'macos' }])).toBeNull()
+  })
+
+  it('says nothing when two platforms are on different prereleases', () => {
+    expect(offerVersionLabel([offer('1.0.0-rc1'), { ...offer('1.0.0-rc2'), os: 'macos' }])).toBeNull()
   })
 
   it('says nothing when the installers do not share a version', () => {

--- a/src/pages/Changelog/utils.test.ts
+++ b/src/pages/Changelog/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { detectViewerOS, getVersionSeverity, groupReleases, latestDesktopDownloads, noteBlocks, offeredAbove, orderBuilds, parseContributors, parseUpdateDesc, safeDownloadUrl } from './utils'
+import { detectViewerOS, getVersionSeverity, groupReleases, latestDesktopDownloads, noteBlocks, offerVersionLabel, offeredAbove, orderBuilds, parseContributors, parseUpdateDesc, safeDownloadUrl } from './utils'
 import type { AppVersion } from './utils'
 
 describe('parseContributors', () => {
@@ -385,6 +385,51 @@ describe('latestDesktopDownloads', () => {
     expect(offers.map((build) => build.app_version)).toEqual(['1.1.0'])
   })
 
+  it('does not let a prerelease displace a stable release, whatever it is numbered', () => {
+    // A prerelease is normally numbered ahead of the stable it precedes — 2.0.1-beta
+    // exists before 2.0.1 does — so comparing numbers first hands out a beta for as
+    // long as it is the highest-numbered row.
+    const stable = release({ os: 'windows', app_version: '2.0.0', download_url: 'https://x/stable.exe', created_at: '2026-01-01 00:00:00' })
+    const laterBeta = release({ os: 'windows', app_version: '2.0.1-beta', download_url: 'https://x/beta.exe', created_at: '2026-01-02 00:00:00' })
+
+    for (const feed of [[stable, laterBeta], [laterBeta, stable]]) {
+      expect(latestDesktopDownloads(feed).map((build) => build.app_version)).toEqual(['2.0.0'])
+    }
+  })
+
+  it('reads a prefixed version the same way for the triple and the suffix', () => {
+    const offers = latestDesktopDownloads([
+      release({ os: 'macos', app_version: 'Octo 2.0.0', download_url: 'https://x/stable.dmg', created_at: '2026-01-01 00:00:00' }),
+      release({ os: 'macos', app_version: 'Octo 2.0.0-beta', download_url: 'https://x/beta.dmg', created_at: '2026-01-10 00:00:00' }),
+    ])
+
+    expect(offers.map((build) => build.download_url)).toEqual(['https://x/stable.dmg'])
+  })
+
+  it('returns the same installer whatever order the feed arrives in', () => {
+    // The API sorts by updated_at, so re-saving any row reshuffles the feed.
+    const rows = [
+      release({ os: 'windows', app_version: '1.0.0(5)', download_url: 'https://x/a.exe', created_at: '2026-01-10 00:00:00' }),
+      release({ os: 'windows', app_version: '1.0.0(9)', download_url: 'https://x/b.exe', created_at: '2026-01-02 00:00:00' }),
+      release({ os: 'windows', app_version: '1.0.0', download_url: 'https://x/c.exe', created_at: '2026-01-05 00:00:00' }),
+      release({ os: 'windows', app_version: 'latest', download_url: 'https://x/d.exe', created_at: '2026-01-03 00:00:00' }),
+    ]
+    const orders = [rows, [...rows].reverse(), [rows[2], rows[3], rows[0], rows[1]], [rows[3], rows[1], rows[2], rows[0]]]
+
+    for (const feed of orders) {
+      expect(latestDesktopDownloads(feed).map((build) => build.download_url)).toEqual(['https://x/b.exe'])
+    }
+  })
+
+  it('never lets a version it cannot read outrank one it can', () => {
+    const offers = latestDesktopDownloads([
+      release({ os: 'windows', app_version: 'latest', download_url: 'https://x/latest.exe', created_at: '2026-01-09 00:00:00' }),
+      release({ os: 'windows', app_version: '2.0.0', download_url: 'https://x/2.0.0.exe', created_at: '2026-01-01 00:00:00' }),
+    ])
+
+    expect(offers.map((build) => build.download_url)).toEqual(['https://x/2.0.0.exe'])
+  })
+
   it('does not let a prerelease displace the stable release it shares a number with', () => {
     const stable = release({ os: 'windows', app_version: '2.0.0', download_url: 'https://x/stable.exe', created_at: '2026-09-01 10:00:00' })
     const beta = release({ os: 'windows', app_version: '2.0.0-beta', download_url: 'https://x/beta.exe', created_at: '2026-09-10 10:00:00' })
@@ -436,5 +481,27 @@ describe('offeredAbove', () => {
   it('is false for a card that has no builds at all', () => {
     const [entry] = groupReleases([release({ os: 'ios', app_version: '3.4.1', download_url: 'https://apps.apple.com/x' })])
     expect(offeredAbove(entry, [offer('windows', 'https://x/a.exe')])).toBe(false)
+  })
+})
+
+describe('offerVersionLabel', () => {
+  const offer = (app_version: string) => ({ os: 'windows', app_version, download_url: 'https://x/a.exe', created_at: '2026-08-20 16:00:00', is_force: 0, update_desc: '' })
+
+  it('labels a shared stable version', () => {
+    expect(offerVersionLabel([offer('1.0.0'), { ...offer('1.0.0'), os: 'macos' }])).toBe('v1.0.0')
+  })
+
+  it('keeps a prerelease verbatim rather than badging it as the stable it is not', () => {
+    // formatVersion drops the suffix, so this would otherwise read "v1.0.0" above a
+    // button handing over the release candidate.
+    expect(offerVersionLabel([offer('1.0.0-rc1')])).toBe('1.0.0-rc1')
+  })
+
+  it('says nothing when the installers do not share a version', () => {
+    expect(offerVersionLabel([offer('1.1.0'), { ...offer('1.0.0'), os: 'macos' }])).toBeNull()
+  })
+
+  it('treats versions that format alike as shared', () => {
+    expect(offerVersionLabel([offer('1.0.0'), { ...offer('v1.0.0'), os: 'macos' }])).toBe('v1.0.0')
   })
 })

--- a/src/pages/Changelog/utils.test.ts
+++ b/src/pages/Changelog/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { detectViewerOS, getVersionSeverity, groupReleases, noteBlocks, orderBuilds, parseContributors, parseUpdateDesc, safeDownloadUrl } from './utils'
+import { detectViewerOS, getVersionSeverity, groupReleases, latestDesktopDownloads, noteBlocks, offeredAbove, orderBuilds, parseContributors, parseUpdateDesc, safeDownloadUrl } from './utils'
 import type { AppVersion } from './utils'
 
 describe('parseContributors', () => {
@@ -347,5 +347,80 @@ describe('noteBlocks', () => {
   it('passes a non-desktop card through as a single block', () => {
     const [entry] = groupReleases([release({ os: 'ios', app_version: '3.4.1', update_desc: '修复：推送角标' })])
     expect(noteBlocks(entry)).toEqual([{ os: [], desc: '修复：推送角标' }])
+  })
+})
+
+describe('latestDesktopDownloads', () => {
+  it('offers the newest installer for each desktop platform', () => {
+    const offers = latestDesktopDownloads([
+      release({ os: 'windows', app_version: '1.1.0', download_url: 'https://x/1.1.0.exe', created_at: '2026-09-01 10:00:00' }),
+      release({ os: 'macos', app_version: '1.0.0', download_url: 'https://x/1.0.0.dmg', created_at: '2026-08-20 14:00:00' }),
+      release({ os: 'windows', app_version: '1.0.0', download_url: 'https://x/1.0.0.exe', created_at: '2026-08-20 16:00:00' }),
+    ])
+
+    expect(offers.map((build) => [build.os, build.app_version, build.download_url])).toEqual([
+      ['windows', '1.1.0', 'https://x/1.1.0.exe'],
+      ['macos', '1.0.0', 'https://x/1.0.0.dmg'],
+    ])
+  })
+
+  it('offers whichever platforms have a build, and nothing when none do', () => {
+    const macOnly = latestDesktopDownloads([
+      release({ os: 'macos', app_version: '1.0.0', download_url: 'https://x/a.dmg' }),
+      release({ os: 'ios', app_version: '3.4.1', download_url: 'https://apps.apple.com/x' }),
+      release({ os: 'web', update_desc: '优化：搜索' }),
+    ])
+    expect(macOnly.map((build) => build.os)).toEqual(['macos'])
+
+    expect(latestDesktopDownloads([release({ os: 'android', download_url: 'https://x/a.apk' })])).toEqual([])
+  })
+
+  it('offers the higher version, not the row uploaded most recently', () => {
+    // A hotfix row for an older version, added after the newer build shipped.
+    const offers = latestDesktopDownloads([
+      release({ os: 'windows', app_version: '1.0.0', download_url: 'https://x/1.0.0.exe', created_at: '2026-09-05 10:00:00' }),
+      release({ os: 'windows', app_version: '1.1.0', download_url: 'https://x/1.1.0.exe', created_at: '2026-09-01 10:00:00' }),
+    ])
+
+    expect(offers.map((build) => build.app_version)).toEqual(['1.1.0'])
+  })
+
+  it('skips a build whose URL should never reach an href, rather than offering a dead button', () => {
+    const offers = latestDesktopDownloads([
+      release({ os: 'windows', app_version: '1.1.0', download_url: 'javascript:alert(1)', created_at: '2026-09-01 10:00:00' }),
+      release({ os: 'windows', app_version: '1.0.0', download_url: 'https://x/1.0.0.exe', created_at: '2026-08-20 16:00:00' }),
+      release({ os: 'macos', app_version: '1.0.0', download_url: '', created_at: '2026-08-20 14:00:00' }),
+    ])
+
+    expect(offers.map((build) => [build.os, build.download_url])).toEqual([['windows', 'https://x/1.0.0.exe']])
+  })
+})
+
+describe('offeredAbove', () => {
+  const offer = (os: string, url: string) => ({ os, download_url: url, created_at: '2026-08-20 16:00:00', is_force: 0, update_desc: '', app_version: '1.0.0' })
+
+  it('is true only when every installer the card links is already offered', () => {
+    const [entry] = groupReleases([
+      release({ os: 'windows', app_version: '1.0.0', download_url: 'https://x/a.exe' }),
+      release({ os: 'macos', app_version: '1.0.0', download_url: 'https://x/a.dmg' }),
+    ])
+
+    expect(offeredAbove(entry, [offer('windows', 'https://x/a.exe'), offer('macos', 'https://x/a.dmg')])).toBe(true)
+    expect(offeredAbove(entry, [offer('windows', 'https://x/a.exe')])).toBe(false)
+    expect(offeredAbove(entry, [])).toBe(false)
+  })
+
+  it('does not let one platform cover for another that shares its URL', () => {
+    const [entry] = groupReleases([
+      release({ os: 'windows', app_version: '1.0.0', download_url: 'https://x/universal.zip' }),
+      release({ os: 'macos', app_version: '1.0.0', download_url: 'https://x/universal.zip' }),
+    ])
+
+    expect(offeredAbove(entry, [offer('windows', 'https://x/universal.zip')])).toBe(false)
+  })
+
+  it('is false for a card that has no builds at all', () => {
+    const [entry] = groupReleases([release({ os: 'ios', app_version: '3.4.1', download_url: 'https://apps.apple.com/x' })])
+    expect(offeredAbove(entry, [offer('windows', 'https://x/a.exe')])).toBe(false)
   })
 })

--- a/src/pages/Changelog/utils.ts
+++ b/src/pages/Changelog/utils.ts
@@ -231,17 +231,24 @@ export interface ReleaseEntry extends AppVersion {
 }
 
 /**
- * A numeric version carrying a `-suffix`: 2.0.0-beta, 1.0.0-rc1, Octo 2.0.0-rc.
+ * A version whose suffix says it is not the final build: 2.0.0-beta, 1.0.0-rc1,
+ * Octo 2.0.0-rc.2.
  *
- * Deliberately as lenient as parseSemVer, which matches a triple anywhere in the
- * string: if one recognises `Octo 2.0.0` as a version, the other has to recognise
- * `Octo 2.0.0-beta` as a prerelease, or the prefixed pair compares as stable vs
- * nothing and the beta wins.
+ * Only recognised tokens count. Not every hyphen means prerelease — `1.2.3-x64` and
+ * `1.2.3-20260115` are an arch and a date stamp, and ranking those below a stable
+ * release would offer an older installer than the one they name.
+ *
+ * The triple is matched as leniently as parseSemVer does, which finds one anywhere
+ * in the string: if that recognises `Octo 2.0.0` as a version, this has to recognise
+ * `Octo 2.0.0-beta` as a prerelease, or the pair compares as stable-versus-nothing
+ * and the beta wins.
  */
-const PRERELEASE_SUFFIX = /\d+\.\d+(?:\.\d+)?-[0-9A-Za-z.-]+/
+const VERSION_SUFFIX = /\d+\.\d+(?:\.\d+)?-([0-9A-Za-z]+)/
+const PRERELEASE_TOKEN = /^(alpha|beta|rc|pre|preview|dev|snapshot|canary|nightly)/i
 
 export function isPrerelease(version: string): boolean {
-  return PRERELEASE_SUFFIX.test(version.replace(/\(.*\)/, ''))
+  const suffix = VERSION_SUFFIX.exec(version.replace(/\(.*\)/, ''))
+  return suffix !== null && PRERELEASE_TOKEN.test(suffix[1])
 }
 
 /** Ranked so a stable release outranks any prerelease, and both outrank a version
@@ -288,7 +295,11 @@ function supersedes(candidate: AppVersion, current: DesktopDownload): boolean {
     if (a.triple[i] !== b.triple[i]) return a.triple[i] > b.triple[i]
   }
   if (a.build !== b.build) return a.build > b.build
-  return candidate.created_at > current.created_at
+  if (candidate.created_at !== current.created_at) return candidate.created_at > current.created_at
+  // Rows alike down to the second still need one answer, or the fold returns
+  // whichever arrived first and the order-independence above is only most of a
+  // total order.
+  return candidate.download_url > current.download_url
 }
 
 /** An installer the page can offer outright, with the version it belongs to. */
@@ -306,10 +317,19 @@ export interface DesktopDownload extends DesktopBuild {
  * moving them together later.)
  */
 export function offerVersionLabel(offers: DesktopDownload[]): string | null {
-  const versions = Array.from(new Set(offers.map((offer) => formatVersion(offer.app_version))))
-  if (versions.length !== 1) return null
-  const offered = offers[0].app_version.trim()
-  return isPrerelease(offered) ? offered : `v${versions[0]}`
+  // Written the same way, modulo a `v` prefix: label it.
+  const raw = Array.from(new Set(offers.map((offer) => offer.app_version.trim().replace(/^v/i, ''))))
+  if (raw.length === 1) return isPrerelease(raw[0]) ? raw[0] : `v${formatVersion(raw[0])}`
+
+  // Written differently with a prerelease among them: say nothing. formatVersion()
+  // drops a `-suffix`, so comparing formatted versions here would collapse Windows
+  // on 1.0.0 and macOS on 1.0.0-rc1 into one version and badge the RC as stable —
+  // above the button that hands it over.
+  if (offers.some((offer) => isPrerelease(offer.app_version))) return null
+
+  // All stable and formatting alike (1.0 and 1.0.0) — one version, said once.
+  const formatted = Array.from(new Set(offers.map((offer) => formatVersion(offer.app_version))))
+  return formatted.length === 1 ? `v${formatted[0]}` : null
 }
 
 /**

--- a/src/pages/Changelog/utils.ts
+++ b/src/pages/Changelog/utils.ts
@@ -230,44 +230,86 @@ export interface ReleaseEntry extends AppVersion {
   builds?: DesktopBuild[]
 }
 
-/** A numeric version carrying a `-suffix`: 2.0.0-beta, 1.0.0-rc1. */
-const PRERELEASE_SUFFIX = /^v?\d+\.\d+(?:\.\d+)?-/
+/**
+ * A numeric version carrying a `-suffix`: 2.0.0-beta, 1.0.0-rc1, Octo 2.0.0-rc.
+ *
+ * Deliberately as lenient as parseSemVer, which matches a triple anywhere in the
+ * string: if one recognises `Octo 2.0.0` as a version, the other has to recognise
+ * `Octo 2.0.0-beta` as a prerelease, or the prefixed pair compares as stable vs
+ * nothing and the beta wins.
+ */
+const PRERELEASE_SUFFIX = /\d+\.\d+(?:\.\d+)?-[0-9A-Za-z.-]+/
 
-function isPrerelease(version: string): boolean {
-  return PRERELEASE_SUFFIX.test(version.replace(/\(.*\)/, '').trim())
+export function isPrerelease(version: string): boolean {
+  return PRERELEASE_SUFFIX.test(version.replace(/\(.*\)/, ''))
+}
+
+/** Ranked so a stable release outranks any prerelease, and both outrank a version
+ *  string we cannot read at all. */
+const STABLE = 2
+const PRERELEASE = 1
+const UNREADABLE = 0
+
+interface VersionRank {
+  tier: number
+  triple: [number, number, number]
+  build: number
+}
+
+function rankVersion(version: string): VersionRank {
+  const triple = parseSemVer(version)
+  if (!triple) return { tier: UNREADABLE, triple: [0, 0, 0], build: 0 }
+  return {
+    tier: isPrerelease(version) ? PRERELEASE : STABLE,
+    triple,
+    build: parseBuildNumber(version) ?? 0,
+  }
 }
 
 /**
- * Which of two rows for one OS the page should offer. Version wins over upload
- * time — a hotfix row for an older version added later must not displace the
- * newer build — and the timestamp only settles versions that compare equal or
- * cannot be parsed.
+ * Which of two rows for one OS the page should offer.
+ *
+ * A total order — tier, then version, then build, then upload time — because
+ * latestDesktopDownloads() folds this over the feed, and a fold over a comparator
+ * that mixes incomparable rules returns whichever answer the arrival order happens
+ * to produce. The API sorts by updated_at, so that order changes whenever a row is
+ * re-saved.
+ *
+ * Tier comes first because a prerelease is normally numbered ahead of the stable it
+ * precedes — 2.0.1-beta exists before 2.0.1 does — so comparing numbers first would
+ * hand out a beta for as long as it is the highest-numbered row. It is still offered
+ * when nothing else is: something installable beats nothing.
  */
 function supersedes(candidate: AppVersion, current: DesktopDownload): boolean {
-  const a = parseSemVer(candidate.app_version)
-  const b = parseSemVer(current.app_version)
-  if (a && b) {
-    for (let i = 0; i < 3; i++) {
-      if (a[i] !== b[i]) return a[i] > b[i]
-    }
-    // parseSemVer reads the triple out of a prerelease by design, so 2.0.0-beta ties
-    // with 2.0.0 and the timestamp would hand out whichever was uploaded later. The
-    // strip labels by that same numeric version, so offering the prerelease would
-    // give everyone a beta badged as v2.0.0.
-    const candidatePrerelease = isPrerelease(candidate.app_version)
-    const currentPrerelease = isPrerelease(current.app_version)
-    if (candidatePrerelease !== currentPrerelease) return currentPrerelease
-
-    const buildA = parseBuildNumber(candidate.app_version)
-    const buildB = parseBuildNumber(current.app_version)
-    if (buildA !== null && buildB !== null && buildA !== buildB) return buildA > buildB
+  const a = rankVersion(candidate.app_version)
+  const b = rankVersion(current.app_version)
+  if (a.tier !== b.tier) return a.tier > b.tier
+  for (let i = 0; i < 3; i++) {
+    if (a.triple[i] !== b.triple[i]) return a.triple[i] > b.triple[i]
   }
+  if (a.build !== b.build) return a.build > b.build
   return candidate.created_at > current.created_at
 }
 
 /** An installer the page can offer outright, with the version it belongs to. */
 export interface DesktopDownload extends DesktopBuild {
   app_version: string
+}
+
+/**
+ * The version line for the offer, or null when the installers do not share one.
+ *
+ * formatVersion() drops a `-suffix`, so a prerelease would be badged as the stable
+ * release it is not — above a button that hands over the prerelease. Prereleases
+ * therefore keep their version string verbatim. (formatVersion itself is left alone:
+ * the timeline cards badge the same way, and moving them apart would be worse than
+ * moving them together later.)
+ */
+export function offerVersionLabel(offers: DesktopDownload[]): string | null {
+  const versions = Array.from(new Set(offers.map((offer) => formatVersion(offer.app_version))))
+  if (versions.length !== 1) return null
+  const offered = offers[0].app_version.trim()
+  return isPrerelease(offered) ? offered : `v${versions[0]}`
 }
 
 /**

--- a/src/pages/Changelog/utils.ts
+++ b/src/pages/Changelog/utils.ts
@@ -230,6 +230,73 @@ export interface ReleaseEntry extends AppVersion {
   builds?: DesktopBuild[]
 }
 
+/**
+ * Which of two rows for one OS the page should offer. Version wins over upload
+ * time — a hotfix row for an older version added later must not displace the
+ * newer build — and the timestamp only settles versions that compare equal or
+ * cannot be parsed.
+ */
+function supersedes(candidate: AppVersion, current: DesktopDownload): boolean {
+  const a = parseSemVer(candidate.app_version)
+  const b = parseSemVer(current.app_version)
+  if (a && b) {
+    for (let i = 0; i < 3; i++) {
+      if (a[i] !== b[i]) return a[i] > b[i]
+    }
+    const buildA = parseBuildNumber(candidate.app_version)
+    const buildB = parseBuildNumber(current.app_version)
+    if (buildA !== null && buildB !== null && buildA !== buildB) return buildA > buildB
+  }
+  return candidate.created_at > current.created_at
+}
+
+/** An installer the page can offer outright, with the version it belongs to. */
+export interface DesktopDownload extends DesktopBuild {
+  app_version: string
+}
+
+/**
+ * The newest usable installer for each desktop OS across the whole feed.
+ *
+ * The timeline answers "what changed"; this answers "give me the app". A desktop
+ * release sinks below a week of web deploys within days, so the offer cannot be
+ * tied to where its card happens to sit. Rows whose URL the browser should not be
+ * handed are skipped rather than rendered as a dead button.
+ */
+export function latestDesktopDownloads(raw: AppVersion[]): DesktopDownload[] {
+  const newestByOS = new Map<string, DesktopDownload>()
+
+  for (const item of raw) {
+    if (!desktopPlatforms.has(item.os)) continue
+    if (!safeDownloadUrl(item.download_url)) continue
+    const current = newestByOS.get(item.os)
+    if (current && !supersedes(item, current)) continue
+    newestByOS.set(item.os, {
+      os: item.os,
+      app_version: item.app_version,
+      download_url: item.download_url,
+      created_at: item.created_at,
+      is_force: item.is_force,
+      update_desc: item.update_desc,
+    })
+  }
+
+  return desktopOrder.map((os) => newestByOS.get(os)).filter((build): build is DesktopDownload => build !== undefined)
+}
+
+/**
+ * Whether every installer this card links is already on offer above it, so the card
+ * can drop its own download row instead of repeating the same buttons half a screen
+ * apart. Keyed by platform as well as URL: two platforms sharing one URL must not
+ * cover for each other.
+ */
+export function offeredAbove(entry: ReleaseEntry, offers: DesktopDownload[]): boolean {
+  if (!entry.builds) return false
+  const offered = new Set(offers.map((offer) => `${offer.os}\u0000${offer.download_url}`))
+  const links = entry.builds.filter((build) => safeDownloadUrl(build.download_url))
+  return links.length > 0 && links.every((build) => offered.has(`${build.os}\u0000${build.download_url}`))
+}
+
 /** A block of release notes as one OS filed them. */
 export interface NoteBlock {
   /** Platforms sharing these notes. Empty when the card has one set of notes. */

--- a/src/pages/Changelog/utils.ts
+++ b/src/pages/Changelog/utils.ts
@@ -230,6 +230,13 @@ export interface ReleaseEntry extends AppVersion {
   builds?: DesktopBuild[]
 }
 
+/** A numeric version carrying a `-suffix`: 2.0.0-beta, 1.0.0-rc1. */
+const PRERELEASE_SUFFIX = /^v?\d+\.\d+(?:\.\d+)?-/
+
+function isPrerelease(version: string): boolean {
+  return PRERELEASE_SUFFIX.test(version.replace(/\(.*\)/, '').trim())
+}
+
 /**
  * Which of two rows for one OS the page should offer. Version wins over upload
  * time — a hotfix row for an older version added later must not displace the
@@ -243,6 +250,14 @@ function supersedes(candidate: AppVersion, current: DesktopDownload): boolean {
     for (let i = 0; i < 3; i++) {
       if (a[i] !== b[i]) return a[i] > b[i]
     }
+    // parseSemVer reads the triple out of a prerelease by design, so 2.0.0-beta ties
+    // with 2.0.0 and the timestamp would hand out whichever was uploaded later. The
+    // strip labels by that same numeric version, so offering the prerelease would
+    // give everyone a beta badged as v2.0.0.
+    const candidatePrerelease = isPrerelease(candidate.app_version)
+    const currentPrerelease = isPrerelease(current.app_version)
+    if (candidatePrerelease !== currentPrerelease) return currentPrerelease
+
     const buildA = parseBuildNumber(candidate.app_version)
     const buildB = parseBuildNumber(current.app_version)
     if (buildA !== null && buildB !== null && buildA !== buildB) return buildA > buildB


### PR DESCRIPTION
Split out of #140 at review request, so this gets read on its own terms rather than as a late addition to the platform-lane change. #140 has merged; this now targets `main` and its diff is only the strip.

## Why

The installers are reachable only from the release that shipped them, so they are findable exactly as long as that release stays at the top of the page. Web ships several times a day, so a desktop release sinks below a week of day-cards within days — and a visitor who came for the app has to know to filter by 桌面端 to find it again.

## What it does

A strip above the page title offering the newest usable installer per desktop OS:

- **one button per platform that has a build** — one if only one does, none at all if none do (the component renders nothing rather than an empty shell);
- **the visitor's own platform is promoted** to the filled button, by the same `detectViewerOS()` rule the release cards use. Where the OS is unknown, or the visitor's platform has no build, every installer is offered with equal weight rather than promoting one they cannot run;
- **read from the whole feed, not the filtered view** — switching to the iOS tab should not take the installer away;
- **picked by a total order** — tier (stable, then prerelease, then a version string that cannot be read), then version, then build number, then upload time, then URL. A hotfix row for an older version added later cannot displace a newer build; a prerelease never displaces a stable release, whatever it is numbered, since a prerelease is normally numbered ahead of the stable it precedes; and the offer does not depend on the order the feed arrives in, which matters because the API sorts by `updated_at`. Only recognised suffixes count as prereleases — `1.2.3-x64` is an arch, and ranking it below a stable would offer an older installer than it names;
- **unusable URLs are skipped** via the existing `safeDownloadUrl()` guard, so a bad row leaves no dead button;
- **the version is shown only when every offered installer says the same thing** — an identical version string modulo a `v` prefix, or a shared formatted version when they differ and none is a prerelease. Otherwise no version line: `formatVersion()` drops a `-suffix`, so labelling a mixed set would badge a release candidate as the stable release above the button that hands it over.

When the newest release is the one the strip already offers, the spotlight drops its own download row instead of repeating the same buttons half a screen apart. `offeredAbove()` decides that, keyed by platform as well as URL so two platforms sharing one URL cannot cover for each other.

It is sized as a call to action rather than a caption — a 48px icon tile, a two-line block naming the product and what is on offer, full-size buttons on a brand-tinted band. The secondary installer is a bordered button at this size rather than an underlined link: underline is the right affordance inline, but reads as unfinished next to a filled button. Its links carry a `:focus-visible` outline, and the band is a labelled `<section>` since they are the first focusable things on the page.

## Verification

`npx tsc --noEmit`, `npm test` (175 passing across 15 files), `npm run build`. Coverage added here: the per-platform offer, partial and empty feeds, version-over-upload-time, prerelease-never-displaces-stable in both feed orders, prerelease-only feeds, the recognised-suffix rule, shuffled arrival orders, unsafe-URL skipping, the dedup predicate including the shared-URL case, the label contract in both platform orders, and a component test rendering the band itself. Checked in a browser with both installers, with only one, with none at all, and in light and dark themes.

## For a reviewer

`download_url` is admin-entered and this puts it in an `href` at the top of a public, unauthenticated page. Every render site goes through `safeDownloadUrl()`, which allows only `http(s)` with an authority or a path-relative value. The server still applies no scheme validation on write, and `app_version` is accepted as free text with only a `required` rule — the page is inferring release semantics from a string nobody validates. Both belong in a write-side follow-up rather than in more heuristics here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUmovPkkCwhbQNRKUYAbia