### PR TITLE
fix(changelog): make What's New readable on a phone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   made the whole changelog page scroll sideways on a phone; notes now break inside
   a word, and the contributor row no longer sets a floor on the page width
 - A line that only announced the release ("Windows 桌面端 1.0.0 版本发布") was filed
-  under 新增 and counted as a feature the release did not contain
+  under 新增 and counted as a feature the release did not contain. Such a line is
+  now shown but never counted, and a card drops the note entirely only when the
+  note is nothing but an announcement of that card's own version
 - A version qualifier was dropped when a version was displayed, so a card for
   1.0.0-rc1 was titled v1.0.0
 - The release card and the band above it could pick different installers for the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   own tab, badge and version headline, grouped into one card per version that
   offers every installer
 - The visitor's own OS leads the desktop download list, when it can be detected
+- The desktop installers are offered above the timeline as well as on their release
+  card, so the app stays reachable after its release sinks below a week of web
+  deploys; on a phone, which can run neither installer, this is one line of text
+  rather than a band of buttons
 
 ### Fixed
 - Desktop releases were folded into the Web lane, which hid their version number
   and merged Windows and macOS builds into one card offering a single installer
 - Releases with no earlier version to compare against were labelled "Patch";
   they now carry no severity tag instead of a guessed one
+- A release note quoting a long identifier — a dotted config key, a file path —
+  made the whole changelog page scroll sideways on a phone; notes now break inside
+  a word, and the contributor row no longer sets a floor on the page width
+- A line that only announced the release ("Windows 桌面端 1.0.0 版本发布") was filed
+  under 新增 and counted as a feature the release did not contain
+- A version qualifier was dropped when a version was displayed, so a card for
+  1.0.0-rc1 was titled v1.0.0
+- The release card and the band above it could pick different installers for the
+  same version when two uploads shared a timestamp
+- Re-uploading a build with the notes box empty erased the notes already on the card
+- 必须升级 is set per build, but a card holding several platforms showed it
+  unqualified; it now names the platforms it applies to
+
+### Security
+- Download links are resolved with the browser's own URL parser before they reach
+  an `href`, and refused unless they resolve to http(s) — and, when they carry no
+  scheme of their own, to this origin. Previously the shape of the string was
+  matched against a list of known-bad forms, which only ever covered the forms
+  someone had thought of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,15 +30,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   they now carry no severity tag instead of a guessed one
 - A release note quoting a long identifier — a dotted config key, a file path —
   made the whole changelog page scroll sideways on a phone; notes now break inside
-  a word, and the contributor row no longer sets a floor on the page width
-- A line that only announced the release ("Windows 桌面端 1.0.0 版本发布") was filed
-  under 新增 and counted as a feature the release did not contain. Such a line is
-  now shown wherever its author filed it and counted nowhere
-- A version qualifier was dropped when a version was displayed, so a card for
-  1.0.0-rc1 was titled v1.0.0
+  a word, and neither the hidden contributor tooltip nor the avatar row sets a floor
+  on the page width any more
 - The release card and the band above it could pick different installers for the
   same version when two uploads shared a timestamp
-- Re-uploading a build with the notes box empty erased the notes already on the card
+- Re-uploading a build with the notes box empty erased the notes already on the
+  card; the link now follows the newest upload and the notes the newest upload that
+  filed any, in any arrival order
 - 必须升级 is set per build, but a card holding several platforms showed it
   unqualified; it now names the platforms it applies to
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   a word, and the contributor row no longer sets a floor on the page width
 - A line that only announced the release ("Windows 桌面端 1.0.0 版本发布") was filed
   under 新增 and counted as a feature the release did not contain. Such a line is
-  now shown but never counted, and a card drops the note entirely only when the
-  note is nothing but an announcement of that card's own version
+  now shown wherever its author filed it and counted nowhere
 - A version qualifier was dropped when a version was displayed, so a card for
   1.0.0-rc1 was titled v1.0.0
 - The release card and the band above it could pick different installers for the

--- a/src/pages/Changelog/ContributorAvatars.test.tsx
+++ b/src/pages/Changelog/ContributorAvatars.test.tsx
@@ -1,0 +1,94 @@
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ReleaseEntry } from './utils'
+
+// The page imports antd for its shell; the card under test uses none of it.
+vi.mock('antd', async () => {
+  const React = await vi.importActual<typeof import('react')>('react')
+  const Passthrough = ({ children }: { children?: React.ReactNode }) => React.createElement('div', null, children)
+  return {
+    Tabs: Passthrough,
+    Spin: Passthrough,
+    Empty: Passthrough,
+    Tag: Passthrough,
+    Tooltip: Passthrough,
+    ConfigProvider: Passthrough,
+    theme: { darkAlgorithm: {}, defaultAlgorithm: {} },
+  }
+})
+
+const NAMES = ['ana', 'bo', 'cai', 'dee', 'eun', 'fei', 'gus', 'hana']
+
+const entry: ReleaseEntry = {
+  os: 'windows',
+  app_version: '2.1.0',
+  is_force: 0,
+  update_desc: `修复：启动白屏\n@contributors: ${NAMES.join(', ')}`,
+  download_url: '',
+  created_at: '2026-08-20 16:34:04',
+}
+
+/* The avatar row is the one part of an entry that cannot shrink, and at the full
+   count it — not the prose — decided how wide the page was on a phone. jsdom cannot
+   measure that, but it can hold the rule that fixed it: fewer faces below 420px.
+
+   The module reads the media query once and caches it, so each case needs a fresh
+   module registry rather than a second render. */
+async function renderAt(narrow: boolean) {
+  vi.resetModules()
+  window.matchMedia = ((query: string) => ({
+    matches: narrow,
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia
+
+  const { LatestReleaseSpotlight } = await import('./index')
+  const host = document.createElement('div')
+  document.body.appendChild(host)
+  const root: Root = createRoot(host)
+  await act(async () => {
+    root.render(<LatestReleaseSpotlight item={entry} severity="minor" />)
+  })
+  const result = {
+    avatars: host.querySelectorAll('img').length,
+    badge: host.querySelector('.contributor-more-badge')?.textContent ?? null,
+    text: host.textContent ?? '',
+  }
+  await act(async () => root.unmount())
+  host.remove()
+  return result
+}
+
+describe('contributor row', () => {
+  let matchMedia: typeof window.matchMedia
+
+  beforeEach(() => {
+    ;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+    matchMedia = window.matchMedia
+  })
+
+  afterEach(() => {
+    window.matchMedia = matchMedia
+  })
+
+  it('shows every contributor where there is room for them', async () => {
+    const wide = await renderAt(false)
+    expect(wide.avatars).toBe(NAMES.length)
+    expect(wide.badge).toBeNull()
+    expect(wide.text).toContain('贡献者')
+  })
+
+  it('shows five and counts the rest on a narrow screen', async () => {
+    const narrow = await renderAt(true)
+    expect(narrow.avatars).toBe(5)
+    expect(narrow.badge).toBe(`+${NAMES.length - 5}`)
+    // The label goes too: it is worth more room than it takes on a phone.
+    expect(narrow.text).not.toContain('贡献者')
+  })
+})

--- a/src/pages/Changelog/DesktopDownloadBar.test.tsx
+++ b/src/pages/Changelog/DesktopDownloadBar.test.tsx
@@ -67,8 +67,10 @@ describe('DesktopDownloadBar', () => {
     }
   })
 
-  it('keeps a lone prerelease qualified', () => {
-    expect(render([build('macos', '1.0.1-rc1')])).toContain('v1.0.1-rc1 · 支持 macOS')
+  it('keeps a lone prerelease verbatim', () => {
+    // formatVersion drops the suffix, so this would otherwise read "v1.0.1" above a
+    // button handing over the release candidate.
+    expect(render([build('macos', '1.0.1-rc1')])).toContain('1.0.1-rc1 · 支持 macOS')
   })
 
   it('renders one link per installer, and nothing at all without one', () => {

--- a/src/pages/Changelog/DesktopDownloadBar.test.tsx
+++ b/src/pages/Changelog/DesktopDownloadBar.test.tsx
@@ -45,8 +45,8 @@ describe('DesktopDownloadBar', () => {
     host.remove()
   })
 
-  const render = (downloads: DesktopDownload[]) => {
-    act(() => root.render(<DesktopDownloadBar downloads={downloads} />))
+  const render = (downloads: DesktopDownload[], handheld = false) => {
+    act(() => root.render(<DesktopDownloadBar downloads={downloads} handheld={handheld} />))
     return host.textContent ?? ''
   }
 
@@ -86,5 +86,17 @@ describe('DesktopDownloadBar', () => {
     expect(Array.from(host.querySelectorAll('a')).map((a) => a.getAttribute('href'))).toEqual([
       'https://cdn.example.com/macos',
     ])
+  })
+
+  it('offers no buttons on a phone, only word that the app exists', () => {
+    const text = render([build('windows', '1.0.0'), build('macos', '1.0.0')], true)
+    expect(host.querySelectorAll('a')).toHaveLength(0)
+    expect(text).toContain('v1.0.0')
+    expect(text).toContain('Windows、macOS')
+    expect(text).toContain('在电脑上打开本页即可下载')
+  })
+
+  it('still says nothing on a phone when there is no build to mention', () => {
+    expect(render([], true)).toBe('')
   })
 })

--- a/src/pages/Changelog/DesktopDownloadBar.test.tsx
+++ b/src/pages/Changelog/DesktopDownloadBar.test.tsx
@@ -67,8 +67,8 @@ describe('DesktopDownloadBar', () => {
     }
   })
 
-  it('keeps a lone prerelease verbatim', () => {
-    expect(render([build('macos', '1.0.1-rc1')])).toContain('1.0.1-rc1 · 支持 macOS')
+  it('keeps a lone prerelease qualified', () => {
+    expect(render([build('macos', '1.0.1-rc1')])).toContain('v1.0.1-rc1 · 支持 macOS')
   })
 
   it('renders one link per installer, and nothing at all without one', () => {

--- a/src/pages/Changelog/LatestReleaseSpotlight.test.tsx
+++ b/src/pages/Changelog/LatestReleaseSpotlight.test.tsx
@@ -1,0 +1,73 @@
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ReleaseEntry } from './utils'
+
+// The page imports antd for its shell; the spotlight card itself uses none of it.
+vi.mock('antd', async () => {
+  const React = await vi.importActual<typeof import('react')>('react')
+  const Passthrough = ({ children }: { children?: React.ReactNode }) => React.createElement('div', null, children)
+  return {
+    Tabs: Passthrough,
+    Spin: Passthrough,
+    Empty: Passthrough,
+    Tag: Passthrough,
+    Tooltip: Passthrough,
+    ConfigProvider: Passthrough,
+    theme: { darkAlgorithm: {}, defaultAlgorithm: {} },
+  }
+})
+
+const { LatestReleaseSpotlight } = await import('./index')
+
+const entry: ReleaseEntry = {
+  os: 'windows',
+  app_version: '1.0.0',
+  is_force: 0,
+  update_desc: '',
+  download_url: '',
+  created_at: '2026-08-20 16:34:04',
+  builds: [
+    { os: 'windows', download_url: 'https://cdn.example.com/setup.exe', created_at: '2026-08-20 16:34:04', is_force: 0, update_desc: '修复：启动白屏' },
+    { os: 'macos', download_url: 'https://cdn.example.com/octo.dmg', created_at: '2026-08-20 14:18:06', is_force: 0, update_desc: '修复：启动白屏' },
+  ],
+}
+
+describe('LatestReleaseSpotlight', () => {
+  let host: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    ;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+    host = document.createElement('div')
+    document.body.appendChild(host)
+    root = createRoot(host)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    host.remove()
+  })
+
+  const render = (hideDownloads: boolean) => {
+    act(() => root.render(<LatestReleaseSpotlight item={entry} severity="initial" hideDownloads={hideDownloads} />))
+    return Array.from(host.querySelectorAll('a')).map((a) => a.getAttribute('href'))
+  }
+
+  it('links every installer when nothing above the card offers them', () => {
+    expect(render(false)).toEqual([
+      'https://cdn.example.com/setup.exe',
+      'https://cdn.example.com/octo.dmg',
+    ])
+  })
+
+  it('drops its own links when the band above already offers the same files', () => {
+    // Two rows of identical buttons half a screen apart, otherwise.
+    expect(render(true)).toEqual([])
+  })
+
+  it('still says what changed when it has stood its downloads down', () => {
+    act(() => root.render(<LatestReleaseSpotlight item={entry} severity="initial" hideDownloads />))
+    expect(host.textContent).toContain('启动白屏')
+  })
+})

--- a/src/pages/Changelog/LatestReleaseSpotlight.test.tsx
+++ b/src/pages/Changelog/LatestReleaseSpotlight.test.tsx
@@ -71,11 +71,9 @@ describe('LatestReleaseSpotlight', () => {
     expect(host.textContent).toContain('启动白屏')
   })
 
-  it('keeps the credits on a release whose note says nothing else', () => {
-    // The card drops a note that only announces the release it sits on — and the
-    // credits on that note are not part of what it said. Reading them off the
-    // blocks that survived lost the contributors of the very release this card is
-    // for.
+  it('credits everyone named on any build, not only the block it renders first', () => {
+    // Credits are read off the entry rather than off the note blocks, so no
+    // rendering decision about the body can decide who gets attribution.
     const announced: ReleaseEntry = {
       ...entry,
       builds: [
@@ -85,9 +83,6 @@ describe('LatestReleaseSpotlight', () => {
     }
 
     act(() => root.render(<LatestReleaseSpotlight item={announced} severity="initial" hideDownloads />))
-    // The body really is dropped — this is not the credits surviving because the
-    // block did.
-    expect(host.textContent).not.toContain('版本发布')
     expect(Array.from(host.querySelectorAll('img')).map((img) => img.getAttribute('alt'))).toEqual(['alice', 'bob'])
   })
 })

--- a/src/pages/Changelog/LatestReleaseSpotlight.test.tsx
+++ b/src/pages/Changelog/LatestReleaseSpotlight.test.tsx
@@ -70,4 +70,24 @@ describe('LatestReleaseSpotlight', () => {
     act(() => root.render(<LatestReleaseSpotlight item={entry} severity="initial" hideDownloads />))
     expect(host.textContent).toContain('启动白屏')
   })
+
+  it('keeps the credits on a release whose note says nothing else', () => {
+    // The card drops a note that only announces the release it sits on — and the
+    // credits on that note are not part of what it said. Reading them off the
+    // blocks that survived lost the contributors of the very release this card is
+    // for.
+    const announced: ReleaseEntry = {
+      ...entry,
+      builds: [
+        { os: 'windows', download_url: 'https://cdn.example.com/setup.exe', created_at: '2026-08-20 16:34:04', is_force: 0, update_desc: 'Windows 桌面端 1.0.0 版本发布\n@contributors: alice' },
+        { os: 'macos', download_url: 'https://cdn.example.com/octo.dmg', created_at: '2026-08-20 14:18:06', is_force: 0, update_desc: 'Mac 桌面端 1.0.0 版本发布\n@contributors: bob' },
+      ],
+    }
+
+    act(() => root.render(<LatestReleaseSpotlight item={announced} severity="initial" hideDownloads />))
+    // The body really is dropped — this is not the credits surviving because the
+    // block did.
+    expect(host.textContent).not.toContain('版本发布')
+    expect(Array.from(host.querySelectorAll('img')).map((img) => img.getAttribute('alt'))).toEqual(['alice', 'bob'])
+  })
 })

--- a/src/pages/Changelog/index.tsx
+++ b/src/pages/Changelog/index.tsx
@@ -1126,7 +1126,7 @@ function ChangelogItem({ item, isFirst, prevVersion, prevTimeLabel }: { item: Re
   )
 }
 
-function LatestReleaseSpotlight({ item, severity, hideDownloads }: { item: ReleaseEntry; severity: VersionSeverity; hideDownloads?: boolean }) {
+export function LatestReleaseSpotlight({ item, severity, hideDownloads }: { item: ReleaseEntry; severity: VersionSeverity; hideDownloads?: boolean }) {
   const isWeb = item.os === 'web'
   const dateObj = dayjs(item.created_at)
   const blocks = useMemo(() => noteBlocks(item, viewerOS), [item])

--- a/src/pages/Changelog/index.tsx
+++ b/src/pages/Changelog/index.tsx
@@ -101,6 +101,11 @@ const css = `
    the timeline row cannot shrink below it, and every screen narrower than the word
    scrolls sideways — the whole page, not just the one line. */
 .changelog-notes {
+  /* word-break first for Safari below 15.4, which drops the anywhere keyword. The
+     deprecated alias is the one that also shrinks min-content there; the
+     break-word value of overflow-wrap does not, and min-content is what set the
+     floor on the page width. */
+  word-break: break-word;
   overflow-wrap: anywhere;
 }
 .contributor-group {
@@ -600,6 +605,11 @@ function EntryBadges({ entry }: { entry: ReleaseEntry }) {
  * equal weight rather than guessing at them.
  */
 function DesktopDownloads({ builds, compact, large }: { builds: DesktopBuild[]; compact?: boolean; large?: boolean }) {
+  // The band above the timeline already told a handheld visitor to open the page on
+  // a computer. Offering them the same installers a few hundred pixels below would
+  // contradict that sentence with the buttons it exists to withdraw.
+  if (viewerIsHandheld) return null
+
   const ordered = orderBuilds(builds, viewerOS)
     .map((build) => ({ ...build, href: safeDownloadUrl(build.download_url) }))
     .filter((build): build is typeof build & { href: string } => build.href !== null)
@@ -1313,11 +1323,10 @@ export default function Changelog() {
   const restItems = filtered.slice(1)
 
   // When the newest release is the one the band above is already offering, the card
-  // would repeat the same two buttons half a screen apart. Only where the band
-  // actually rendered them: on a handheld it does not, and the card must keep its
-  // own links rather than defer to an offer that is not there.
+  // would repeat the same two buttons half a screen apart. The handheld case needs
+  // no exception here: DesktopDownloads renders nothing there either way.
   const spotlightOfferedAbove = useMemo(
-    () => (latestItem && !viewerIsHandheld ? offeredAbove(latestItem, desktopDownloads) : false),
+    () => (latestItem ? offeredAbove(latestItem, desktopDownloads) : false),
     [latestItem, desktopDownloads],
   )
 

--- a/src/pages/Changelog/index.tsx
+++ b/src/pages/Changelog/index.tsx
@@ -30,7 +30,7 @@ import 'dayjs/locale/zh-cn'
 import relativeTime from 'dayjs/plugin/relativeTime'
 import api from '../../api'
 import { colors, radius, space, font } from '../../styles/tokens'
-import { parseUpdateDesc, getVersionSeverity, formatVersion, parseContributors, detectViewerOS, groupReleases, orderBuilds, noteBlocks, latestDesktopDownloads, offerVersionLabel, offeredAbove, safeDownloadUrl, desktopPlatforms } from './utils'
+import { parseUpdateDesc, getVersionSeverity, formatVersion, parseContributors, detectViewerOS, isHandheld, groupReleases, orderBuilds, noteBlocks, latestDesktopDownloads, offerVersionLabel, offeredAbove, safeDownloadUrl, desktopPlatforms } from './utils'
 import type { VersionSeverity, ChangeCategory, Contributor, ViewerOS, AppVersion, DesktopBuild, DesktopDownload, NoteBlock, ReleaseEntry } from './utils'
 import type { PlatformKey } from '../../styles/tokens'
 import { AnalyticsPanel } from './AnalyticsPanel'
@@ -67,6 +67,10 @@ const platformConfig: Record<string, { label: string; icon: React.ReactNode; ton
 const viewerOS: ViewerOS | null = typeof navigator === 'undefined'
   ? null
   : detectViewerOS(navigator.userAgent, navigator.maxTouchPoints)
+
+const viewerIsHandheld: boolean = typeof navigator === 'undefined'
+  ? false
+  : isHandheld(navigator.userAgent, navigator.maxTouchPoints)
 
 const tabItems = [
   { key: 'all', label: '全部', icon: <UnorderedListOutlined />, color: '', colorDark: '' },
@@ -782,13 +786,36 @@ function StructuredChanges({ desc }: { desc: string }) {
  * deploys within days, so the installer cannot only live where its release sits —
  * one button per OS that has a build, the visitor's own promoted.
  */
-export function DesktopDownloadBar({ downloads }: { downloads: DesktopDownload[] }) {
+export function DesktopDownloadBar({ downloads, handheld = viewerIsHandheld }: {
+  downloads: DesktopDownload[]
+  handheld?: boolean
+}) {
   if (downloads.length === 0) return null
 
   const versionLabel = offerVersionLabel(downloads)
   // Same order the buttons take, so the line does not read "Windows、macOS" above a
-  // macOS-first row.
+  // macOS-first row. On a handheld no platform is the visitor's, so the fallback
+  // order applies and the sentence reads the same for everyone.
   const platforms = orderBuilds(downloads, viewerOS).map((build) => platformConfig[build.os]?.label ?? build.os).join('、')
+
+  // A phone cannot run either installer, so the offer is news rather than an
+  // action: one quiet line that says the desktop app exists, instead of a band of
+  // dead buttons between the visitor and the page they came for.
+  if (handheld) {
+    return (
+      // One text flow rather than a flex row: the sentence wraps to two lines on a
+      // phone, and as a flex item it would drag the icon onto a line of its own.
+      <section aria-label="Octo 桌面端" style={{
+        marginBottom: space[5],
+        fontSize: font.size.sm,
+        lineHeight: 1.6,
+        color: colors.text.tertiary,
+      }}>
+        <DesktopOutlined style={{ color: 'var(--brand-text-on-bg)', marginRight: 6 }} />
+        Octo 桌面端{versionLabel && ` ${versionLabel}`} 支持 {platforms}，在电脑上打开本页即可下载
+      </section>
+    )
+  }
 
   return (
     // Labelled: these are the first focusable things on the page, ahead of its <h1>.
@@ -1270,8 +1297,11 @@ export default function Changelog() {
 
   // When the newest release is the one the bar above is already offering, the card
   // would repeat the same two buttons half a screen apart.
+  // Only true when the band actually rendered the buttons: on a handheld it does
+  // not, and the card must keep its own links rather than defer to an offer that
+  // is not there.
   const spotlightOfferedAbove = useMemo(
-    () => (latestItem ? offeredAbove(latestItem, desktopDownloads) : false),
+    () => (latestItem && !viewerIsHandheld ? offeredAbove(latestItem, desktopDownloads) : false),
     [latestItem, desktopDownloads],
   )
 

--- a/src/pages/Changelog/index.tsx
+++ b/src/pages/Changelog/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo } from 'react'
+import { useEffect, useState, useMemo, useSyncExternalStore } from 'react'
 import { Tabs, Spin, Empty, Tag, ConfigProvider, theme as antdTheme } from 'antd'
 import {
   AndroidOutlined,
@@ -91,6 +91,14 @@ const css = `
 .changelog-item {
   animation: fadeSlideIn 0.35s cubic-bezier(0.22, 1, 0.36, 1) both;
 }
+/* Release notes quote code: a dotted config key or a file path is one unbreakable
+   word, routinely past 60 characters, and no line-breaking opportunity exists
+   inside it. Left alone such a word sets the min-content width of the note column,
+   the timeline row cannot shrink below it, and every screen narrower than the word
+   scrolls sideways — the whole page, not just the one line. */
+.changelog-notes {
+  overflow-wrap: anywhere;
+}
 .contributor-group {
   display: flex;
   align-items: center;
@@ -153,8 +161,11 @@ const css = `
   .contributor-avatar:hover img {
     transform: none;
   }
-  .contributor-avatar:hover .contributor-name {
-    opacity: 0;
+  /* Not just transparent: an absolutely positioned tooltip still counts toward the
+     document's scrollable width, and near the right edge of a phone that is enough
+     to make the page scroll sideways to reveal a name nobody can trigger. */
+  .contributor-name {
+    display: none;
   }
 }
 .contributor-name {
@@ -437,22 +448,46 @@ function Heatmap({ data }: { data: AppVersion[] }) {
 // flex row accounts for it — the fan happens inside that reserved box and can
 // never overflow the card (the whole group wraps to its own line if too wide).
 const MAX_VISIBLE_CONTRIBUTORS = 10
+/* The avatar row is the one part of an entry that refuses to shrink: ten 24px
+   avatars and a "+N" badge come to 184px, while a 360px phone leaves the note
+   column about 200px after the page padding, the date gutter and the rail. At the
+   full count the faces — not the prose — decide how wide the page is, and the page
+   scrolls sideways. Show fewer of them there; the badge still counts the rest. */
+const MAX_VISIBLE_CONTRIBUTORS_NARROW = 5
+const NARROW_SCREEN = '(max-width: 420px)'
+
+function narrowScreenQuery(): MediaQueryList | null {
+  return typeof window === 'undefined' || !window.matchMedia ? null : window.matchMedia(NARROW_SCREEN)
+}
+
+function subscribeToWidth(notify: () => void): () => void {
+  const query = narrowScreenQuery()
+  if (!query) return () => {}
+  query.addEventListener('change', notify)
+  return () => query.removeEventListener('change', notify)
+}
+
+function useNarrowScreen(): boolean {
+  return useSyncExternalStore(subscribeToWidth, () => narrowScreenQuery()?.matches ?? false, () => false)
+}
 const AVATAR_SIZE = 24
 // Per-avatar step: 16px at rest (8px overlap, via margin-left:-8px in CSS) →
 // 20px on hover (4px overlap). The group reserves the fanned width below.
 const FAN_STEP = 20
 
 function ContributorAvatars({ contributors, showLabel }: { contributors: Contributor[]; showLabel?: boolean }) {
+  const narrow = useNarrowScreen()
   if (contributors.length === 0) return null
 
-  const visible = contributors.slice(0, MAX_VISIBLE_CONTRIBUTORS)
-  const overflow = contributors.slice(MAX_VISIBLE_CONTRIBUTORS)
+  const cap = narrow ? MAX_VISIBLE_CONTRIBUTORS_NARROW : MAX_VISIBLE_CONTRIBUTORS
+  const visible = contributors.slice(0, cap)
+  const overflow = contributors.slice(cap)
   const itemCount = visible.length + (overflow.length > 0 ? 1 : 0)
   const reservedWidth = (itemCount - 1) * FAN_STEP + AVATAR_SIZE
 
   return (
     <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-      {showLabel && (
+      {showLabel && !narrow && (
         <span style={{ fontSize: font.size.xs, color: colors.text.tertiary, display: 'inline-flex', alignItems: 'center', gap: 4 }}>
           <TeamOutlined />
           贡献者
@@ -639,7 +674,7 @@ function StructuredChanges({ desc }: { desc: string }) {
   }
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 0 }}>
+    <div className="changelog-notes" style={{ display: 'flex', flexDirection: 'column', gap: 0 }}>
       {sections.map((section, si) => {
         const parsed = parseUpdateDesc(section.content)
         const categories = (['added', 'changed', 'fixed', 'security', 'removed', 'other'] as const).filter((k) => parsed[k].length > 0)

--- a/src/pages/Changelog/index.tsx
+++ b/src/pages/Changelog/index.tsx
@@ -30,8 +30,8 @@ import 'dayjs/locale/zh-cn'
 import relativeTime from 'dayjs/plugin/relativeTime'
 import api from '../../api'
 import { colors, radius, space, font } from '../../styles/tokens'
-import { parseUpdateDesc, getVersionSeverity, formatVersion, parseContributors, detectViewerOS, isHandheld, forcedPlatforms, groupReleases, orderBuilds, noteBlocks, latestDesktopDownloads, offerVersionLabel, offeredAbove, safeDownloadUrl, desktopPlatforms } from './utils'
-import type { VersionSeverity, ChangeCategory, Contributor, ViewerOS, AppVersion, DesktopBuild, DesktopDownload, NoteBlock, ReleaseEntry } from './utils'
+import { parseUpdateDesc, getVersionSeverity, formatVersion, detectViewerOS, isHandheld, forcedPlatforms, entryContributors, groupReleases, orderBuilds, noteBlocks, latestDesktopDownloads, offerVersionLabel, offeredAbove, safeDownloadUrl, desktopPlatforms } from './utils'
+import type { VersionSeverity, ChangeCategory, ChangeItem, Contributor, ViewerOS, AppVersion, DesktopBuild, DesktopDownload, NoteBlock, ReleaseEntry } from './utils'
 import type { PlatformKey } from '../../styles/tokens'
 import { AnalyticsPanel } from './AnalyticsPanel'
 import { useTheme } from '../../hooks/useTheme'
@@ -680,7 +680,7 @@ function splitByTimeTag(desc: string): { time: string | null; content: string }[
 
 /* Announcements are shown but never counted: "1.0.0 版本发布" is the release, not
    something in it, and counting it reports a change the release does not contain. */
-const isChange = (item: { announces?: string }) => item.announces === undefined
+const isChange = (item: ChangeItem) => item.announces === undefined
 
 function countChanges(parsed: ReturnType<typeof parseUpdateDesc>): number {
   return Object.values(parsed).reduce((total, items) => total + items.filter(isChange).length, 0)
@@ -698,6 +698,12 @@ function StructuredChanges({ desc }: { desc: string }) {
     <div className="changelog-notes" style={{ display: 'flex', flexDirection: 'column', gap: 0 }}>
       {sections.map((section, si) => {
         const parsed = parseUpdateDesc(section.content)
+        // Every line an author wrote is rendered under the heading they filed it
+        // under, announcements included — "shown but never counted" is the whole
+        // rule, and filtering the headings by isChange would hide the lines rather
+        // than merely stop counting them. So on a note holding one change and one
+        // announcement the badge shows two bullets while the summary says one:
+        // deliberate, since the alternative is a line disappearing.
         const categories = (['added', 'changed', 'fixed', 'security', 'removed', 'other'] as const).filter((k) => parsed[k].length > 0)
         const totalChanges = countChanges(parsed)
 
@@ -924,19 +930,6 @@ function blockStats(blocks: NoteBlock[]): { added: number; fixed: number; change
   )
 }
 
-function blockContributors(blocks: NoteBlock[]): Contributor[] {
-  const seen = new Set<string>()
-  const all: Contributor[] = []
-  for (const block of blocks) {
-    for (const contributor of parseContributors(block.desc)) {
-      if (seen.has(contributor.name)) continue
-      seen.add(contributor.name)
-      all.push(contributor)
-    }
-  }
-  return all
-}
-
 function getChangeStats(desc: string): { added: number; fixed: number; changed: number } {
   const sections = splitByTimeTag(desc)
   let added = 0, fixed = 0, changed = 0
@@ -1014,7 +1007,7 @@ function ChangelogItem({ item, isFirst, prevVersion, prevTimeLabel }: { item: Re
   // build of one version, and is_force is per build.
   const forcedOn = forcedPlatforms(item).map((os) => platformConfig[os]?.label ?? os)
   const blocks = useMemo(() => noteBlocks(item, viewerOS), [item])
-  const contributors = useMemo(() => blockContributors(blocks), [blocks])
+  const contributors = useMemo(() => entryContributors(item), [item])
   const dotColor = 'var(--timeline-dot-border)'
 
   const dateObj = dayjs(item.created_at)
@@ -1149,7 +1142,7 @@ export function LatestReleaseSpotlight({ item, severity, hideDownloads }: { item
   const dateObj = dayjs(item.created_at)
   const blocks = useMemo(() => noteBlocks(item, viewerOS), [item])
   const stats = useMemo(() => blockStats(blocks), [blocks])
-  const contributors = useMemo(() => blockContributors(blocks), [blocks])
+  const contributors = useMemo(() => entryContributors(item), [item])
   const isWebMerged = isWeb && TIME_TAG_PATTERN.test(item.update_desc)
   const downloadHref = safeDownloadUrl(item.download_url)
 

--- a/src/pages/Changelog/index.tsx
+++ b/src/pages/Changelog/index.tsx
@@ -460,8 +460,15 @@ const MAX_VISIBLE_CONTRIBUTORS = 10
 const MAX_VISIBLE_CONTRIBUTORS_NARROW = 5
 const NARROW_SCREEN = '(max-width: 420px)'
 
+/* Resolved once and shared: getSnapshot runs on every render of every card, and
+   matchMedia hands back a new object each call. */
+let narrowScreenMedia: MediaQueryList | null | undefined
+
 function narrowScreenQuery(): MediaQueryList | null {
-  return typeof window === 'undefined' || !window.matchMedia ? null : window.matchMedia(NARROW_SCREEN)
+  if (narrowScreenMedia === undefined) {
+    narrowScreenMedia = typeof window === 'undefined' || !window.matchMedia ? null : window.matchMedia(NARROW_SCREEN)
+  }
+  return narrowScreenMedia
 }
 
 function subscribeToWidth(notify: () => void): () => void {
@@ -1298,11 +1305,10 @@ export default function Changelog() {
   const latestItem = filtered[0] ?? null
   const restItems = filtered.slice(1)
 
-  // When the newest release is the one the bar above is already offering, the card
-  // would repeat the same two buttons half a screen apart.
-  // Only true when the band actually rendered the buttons: on a handheld it does
-  // not, and the card must keep its own links rather than defer to an offer that
-  // is not there.
+  // When the newest release is the one the band above is already offering, the card
+  // would repeat the same two buttons half a screen apart. Only where the band
+  // actually rendered them: on a handheld it does not, and the card must keep its
+  // own links rather than defer to an offer that is not there.
   const spotlightOfferedAbove = useMemo(
     () => (latestItem && !viewerIsHandheld ? offeredAbove(latestItem, desktopDownloads) : false),
     [latestItem, desktopDownloads],

--- a/src/pages/Changelog/index.tsx
+++ b/src/pages/Changelog/index.tsx
@@ -474,6 +474,13 @@ function narrowScreenQuery(): MediaQueryList | null {
 function subscribeToWidth(notify: () => void): () => void {
   const query = narrowScreenQuery()
   if (!query) return () => {}
+  // Safari below 14 exposes only the deprecated addListener, and this runs inside
+  // useSyncExternalStore's subscribe: throwing here takes the page down rather than
+  // leaving the avatar row at its wider cap.
+  if (typeof query.addEventListener !== 'function') {
+    query.addListener(notify)
+    return () => query.removeListener(notify)
+  }
   query.addEventListener('change', notify)
   return () => query.removeEventListener('change', notify)
 }
@@ -671,9 +678,12 @@ function splitByTimeTag(desc: string): { time: string | null; content: string }[
   return result
 }
 
+/* Announcements are shown but never counted: "1.0.0 版本发布" is the release, not
+   something in it, and counting it reports a change the release does not contain. */
+const isChange = (item: { announces?: string }) => item.announces === undefined
+
 function countChanges(parsed: ReturnType<typeof parseUpdateDesc>): number {
-  return parsed.added.length + parsed.fixed.length + parsed.changed.length
-    + parsed.removed.length + parsed.security.length + parsed.other.length
+  return Object.values(parsed).reduce((total, items) => total + items.filter(isChange).length, 0)
 }
 
 function StructuredChanges({ desc }: { desc: string }) {
@@ -932,9 +942,10 @@ function getChangeStats(desc: string): { added: number; fixed: number; changed: 
   let added = 0, fixed = 0, changed = 0
   for (const section of sections) {
     const parsed = parseUpdateDesc(section.content)
-    added += parsed.added.length
-    fixed += parsed.fixed.length
-    changed += parsed.changed.length + parsed.removed.length + parsed.security.length + parsed.other.length
+    added += parsed.added.filter(isChange).length
+    fixed += parsed.fixed.filter(isChange).length
+    changed += [parsed.changed, parsed.removed, parsed.security, parsed.other]
+      .reduce((total, items) => total + items.filter(isChange).length, 0)
   }
   return { added, fixed, changed }
 }

--- a/src/pages/Changelog/index.tsx
+++ b/src/pages/Changelog/index.tsx
@@ -30,7 +30,7 @@ import 'dayjs/locale/zh-cn'
 import relativeTime from 'dayjs/plugin/relativeTime'
 import api from '../../api'
 import { colors, radius, space, font } from '../../styles/tokens'
-import { parseUpdateDesc, getVersionSeverity, formatVersion, parseContributors, detectViewerOS, isHandheld, groupReleases, orderBuilds, noteBlocks, latestDesktopDownloads, offerVersionLabel, offeredAbove, safeDownloadUrl, desktopPlatforms } from './utils'
+import { parseUpdateDesc, getVersionSeverity, formatVersion, parseContributors, detectViewerOS, isHandheld, forcedPlatforms, groupReleases, orderBuilds, noteBlocks, latestDesktopDownloads, offerVersionLabel, offeredAbove, safeDownloadUrl, desktopPlatforms } from './utils'
 import type { VersionSeverity, ChangeCategory, Contributor, ViewerOS, AppVersion, DesktopBuild, DesktopDownload, NoteBlock, ReleaseEntry } from './utils'
 import type { PlatformKey } from '../../styles/tokens'
 import { AnalyticsPanel } from './AnalyticsPanel'
@@ -992,6 +992,9 @@ function ChangelogItem({ item, isFirst, prevVersion, prevTimeLabel }: { item: Re
   const isWeb = item.os === 'web'
   const severity = getVersionSeverity(item.app_version, prevVersion)
   const isForce = item.is_force === 1
+  // Which platforms are actually being told to upgrade — a card holds every OS
+  // build of one version, and is_force is per build.
+  const forcedOn = forcedPlatforms(item).map((os) => platformConfig[os]?.label ?? os)
   const blocks = useMemo(() => noteBlocks(item, viewerOS), [item])
   const contributors = useMemo(() => blockContributors(blocks), [blocks])
   const dotColor = 'var(--timeline-dot-border)'
@@ -1107,7 +1110,7 @@ function ChangelogItem({ item, isFirst, prevVersion, prevTimeLabel }: { item: Re
                   borderRadius: radius.pill,
                 }}>
                   <WarningOutlined />
-                  必须升级
+                  {forcedOn.length > 0 ? `${forcedOn.join('、')} 必须升级` : '必须升级'}
                 </span>
               )}
               <ContributorAvatars contributors={contributors} showLabel />

--- a/src/pages/Changelog/index.tsx
+++ b/src/pages/Changelog/index.tsx
@@ -30,8 +30,8 @@ import 'dayjs/locale/zh-cn'
 import relativeTime from 'dayjs/plugin/relativeTime'
 import api from '../../api'
 import { colors, radius, space, font } from '../../styles/tokens'
-import { parseUpdateDesc, getVersionSeverity, formatVersion, detectViewerOS, isHandheld, forcedPlatforms, entryContributors, groupReleases, orderBuilds, noteBlocks, latestDesktopDownloads, offerVersionLabel, offeredAbove, safeDownloadUrl, desktopPlatforms } from './utils'
-import type { VersionSeverity, ChangeCategory, ChangeItem, Contributor, ViewerOS, AppVersion, DesktopBuild, DesktopDownload, NoteBlock, ReleaseEntry } from './utils'
+import { parseUpdateDesc, getVersionSeverity, formatVersion, parseContributors, detectViewerOS, isHandheld, forcedPlatforms, groupReleases, orderBuilds, noteBlocks, latestDesktopDownloads, offerVersionLabel, offeredAbove, safeDownloadUrl, desktopPlatforms } from './utils'
+import type { VersionSeverity, ChangeCategory, Contributor, ViewerOS, AppVersion, DesktopBuild, DesktopDownload, NoteBlock, ReleaseEntry } from './utils'
 import type { PlatformKey } from '../../styles/tokens'
 import { AnalyticsPanel } from './AnalyticsPanel'
 import { useTheme } from '../../hooks/useTheme'
@@ -678,12 +678,9 @@ function splitByTimeTag(desc: string): { time: string | null; content: string }[
   return result
 }
 
-/* Announcements are shown but never counted: "1.0.0 版本发布" is the release, not
-   something in it, and counting it reports a change the release does not contain. */
-const isChange = (item: ChangeItem) => item.announces === undefined
-
 function countChanges(parsed: ReturnType<typeof parseUpdateDesc>): number {
-  return Object.values(parsed).reduce((total, items) => total + items.filter(isChange).length, 0)
+  return parsed.added.length + parsed.fixed.length + parsed.changed.length
+    + parsed.removed.length + parsed.security.length + parsed.other.length
 }
 
 function StructuredChanges({ desc }: { desc: string }) {
@@ -698,12 +695,6 @@ function StructuredChanges({ desc }: { desc: string }) {
     <div className="changelog-notes" style={{ display: 'flex', flexDirection: 'column', gap: 0 }}>
       {sections.map((section, si) => {
         const parsed = parseUpdateDesc(section.content)
-        // Every line an author wrote is rendered under the heading they filed it
-        // under, announcements included — "shown but never counted" is the whole
-        // rule, and filtering the headings by isChange would hide the lines rather
-        // than merely stop counting them. So on a note holding one change and one
-        // announcement the badge shows two bullets while the summary says one:
-        // deliberate, since the alternative is a line disappearing.
         const categories = (['added', 'changed', 'fixed', 'security', 'removed', 'other'] as const).filter((k) => parsed[k].length > 0)
         const totalChanges = countChanges(parsed)
 
@@ -930,15 +921,27 @@ function blockStats(blocks: NoteBlock[]): { added: number; fixed: number; change
   )
 }
 
+function blockContributors(blocks: NoteBlock[]): Contributor[] {
+  const seen = new Set<string>()
+  const all: Contributor[] = []
+  for (const block of blocks) {
+    for (const contributor of parseContributors(block.desc)) {
+      if (seen.has(contributor.name)) continue
+      seen.add(contributor.name)
+      all.push(contributor)
+    }
+  }
+  return all
+}
+
 function getChangeStats(desc: string): { added: number; fixed: number; changed: number } {
   const sections = splitByTimeTag(desc)
   let added = 0, fixed = 0, changed = 0
   for (const section of sections) {
     const parsed = parseUpdateDesc(section.content)
-    added += parsed.added.filter(isChange).length
-    fixed += parsed.fixed.filter(isChange).length
-    changed += [parsed.changed, parsed.removed, parsed.security, parsed.other]
-      .reduce((total, items) => total + items.filter(isChange).length, 0)
+    added += parsed.added.length
+    fixed += parsed.fixed.length
+    changed += parsed.changed.length + parsed.removed.length + parsed.security.length + parsed.other.length
   }
   return { added, fixed, changed }
 }
@@ -1007,7 +1010,7 @@ function ChangelogItem({ item, isFirst, prevVersion, prevTimeLabel }: { item: Re
   // build of one version, and is_force is per build.
   const forcedOn = forcedPlatforms(item).map((os) => platformConfig[os]?.label ?? os)
   const blocks = useMemo(() => noteBlocks(item, viewerOS), [item])
-  const contributors = useMemo(() => entryContributors(item), [item])
+  const contributors = useMemo(() => blockContributors(blocks), [blocks])
   const dotColor = 'var(--timeline-dot-border)'
 
   const dateObj = dayjs(item.created_at)
@@ -1142,7 +1145,7 @@ export function LatestReleaseSpotlight({ item, severity, hideDownloads }: { item
   const dateObj = dayjs(item.created_at)
   const blocks = useMemo(() => noteBlocks(item, viewerOS), [item])
   const stats = useMemo(() => blockStats(blocks), [blocks])
-  const contributors = useMemo(() => entryContributors(item), [item])
+  const contributors = useMemo(() => blockContributors(blocks), [blocks])
   const isWebMerged = isWeb && TIME_TAG_PATTERN.test(item.update_desc)
   const downloadHref = safeDownloadUrl(item.download_url)
 

--- a/src/pages/Changelog/utils.test.ts
+++ b/src/pages/Changelog/utils.test.ts
@@ -337,6 +337,19 @@ describe('safeDownloadUrl', () => {
     expect(safeDownloadUrl('\\/attacker.example/x.exe')).toBeNull()
   })
 
+  it('refuses every scheme that is not http(s), however it resolves', () => {
+    expect(safeDownloadUrl('mailto:release@example.com')).toBeNull()
+    expect(safeDownloadUrl('file:///etc/passwd')).toBeNull()
+    expect(safeDownloadUrl('blob:https://cdn.example.com/abc')).toBeNull()
+  })
+
+  it('allows a relative path wherever on this origin it lands', () => {
+    expect(safeDownloadUrl('../releases/a.exe')).toBe('../releases/a.exe')
+    expect(safeDownloadUrl('a.exe')).toBe('a.exe')
+    // A backslash written as data, not as a separator, is a path like any other.
+    expect(safeDownloadUrl('/static/%5C%5Cattacker.example/x.exe')).toBe('/static/%5C%5Cattacker.example/x.exe')
+  })
+
   it('refuses an http(s) scheme with no authority, which is still absolute', () => {
     // "http:attacker.example" on an https page navigates off-origin, not to a path.
     expect(safeDownloadUrl('http:attacker.example')).toBeNull()

--- a/src/pages/Changelog/utils.test.ts
+++ b/src/pages/Changelog/utils.test.ts
@@ -78,6 +78,14 @@ describe('getVersionSeverity', () => {
   it('tags nothing when there is no predecessor to diff against', () => {
     expect(getVersionSeverity('3.2.1')).toBe('unknown')
     expect(getVersionSeverity('3.2.1', 'not-a-version')).toBe('unknown')
+    // parseSemVer reads 1.0.0 out of this one, and it is the opposite of a first
+    // stable release.
+    expect(getVersionSeverity('1.0.0-rc1')).toBe('unknown')
+  })
+
+  it('reads the version prefix however it was typed', () => {
+    expect(getVersionSeverity('v1.0.0')).toBe('initial')
+    expect(getVersionSeverity('V1.0.0')).toBe('initial')
   })
 
   it('tags nothing when the comparison does not move forward', () => {
@@ -474,6 +482,26 @@ describe('latestDesktopDownloads', () => {
 
     for (const feed of [[stable, laterBeta], [laterBeta, stable]]) {
       expect(latestDesktopDownloads(feed).map((build) => build.app_version)).toEqual(['2.0.0'])
+    }
+  })
+
+  it('sees a prerelease token behind an architecture that is not one', () => {
+    // 1.0.0-x86-rc1 names the architecture first, so reading only the token after
+    // the triple calls it stable and hands out a release candidate.
+    const stable = release({ os: 'windows', app_version: '1.0.0', download_url: 'https://x/stable.exe', created_at: '2026-01-01 00:00:00' })
+    const rc = release({ os: 'windows', app_version: '1.0.1-x86-rc1', download_url: 'https://x/rc.exe', created_at: '2026-02-01 00:00:00' })
+
+    for (const feed of [[stable, rc], [rc, stable]]) {
+      expect(latestDesktopDownloads(feed).map((build) => build.download_url)).toEqual(['https://x/stable.exe'])
+    }
+  })
+
+  it('leaves an architecture that is only an architecture alone', () => {
+    const older = release({ os: 'windows', app_version: '1.0.0', download_url: 'https://x/old.exe', created_at: '2026-01-01 00:00:00' })
+    const newer = release({ os: 'windows', app_version: '1.0.1-x64', download_url: 'https://x/new.exe', created_at: '2026-02-01 00:00:00' })
+
+    for (const feed of [[older, newer], [newer, older]]) {
+      expect(latestDesktopDownloads(feed).map((build) => build.download_url)).toEqual(['https://x/new.exe'])
     }
   })
 

--- a/src/pages/Changelog/utils.test.ts
+++ b/src/pages/Changelog/utils.test.ts
@@ -20,11 +20,17 @@ describe('parseContributors', () => {
 })
 
 describe('parseUpdateDesc', () => {
+  it('files a platform-first release announcement under added', () => {
+    const parsed = parseUpdateDesc('Windows 桌面端 1.0.0 版本发布')
+    expect(parsed.added).toEqual([{ text: 'Windows 桌面端 1.0.0 版本发布', group: undefined }])
+    expect(parsed.other).toEqual([])
+  })
+
 
   it('never marks a line that reports a change on its way to the announcement', () => {
-    // Chinese writes without spaces, so any slack in the rule swallows meaning:
-    // these read as bare announcements while the fix they report disappears, and
-    // only the spaced variant — the unusual one — survived.
+    // Chinese writes without spaces, so any rule reading a release out of prose is
+    // tempted to swallow these whole — each reports a fix and mentions the release
+    // in one breath. They must survive as one item with their text intact.
     for (const desc of [
       '2.0.0修复若干问题后正式发布',
       'Windows 桌面端 1.0.0修复白屏后正式发布。',
@@ -32,13 +38,12 @@ describe('parseUpdateDesc', () => {
     ]) {
       const items = Object.values(parseUpdateDesc(desc)).flat()
       expect(items).toHaveLength(1)
-      expect(items[0].announces).toBeUndefined()
     }
   })
 
-  it('never marks a line that says anything besides the announcement', () => {
-    // Marking these would let a card drop them, and a reader cannot tell a note
-    // that was never written from one a regex removed.
+  it('keeps a line that says anything besides an announcement whole', () => {
+    // The shapes a release-detection rule mistakes for announcements. Nothing on
+    // this page removes a note today; these pin the parse so that stays true.
     for (const desc of [
       '白屏崩溃已解决，伴随 1.0.0 版本发布',
       '协议从 1.0 升级到 2.0 正式上线',
@@ -48,7 +53,6 @@ describe('parseUpdateDesc', () => {
     ]) {
       const items = Object.values(parseUpdateDesc(desc)).flat()
       expect(items).toHaveLength(1)
-      expect(items[0].announces).toBeUndefined()
       expect(items[0].text).toContain(desc.slice(0, 4))
     }
   })

--- a/src/pages/Changelog/utils.test.ts
+++ b/src/pages/Changelog/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { announcesOnly, detectViewerOS, forcedPlatforms, formatVersion, isHandheld, getVersionSeverity, groupReleases, latestDesktopDownloads, noteBlocks, offerVersionLabel, offeredAbove, orderBuilds, parseContributors, parseUpdateDesc, safeDownloadUrl } from './utils'
+import { detectViewerOS, forcedPlatforms, formatVersion, isHandheld, getVersionSeverity, groupReleases, latestDesktopDownloads, noteBlocks, offerVersionLabel, offeredAbove, orderBuilds, parseContributors, parseUpdateDesc, safeDownloadUrl } from './utils'
 import type { AppVersion } from './utils'
 
 describe('parseContributors', () => {
@@ -113,46 +113,6 @@ describe('parseUpdateDesc', () => {
   })
 })
 
-describe('announcesOnly', () => {
-  it('is true only for a note announcing this release, on this platform', () => {
-    expect(announcesOnly('Windows 桌面端 1.0.0 版本发布', '1.0.0', 'windows')).toBe(true)
-    expect(announcesOnly('Windows 桌面端 1.0.0 版本发布', 'v1.0', 'windows')).toBe(true)
-    // No subject at all can only be about the release it sits on.
-    expect(announcesOnly('1.0.0 版本发布', '1.0.0', 'windows')).toBe(true)
-    // A full stop is punctuation, not a change of meaning.
-    expect(announcesOnly('Windows 桌面端 1.0.0 版本发布。', '1.0.0', 'windows')).toBe(true)
-  })
-
-  it('keeps a note whose subject is something else that reached this number', () => {
-    // A version number names no particular thing: the plugin market can reach 2.0
-    // in the same train that takes the desktop app to 2.0.0. Matching on the number
-    // alone read this as the card repeating itself and deleted the news.
-    expect(announcesOnly('插件市场 2.0 正式上线', '2.0.0', 'windows')).toBe(false)
-    expect(announcesOnly('深色模式 3.0 正式发布', '3.0.0', 'windows')).toBe(false)
-    // And the Windows note on a card does not get to announce macOS.
-    expect(announcesOnly('Mac 桌面端 1.0.0 版本发布', '1.0.0', 'windows')).toBe(false)
-  })
-
-  it('keeps a note announcing anything other than this release', () => {
-    expect(announcesOnly('插件市场 2.0 正式上线', '1.0.0', 'windows')).toBe(false)
-    expect(announcesOnly('白屏崩溃已解决，伴随 1.0.0 版本发布', '1.0.0', 'windows')).toBe(false)
-  })
-
-  it('keeps a note that announces the release and then says something', () => {
-    expect(announcesOnly('Windows 桌面端 1.0.0 版本发布\n修复：启动白屏', '1.0.0', 'windows')).toBe(false)
-  })
-
-  it('is unmoved by a credit line, which the card reads from elsewhere', () => {
-    // The block goes; the credits do not, because entryContributors() reads them
-    // off the entry rather than off the blocks that survived.
-    expect(announcesOnly('Windows 桌面端 1.0.0 版本发布\n@contributors: alice, bob', '1.0.0', 'windows')).toBe(true)
-  })
-
-  it('is false for a note with nothing in it, which has its own handling', () => {
-    expect(announcesOnly('', '1.0.0', 'windows')).toBe(false)
-  })
-})
-
 describe('getVersionSeverity', () => {
   it('marks a 1.0.0 with no predecessor as the initial release', () => {
     expect(getVersionSeverity('1.0.0')).toBe('initial')
@@ -208,21 +168,12 @@ describe('groupReleases', () => {
       { os: 'windows', download_url: 'https://x/setup.exe', created_at: '2026-08-20 16:34:04', is_force: 0, update_desc: 'Windows 桌面端 1.0.0 版本发布' },
       { os: 'macos', download_url: 'https://x/octo.dmg', created_at: '2026-08-20 14:18:06', is_force: 0, update_desc: 'Mac 桌面端 1.0.0 版本发布' },
     ])
-    // The card is dated by the newest build.
+    // The card is dated by the newest build, and every build's notes are reachable.
     expect(entry.created_at).toBe('2026-08-20 16:34:04')
-    // Both notes only announce the release the card is already titled after, so
-    // the card renders no body rather than two platform headings over two lines
-    // that repeat its header.
-    expect(noteBlocks(entry)).toEqual([])
-  })
-
-  it('keeps the platforms that said something when another only announced itself', () => {
-    const [entry] = groupReleases([
-      release({ os: 'windows', app_version: '1.0.0', update_desc: 'Windows 桌面端 1.0.0 版本发布' }),
-      release({ os: 'macos', app_version: '1.0.0', update_desc: '修复：外接显示器下的窗口错位' }),
+    expect(noteBlocks(entry).map((block) => block.desc)).toEqual([
+      'Windows 桌面端 1.0.0 版本发布',
+      'Mac 桌面端 1.0.0 版本发布',
     ])
-
-    expect(noteBlocks(entry)).toEqual([{ os: ['macos'], desc: '修复：外接显示器下的窗口错位' }])
   })
 
   it('keeps identical per-OS notes from being repeated on the card', () => {

--- a/src/pages/Changelog/utils.test.ts
+++ b/src/pages/Changelog/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { detectViewerOS, getVersionSeverity, groupReleases, latestDesktopDownloads, noteBlocks, offerVersionLabel, offeredAbove, orderBuilds, parseContributors, parseUpdateDesc, safeDownloadUrl } from './utils'
+import { detectViewerOS, isHandheld, getVersionSeverity, groupReleases, latestDesktopDownloads, noteBlocks, offerVersionLabel, offeredAbove, orderBuilds, parseContributors, parseUpdateDesc, safeDownloadUrl } from './utils'
 import type { AppVersion } from './utils'
 
 describe('parseContributors', () => {
@@ -228,6 +228,29 @@ describe('detectViewerOS', () => {
     expect(detectViewerOS('Mozilla/5.0 (X11; CrOS x86_64 14541.0.0)')).toBeNull()
     // iPadOS claims to be a Mac; the touch points are the tell.
     expect(detectViewerOS('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15', 5)).toBeNull()
+  })
+})
+
+describe('isHandheld', () => {
+  it('names the devices that cannot run an installer at all', () => {
+    expect(isHandheld('Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)')).toBe(true)
+    expect(isHandheld('Mozilla/5.0 (Linux; Android 14; Pixel 8)')).toBe(true)
+    expect(isHandheld('Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X)')).toBe(true)
+    // iPadOS claims to be a Mac; the touch points are the tell.
+    expect(isHandheld('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15', 5)).toBe(true)
+  })
+
+  it('leaves every desktop alone, recognised or not', () => {
+    expect(isHandheld('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36')).toBe(false)
+    expect(isHandheld('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36')).toBe(false)
+    expect(isHandheld('Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36')).toBe(false)
+    // A Chromebook runs neither installer, but it is a computer: whoever visits
+    // from one is browsing on the class of device the offer is aimed at, and
+    // detectViewerOS staying silent is the whole answer there.
+    expect(isHandheld('Mozilla/5.0 (X11; CrOS x86_64 14541.0.0)')).toBe(false)
+    // The one UA that must not be read as a phone: a desktop nothing recognises,
+    // which is exactly who needs the offer.
+    expect(isHandheld('SomeBrowser/1.0')).toBe(false)
   })
 })
 

--- a/src/pages/Changelog/utils.test.ts
+++ b/src/pages/Changelog/utils.test.ts
@@ -745,6 +745,14 @@ describe('formatVersion', () => {
     // isPrerelease reads underscores in a qualifier; the two readers have to agree,
     // or a card is titled v1.0.0-x86 for a build called 1.0.0-x86_64.
     expect(formatVersion('1.0.0-x86_64')).toBe('1.0.0-x86_64')
+    expect(formatVersion('1.0.1_rc1')).toBe('1.0.1_rc1')
+  })
+
+  it('does not read the separator of a date-shaped version as a qualifier', () => {
+    // isPrerelease splits on the dot as well, but a version is written with dots:
+    // accepting one here renders a 2026.04.16 web version as 2026.4.16.16.
+    expect(formatVersion('2026.04.16')).toBe('2026.4.16')
+    expect(formatVersion('2026.08.03')).toBe('2026.8.3')
   })
 
   it('hands back a string it cannot read a version out of', () => {
@@ -763,6 +771,21 @@ describe('offerVersionLabel', () => {
     // The band sits above a button handing over the release candidate; "v1.0.0"
     // there would name a release nobody can download yet.
     expect(offerVersionLabel([offer('1.0.0-rc1')])).toBe('v1.0.0-rc1')
+  })
+
+  it('says nothing over a prerelease however its qualifier is spelled', () => {
+    // isPrerelease reads _rc1 and .rc1; formatVersion does not read the dot. Asking
+    // "do these format alike" first therefore badged v1.0.0 over the button handing
+    // out the candidate — the label has to be gated on being one release, not on
+    // formatting alike.
+    for (const rc of ['1.0.0-rc1', '1.0.0_rc1', '1.0.0.rc1']) {
+      expect(offerVersionLabel([offer('1.0.0'), { ...offer(rc), os: 'macos' }])).toBeNull()
+    }
+  })
+
+  it('still labels a lone prerelease, which misdescribes nothing', () => {
+    expect(offerVersionLabel([offer('1.0.0-rc1')])).toBe('v1.0.0-rc1')
+    expect(offerVersionLabel([offer('1.0.0-rc1'), { ...offer('1.0.0-rc1'), os: 'macos' }])).toBe('v1.0.0-rc1')
   })
 
   it('reads two architectures of one version as one release', () => {

--- a/src/pages/Changelog/utils.test.ts
+++ b/src/pages/Changelog/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { detectViewerOS, forcedPlatforms, formatVersion, isHandheld, isPrerelease, getVersionSeverity, groupReleases, latestDesktopDownloads, noteBlocks, offerVersionLabel, offeredAbove, orderBuilds, parseContributors, parseUpdateDesc, safeDownloadUrl } from './utils'
+import { detectViewerOS, forcedPlatforms, isHandheld, getVersionSeverity, groupReleases, latestDesktopDownloads, noteBlocks, offerVersionLabel, offeredAbove, orderBuilds, parseContributors, parseUpdateDesc, safeDownloadUrl } from './utils'
 import type { AppVersion } from './utils'
 
 describe('parseContributors', () => {
@@ -20,23 +20,6 @@ describe('parseContributors', () => {
 })
 
 describe('parseUpdateDesc', () => {
-  it('marks a line that only announces a release, and files it under 其他', () => {
-    // Marked, not deleted: the card counters skip it, so shipping stops being
-    // reported as a feature, but a reader still sees every line an author wrote.
-    const parsed = parseUpdateDesc('Windows 桌面端 1.0.0 版本发布')
-    expect(parsed.added).toEqual([])
-    expect(parsed.other).toEqual([{ text: 'Windows 桌面端 1.0.0 版本发布', group: undefined, announces: { version: '1.0.0', subject: 'Windows 桌面端' } }])
-  })
-
-  it('marks the announcement wherever the note happens to file it', () => {
-    // The counters read the mark, not the category, so all three shapes of the same
-    // sentence stop inflating 新增 — under a heading, behind a prefix, or bare.
-    for (const desc of ['新增\n- Windows 桌面端 1.0.0 版本发布', '新增：Windows 桌面端 1.0.0 版本发布']) {
-      expect(parseUpdateDesc(desc).added).toEqual([
-        { text: 'Windows 桌面端 1.0.0 版本发布', group: undefined, announces: { version: '1.0.0', subject: 'Windows 桌面端' } },
-      ])
-    }
-  })
 
   it('never marks a line that reports a change on its way to the announcement', () => {
     // Chinese writes without spaces, so any slack in the rule swallows meaning:
@@ -68,31 +51,6 @@ describe('parseUpdateDesc', () => {
       expect(items[0].announces).toBeUndefined()
       expect(items[0].text).toContain(desc.slice(0, 4))
     }
-  })
-
-  it('marks an announcement whichever separator its version carries', () => {
-    // Unmarked meant counted: a release announcing itself was reported as a feature
-    // whenever the version was spelled with a separator this rule did not read.
-    for (const version of ['1.0.0-rc1', '1.0.0_rc1', '1.0.0.rc1', '1.0.0+arm64']) {
-      const parsed = parseUpdateDesc(`Windows 桌面端 ${version} 版本发布`)
-      const items = [...parsed.added, ...parsed.other]
-      expect(items).toHaveLength(1)
-      expect(items[0].announces?.version).toBe(version)
-    }
-  })
-
-  it('keeps an announcement that names a feature rather than a version', () => {
-    expect(parseUpdateDesc('深色模式正式发布').added).toEqual([{ text: '深色模式正式发布', group: undefined }])
-    // A number in a feature's name is not the sentence announcing a release: the
-    // version has to sit next to the announcement, not merely somewhere in the line.
-    expect(parseUpdateDesc('1.5x 倍速播放正式上线').added).toHaveLength(1)
-  })
-
-  it('leaves prose that ends in 上线 without an announcement qualifier alone', () => {
-    // Dropping requires the same 正式/首次/版本 qualifier the rule above requires;
-    // without it a line naming a version is still just a line.
-    expect(parseUpdateDesc('TLS 1.3 通道上线').other).toHaveLength(1)
-    expect(parseUpdateDesc('TLS 1.3 通道上线').added).toEqual([])
   })
 
   it('keeps an explicit prefix ahead of the release-announcement fallback', () => {
@@ -142,11 +100,6 @@ describe('getVersionSeverity', () => {
     // parseSemVer reads 1.0.0 out of this one, and it is the opposite of a first
     // stable release.
     expect(getVersionSeverity('1.0.0-rc1')).toBe('unknown')
-  })
-
-  it('reads the version prefix however it was typed', () => {
-    expect(getVersionSeverity('v1.0.0')).toBe('initial')
-    expect(getVersionSeverity('V1.0.0')).toBe('initial')
   })
 
   it('tags nothing when the comparison does not move forward', () => {
@@ -462,7 +415,6 @@ describe('safeDownloadUrl', () => {
   })
 })
 
-
 describe('noteBlocks', () => {
   it("keeps each platform's lines under the section that platform filed them in", () => {
     // parseUpdateDesc is stateful: a 【…】 heading owns every line below it. Merging
@@ -566,68 +518,6 @@ describe('latestDesktopDownloads', () => {
 
     for (const feed of [[stable, laterBeta], [laterBeta, stable]]) {
       expect(latestDesktopDownloads(feed).map((build) => build.app_version)).toEqual(['2.0.0'])
-    }
-  })
-
-  it('sees a prerelease token behind an architecture that is not one', () => {
-    // 1.0.0-x86-rc1 names the architecture first, so reading only the token after
-    // the triple calls it stable and hands out a release candidate.
-    const stable = release({ os: 'windows', app_version: '1.0.0', download_url: 'https://x/stable.exe', created_at: '2026-01-01 00:00:00' })
-    const rc = release({ os: 'windows', app_version: '1.0.1-x86-rc1', download_url: 'https://x/rc.exe', created_at: '2026-02-01 00:00:00' })
-
-    for (const feed of [[stable, rc], [rc, stable]]) {
-      expect(latestDesktopDownloads(feed).map((build) => build.download_url)).toEqual(['https://x/stable.exe'])
-    }
-  })
-
-  it('sees a prerelease token however the qualifier is spelled', () => {
-    // semver's own separator is the dot, and an architecture is as likely to be
-    // written x86_64 as x86. Splitting on the hyphen alone left both unread, and
-    // the band then offered a release candidate over the stable it precedes.
-    const stable = release({ os: 'windows', app_version: '1.0.0', download_url: 'https://x/stable.exe', created_at: '2026-01-01 00:00:00' })
-    for (const spelling of ['1.0.1-x86.rc1', '1.0.1-x86_64-rc1']) {
-      const rc = release({ os: 'windows', app_version: spelling, download_url: 'https://x/rc.exe', created_at: '2026-02-01 00:00:00' })
-      for (const feed of [[stable, rc], [rc, stable]]) {
-        expect(latestDesktopDownloads(feed).map((build) => build.download_url)).toEqual(['https://x/stable.exe'])
-      }
-    }
-  })
-
-  it('does not let build metadata after a + decide a release is a candidate', () => {
-    // semver reads everything past the + as belonging to the release it hangs off,
-    // so no wording there makes the release a candidate. Ranking it as one held a
-    // newer stable build back behind an older release.
-    for (const version of ['2.0.0+rc1', '2.0.0+x64-rc1', '2.0.0+win-beta', '2.0.0+build.rc1', '1.2.3+arm64']) {
-      expect(isPrerelease(version)).toBe(false)
-    }
-    // A qualifier ahead of the metadata still counts.
-    expect(isPrerelease('2.0.0-rc1+build5')).toBe(true)
-  })
-
-  it('offers the newest stable build even when its metadata mentions a candidate', () => {
-    const older = release({ os: 'windows', app_version: '1.9.0', download_url: 'https://x/old.exe', created_at: '2026-01-01 00:00:00' })
-    const newer = release({ os: 'windows', app_version: '2.0.0+x64-rc1', download_url: 'https://x/new.exe', created_at: '2026-02-01 00:00:00' })
-
-    for (const feed of [[older, newer], [newer, older]]) {
-      expect(latestDesktopDownloads(feed).map((build) => build.download_url)).toEqual(['https://x/new.exe'])
-    }
-  })
-
-  it('does not read a word that merely starts like a qualifier as one', () => {
-    const older = release({ os: 'windows', app_version: '1.2.2', download_url: 'https://x/old.exe', created_at: '2026-01-01 00:00:00' })
-    const prebuilt = release({ os: 'windows', app_version: '1.2.3-prebuilt', download_url: 'https://x/new.exe', created_at: '2026-02-01 00:00:00' })
-
-    for (const feed of [[older, prebuilt], [prebuilt, older]]) {
-      expect(latestDesktopDownloads(feed).map((build) => build.download_url)).toEqual(['https://x/new.exe'])
-    }
-  })
-
-  it('leaves an architecture that is only an architecture alone', () => {
-    const older = release({ os: 'windows', app_version: '1.0.0', download_url: 'https://x/old.exe', created_at: '2026-01-01 00:00:00' })
-    const newer = release({ os: 'windows', app_version: '1.0.1-x64', download_url: 'https://x/new.exe', created_at: '2026-02-01 00:00:00' })
-
-    for (const feed of [[older, newer], [newer, older]]) {
-      expect(latestDesktopDownloads(feed).map((build) => build.download_url)).toEqual(['https://x/new.exe'])
     }
   })
 
@@ -755,103 +645,11 @@ describe('forcedPlatforms', () => {
   })
 })
 
-describe('formatVersion', () => {
-  it('normalises what is only written differently', () => {
-    expect(formatVersion('1.0')).toBe('1.0.0')
-    expect(formatVersion('v2.3.4')).toBe('2.3.4')
-    expect(formatVersion('1.0.0(62)')).toBe('1.0.0(62)')
-    // A patch number typed as nothing at all.
-    expect(formatVersion('1.0.(63)')).toBe('1.0.0(63)')
-  })
-
-  it('keeps the qualifier that says which release this is', () => {
-    // Dropping it titles a release-candidate card "v1.0.0" — the name of a build
-    // that does not exist yet.
-    expect(formatVersion('1.0.0-rc1')).toBe('1.0.0-rc1')
-    expect(formatVersion('2.0.0-beta.2')).toBe('2.0.0-beta.2')
-    expect(formatVersion('1.2.3-x64(9)')).toBe('1.2.3-x64(9)')
-    // Build metadata after '+' distinguishes two releases just as a '-' suffix does,
-    // now that formatting alike is what decides whether two installers are one.
-    expect(formatVersion('1.2.3+arm64')).toBe('1.2.3+arm64')
-    // isPrerelease reads underscores in a qualifier; the two readers have to agree,
-    // or a card is titled v1.0.0-x86 for a build called 1.0.0-x86_64.
-    expect(formatVersion('1.0.0-x86_64')).toBe('1.0.0-x86_64')
-    expect(formatVersion('1.0.1_rc1')).toBe('1.0.1_rc1')
-  })
-
-  it('reads a qualifier the same way whichever separator opens it', () => {
-    // Three expressions used to read a qualifier and had drifted into three
-    // alphabets, so the same build was a prerelease to the ranking, a stable
-    // release to the title, and a feature to the counter.
-    expect(formatVersion('1.0.1_rc1')).toBe('1.0.1_rc1')
-    expect(formatVersion('1.0.1.rc1')).toBe('1.0.1.rc1')
-    expect(formatVersion('1.0.1-rc1')).toBe('1.0.1-rc1')
-  })
-
-  it('does not read the separator of a date-shaped version as a qualifier', () => {
-    // isPrerelease splits on the dot as well, but a version is written with dots:
-    // accepting one here renders a 2026.04.16 web version as 2026.4.16.16.
-    expect(formatVersion('2026.04.16')).toBe('2026.4.16')
-    expect(formatVersion('2026.08.03')).toBe('2026.8.3')
-    // A dot opener is only a qualifier when a letter follows it. The fourth part of
-    // a Windows-style version is a number and stays part of the number.
-    expect(formatVersion('1.0.0.1')).toBe('1.0.0')
-  })
-
-  it('hands back a string it cannot read a version out of', () => {
-    expect(formatVersion('内测版')).toBe('内测版')
-  })
-})
-
 describe('offerVersionLabel', () => {
   const offer = (app_version: string) => ({ os: 'windows', app_version, download_url: 'https://x/a.exe', created_at: '2026-08-20 16:00:00', is_force: 0, update_desc: '' })
 
   it('labels a shared stable version', () => {
     expect(offerVersionLabel([offer('1.0.0'), { ...offer('1.0.0'), os: 'macos' }])).toBe('v1.0.0')
-  })
-
-  it('keeps the qualifier rather than badging a prerelease as the stable it is not', () => {
-    // The band sits above a button handing over the release candidate; "v1.0.0"
-    // there would name a release nobody can download yet.
-    expect(offerVersionLabel([offer('1.0.0-rc1')])).toBe('v1.0.0-rc1')
-  })
-
-  it('says nothing over a prerelease however its qualifier is spelled', () => {
-    // isPrerelease reads _rc1 and .rc1; formatVersion does not read the dot. Asking
-    // "do these format alike" first therefore badged v1.0.0 over the button handing
-    // out the candidate — the label has to be gated on being one release, not on
-    // formatting alike.
-    for (const rc of ['1.0.0-rc1', '1.0.0_rc1', '1.0.0.rc1']) {
-      expect(offerVersionLabel([offer('1.0.0'), { ...offer(rc), os: 'macos' }])).toBeNull()
-    }
-  })
-
-  it('still labels a lone prerelease, in the spelling it was written in', () => {
-    // Not just v1.0.0: the label sits above the button handing that build over, so
-    // dropping the qualifier names a release the visitor is not being given.
-    expect(offerVersionLabel([offer('1.0.0-rc1')])).toBe('v1.0.0-rc1')
-    expect(offerVersionLabel([offer('1.0.0_rc1')])).toBe('v1.0.0_rc1')
-    expect(offerVersionLabel([offer('1.0.0.rc1')])).toBe('v1.0.0.rc1')
-    expect(offerVersionLabel([offer('1.0.0-rc1'), { ...offer('1.0.0-rc1'), os: 'macos' }])).toBe('v1.0.0-rc1')
-  })
-
-  it('reads two architectures of one version as one release', () => {
-    // isPrerelease already says -x64 is an architecture rather than a release
-    // distinction; the label has to agree, or the band drops the version line for
-    // a release that has one.
-    expect(offerVersionLabel([offer('1.0.0-x64'), { ...offer('1.0.0-arm64'), os: 'macos' }])).toBe('v1.0.0')
-    // A prerelease among them is a different release, and still says nothing.
-    expect(offerVersionLabel([offer('1.0.0-x64'), { ...offer('1.0.0-rc1'), os: 'macos' }])).toBeNull()
-  })
-
-  it('says nothing about a version string it cannot read', () => {
-    // A "v" in front of free text claims the text is a version.
-    expect(offerVersionLabel([offer('内测版')])).toBeNull()
-    expect(offerVersionLabel([offer('1.0.0'), { ...offer('内测版'), os: 'macos' }])).toBeNull()
-  })
-
-  it('reads one release written two ways as one release', () => {
-    expect(offerVersionLabel([offer('1.0'), { ...offer('1.0.0'), os: 'macos' }])).toBe('v1.0.0')
   })
 
   it('says nothing when one platform is on a prerelease and another is not', () => {

--- a/src/pages/Changelog/utils.test.ts
+++ b/src/pages/Changelog/utils.test.ts
@@ -151,6 +151,21 @@ describe('groupReleases', () => {
     }
   })
 
+  it('links the same installer the band offers when two rows tie on the second', () => {
+    // Two uploads of one OS at the same timestamp: the card and the band each pick
+    // a winner, and if they break the tie differently the page shows a version and
+    // hands over a different file.
+    const rows = [
+      release({ os: 'windows', app_version: '1.0.0', download_url: 'https://x/a.exe', created_at: '2026-08-20 16:34:04' }),
+      release({ os: 'windows', app_version: '1.0.0', download_url: 'https://x/b.exe', created_at: '2026-08-20 16:34:04' }),
+    ]
+
+    for (const feed of [rows, [...rows].reverse()]) {
+      const [entry] = groupReleases(feed)
+      expect(entry.builds?.[0].download_url).toBe(latestDesktopDownloads(feed)[0].download_url)
+    }
+  })
+
   it('does not let a superseded upload force the build the card links', () => {
     const [entry] = groupReleases([
       release({ os: 'windows', app_version: '3.0.0', download_url: 'https://x/new.exe', created_at: '2026-08-20 18:00:00', is_force: 0 }),

--- a/src/pages/Changelog/utils.test.ts
+++ b/src/pages/Changelog/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { detectViewerOS, isHandheld, getVersionSeverity, groupReleases, latestDesktopDownloads, noteBlocks, offerVersionLabel, offeredAbove, orderBuilds, parseContributors, parseUpdateDesc, safeDownloadUrl } from './utils'
+import { detectViewerOS, formatVersion, isHandheld, getVersionSeverity, groupReleases, latestDesktopDownloads, noteBlocks, offerVersionLabel, offeredAbove, orderBuilds, parseContributors, parseUpdateDesc, safeDownloadUrl } from './utils'
 import type { AppVersion } from './utils'
 
 describe('parseContributors', () => {
@@ -557,6 +557,28 @@ describe('offeredAbove', () => {
   })
 })
 
+describe('formatVersion', () => {
+  it('normalises what is only written differently', () => {
+    expect(formatVersion('1.0')).toBe('1.0.0')
+    expect(formatVersion('v2.3.4')).toBe('2.3.4')
+    expect(formatVersion('1.0.0(62)')).toBe('1.0.0(62)')
+    // A patch number typed as nothing at all.
+    expect(formatVersion('1.0.(63)')).toBe('1.0.0(63)')
+  })
+
+  it('keeps the qualifier that says which release this is', () => {
+    // Dropping it titles a release-candidate card "v1.0.0" — the name of a build
+    // that does not exist yet.
+    expect(formatVersion('1.0.0-rc1')).toBe('1.0.0-rc1')
+    expect(formatVersion('2.0.0-beta.2')).toBe('2.0.0-beta.2')
+    expect(formatVersion('1.2.3-x64(9)')).toBe('1.2.3-x64(9)')
+  })
+
+  it('hands back a string it cannot read a version out of', () => {
+    expect(formatVersion('内测版')).toBe('内测版')
+  })
+})
+
 describe('offerVersionLabel', () => {
   const offer = (app_version: string) => ({ os: 'windows', app_version, download_url: 'https://x/a.exe', created_at: '2026-08-20 16:00:00', is_force: 0, update_desc: '' })
 
@@ -564,10 +586,20 @@ describe('offerVersionLabel', () => {
     expect(offerVersionLabel([offer('1.0.0'), { ...offer('1.0.0'), os: 'macos' }])).toBe('v1.0.0')
   })
 
-  it('keeps a prerelease verbatim rather than badging it as the stable it is not', () => {
-    // formatVersion drops the suffix, so this would otherwise read "v1.0.0" above a
-    // button handing over the release candidate.
-    expect(offerVersionLabel([offer('1.0.0-rc1')])).toBe('1.0.0-rc1')
+  it('keeps the qualifier rather than badging a prerelease as the stable it is not', () => {
+    // The band sits above a button handing over the release candidate; "v1.0.0"
+    // there would name a release nobody can download yet.
+    expect(offerVersionLabel([offer('1.0.0-rc1')])).toBe('v1.0.0-rc1')
+  })
+
+  it('says nothing about a version string it cannot read', () => {
+    // A "v" in front of free text claims the text is a version.
+    expect(offerVersionLabel([offer('内测版')])).toBeNull()
+    expect(offerVersionLabel([offer('1.0.0'), { ...offer('内测版'), os: 'macos' }])).toBeNull()
+  })
+
+  it('reads one release written two ways as one release', () => {
+    expect(offerVersionLabel([offer('1.0'), { ...offer('1.0.0'), os: 'macos' }])).toBe('v1.0.0')
   })
 
   it('says nothing when one platform is on a prerelease and another is not', () => {

--- a/src/pages/Changelog/utils.test.ts
+++ b/src/pages/Changelog/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { detectViewerOS, forcedPlatforms, formatVersion, isHandheld, getVersionSeverity, groupReleases, latestDesktopDownloads, noteBlocks, offerVersionLabel, offeredAbove, orderBuilds, parseContributors, parseUpdateDesc, safeDownloadUrl } from './utils'
+import { announcesOnly, detectViewerOS, forcedPlatforms, formatVersion, isHandheld, getVersionSeverity, groupReleases, latestDesktopDownloads, noteBlocks, offerVersionLabel, offeredAbove, orderBuilds, parseContributors, parseUpdateDesc, safeDownloadUrl } from './utils'
 import type { AppVersion } from './utils'
 
 describe('parseContributors', () => {
@@ -20,12 +20,39 @@ describe('parseContributors', () => {
 })
 
 describe('parseUpdateDesc', () => {
-  it('drops a line that only announces the release it belongs to', () => {
-    // The card header says v1.0.0, Windows and Initial Release already. Kept, the
-    // line reads as a feature, and the card's own counter then reports 新增 1.
+  it('marks a line that only announces a release, and files it under 其他', () => {
+    // Marked, not deleted: the card counters skip it, so shipping stops being
+    // reported as a feature, but a reader still sees every line an author wrote.
     const parsed = parseUpdateDesc('Windows 桌面端 1.0.0 版本发布')
     expect(parsed.added).toEqual([])
-    expect(parsed.other).toEqual([])
+    expect(parsed.other).toEqual([{ text: 'Windows 桌面端 1.0.0 版本发布', group: undefined, announces: '1.0.0' }])
+  })
+
+  it('marks the announcement wherever the note happens to file it', () => {
+    // The counters read the mark, not the category, so all three shapes of the same
+    // sentence stop inflating 新增 — under a heading, behind a prefix, or bare.
+    for (const desc of ['新增\n- Windows 桌面端 1.0.0 版本发布', '新增：Windows 桌面端 1.0.0 版本发布']) {
+      expect(parseUpdateDesc(desc).added).toEqual([
+        { text: 'Windows 桌面端 1.0.0 版本发布', group: undefined, announces: '1.0.0' },
+      ])
+    }
+  })
+
+  it('never marks a line that says anything besides the announcement', () => {
+    // Marking these would let a card drop them, and a reader cannot tell a note
+    // that was never written from one a regex removed.
+    for (const desc of [
+      '白屏崩溃已解决，伴随 1.0.0 版本发布',
+      '协议从 1.0 升级到 2.0 正式上线',
+      '1.5x 倍速播放正式上线',
+      '深色模式正式发布',
+      'TLS 1.3 通道上线',
+    ]) {
+      const items = Object.values(parseUpdateDesc(desc)).flat()
+      expect(items).toHaveLength(1)
+      expect(items[0].announces).toBeUndefined()
+      expect(items[0].text).toContain(desc.slice(0, 4))
+    }
   })
 
   it('keeps an announcement that names a feature rather than a version', () => {
@@ -68,6 +95,28 @@ describe('parseUpdateDesc', () => {
   it('does not read ordinary prose that merely ends in 上线 as a new feature', () => {
     expect(parseUpdateDesc('问题：功能无法上线').other).toHaveLength(1)
     expect(parseUpdateDesc('问题：功能无法上线').added).toEqual([])
+  })
+})
+
+describe('announcesOnly', () => {
+  it('is true only for a note that announces the very release it sits on', () => {
+    expect(announcesOnly('Windows 桌面端 1.0.0 版本发布', '1.0.0')).toBe(true)
+    expect(announcesOnly('Windows 桌面端 1.0.0 版本发布', 'v1.0')).toBe(true)
+  })
+
+  it('keeps a note announcing anything other than this release', () => {
+    // Same sentence, different subject: the plugin market shipping 2.0 is news on
+    // the 1.0.0 card, not a restatement of its headline.
+    expect(announcesOnly('插件市场 2.0 正式上线', '1.0.0')).toBe(false)
+    expect(announcesOnly('白屏崩溃已解决，伴随 1.0.0 版本发布', '1.0.0')).toBe(false)
+  })
+
+  it('keeps a note that announces the release and then says something', () => {
+    expect(announcesOnly('Windows 桌面端 1.0.0 版本发布\n修复：启动白屏', '1.0.0')).toBe(false)
+  })
+
+  it('is false for a note with nothing in it, which has its own handling', () => {
+    expect(announcesOnly('', '1.0.0')).toBe(false)
   })
 })
 
@@ -369,6 +418,14 @@ describe('safeDownloadUrl', () => {
     expect(safeDownloadUrl('\\/attacker.example/x.exe')).toBeNull()
   })
 
+  it('refuses a URL it could only approve by reading a different string', () => {
+    // A space is not ignored inside a URL the way a tab is — it is a forbidden host
+    // code point. Deciding on a copy with it removed approved one link and
+    // published another.
+    expect(safeDownloadUrl('http:// evil.com')).toBeNull()
+    expect(safeDownloadUrl('https://evil.com .good.com')).toBeNull()
+  })
+
   it('refuses every scheme that is not http(s), however it resolves', () => {
     expect(safeDownloadUrl('mailto:release@example.com')).toBeNull()
     expect(safeDownloadUrl('file:///etc/passwd')).toBeNull()
@@ -505,6 +562,15 @@ describe('latestDesktopDownloads', () => {
 
     for (const feed of [[stable, rc], [rc, stable]]) {
       expect(latestDesktopDownloads(feed).map((build) => build.download_url)).toEqual(['https://x/stable.exe'])
+    }
+  })
+
+  it('does not read a word that merely starts like a qualifier as one', () => {
+    const older = release({ os: 'windows', app_version: '1.2.2', download_url: 'https://x/old.exe', created_at: '2026-01-01 00:00:00' })
+    const prebuilt = release({ os: 'windows', app_version: '1.2.3-prebuilt', download_url: 'https://x/new.exe', created_at: '2026-02-01 00:00:00' })
+
+    for (const feed of [[older, prebuilt], [prebuilt, older]]) {
+      expect(latestDesktopDownloads(feed).map((build) => build.download_url)).toEqual(['https://x/new.exe'])
     }
   })
 
@@ -656,6 +722,9 @@ describe('formatVersion', () => {
     expect(formatVersion('1.0.0-rc1')).toBe('1.0.0-rc1')
     expect(formatVersion('2.0.0-beta.2')).toBe('2.0.0-beta.2')
     expect(formatVersion('1.2.3-x64(9)')).toBe('1.2.3-x64(9)')
+    // Build metadata after '+' distinguishes two releases just as a '-' suffix does,
+    // now that formatting alike is what decides whether two installers are one.
+    expect(formatVersion('1.2.3+arm64')).toBe('1.2.3+arm64')
   })
 
   it('hands back a string it cannot read a version out of', () => {

--- a/src/pages/Changelog/utils.test.ts
+++ b/src/pages/Changelog/utils.test.ts
@@ -166,6 +166,18 @@ describe('groupReleases', () => {
     }
   })
 
+  it('keeps the notes when the same build is re-uploaded with an empty box', () => {
+    const [entry] = groupReleases([
+      release({ os: 'windows', app_version: '1.0.0', download_url: 'https://x/typo.exe', created_at: '2026-08-20 10:00:00', update_desc: '修复：启动白屏' }),
+      release({ os: 'windows', app_version: '1.0.0', download_url: 'https://x/fixed.exe', created_at: '2026-08-20 18:00:00', update_desc: '   ' }),
+    ])
+
+    // The link follows the re-upload; what shipped did not change, so the notes do
+    // not either.
+    expect(entry.builds?.[0].download_url).toBe('https://x/fixed.exe')
+    expect(noteBlocks(entry)).toEqual([{ os: [], desc: '修复：启动白屏' }])
+  })
+
   it('does not let a superseded upload force the build the card links', () => {
     const [entry] = groupReleases([
       release({ os: 'windows', app_version: '3.0.0', download_url: 'https://x/new.exe', created_at: '2026-08-20 18:00:00', is_force: 0 }),

--- a/src/pages/Changelog/utils.test.ts
+++ b/src/pages/Changelog/utils.test.ts
@@ -30,8 +30,16 @@ describe('parseUpdateDesc', () => {
 
   it('keeps an announcement that names a feature rather than a version', () => {
     expect(parseUpdateDesc('深色模式正式发布').added).toEqual([{ text: '深色模式正式发布', group: undefined }])
-    // A version buried mid-sentence is not the sentence announcing itself.
-    expect(parseUpdateDesc('支持 1.5x 倍速播放正式上线').added).toHaveLength(1)
+    // A number in a feature's name is not the sentence announcing a release: the
+    // version has to sit next to the announcement, not merely somewhere in the line.
+    expect(parseUpdateDesc('1.5x 倍速播放正式上线').added).toHaveLength(1)
+  })
+
+  it('leaves prose that ends in 上线 without an announcement qualifier alone', () => {
+    // Dropping requires the same 正式/首次/版本 qualifier the rule above requires;
+    // without it a line naming a version is still just a line.
+    expect(parseUpdateDesc('TLS 1.3 通道上线').other).toHaveLength(1)
+    expect(parseUpdateDesc('TLS 1.3 通道上线').added).toEqual([])
   })
 
   it('keeps an explicit prefix ahead of the release-announcement fallback', () => {
@@ -175,15 +183,19 @@ describe('groupReleases', () => {
   })
 
   it('keeps the notes when the same build is re-uploaded with an empty box', () => {
-    const [entry] = groupReleases([
-      release({ os: 'windows', app_version: '1.0.0', download_url: 'https://x/typo.exe', created_at: '2026-08-20 10:00:00', update_desc: '修复：启动白屏' }),
-      release({ os: 'windows', app_version: '1.0.0', download_url: 'https://x/fixed.exe', created_at: '2026-08-20 18:00:00', update_desc: '   ' }),
-    ])
+    const notes = release({ os: 'windows', app_version: '1.0.0', download_url: 'https://x/typo.exe', created_at: '2026-08-20 10:00:00', update_desc: '修复：启动白屏' })
+    const blank = release({ os: 'windows', app_version: '1.0.0', download_url: 'https://x/fixed.exe', created_at: '2026-08-20 18:00:00', update_desc: '   ' })
 
-    // The link follows the re-upload; what shipped did not change, so the notes do
-    // not either.
-    expect(entry.builds?.[0].download_url).toBe('https://x/fixed.exe')
-    expect(noteBlocks(entry)).toEqual([{ os: [], desc: '修复：启动白屏' }])
+    // Both arrival orders: the feed is sorted by updated_at, so the blank re-upload
+    // is as likely to be seen first as second, and only in one of those orders is
+    // it the row being written over.
+    for (const feed of [[notes, blank], [blank, notes]]) {
+      const [entry] = groupReleases(feed)
+      // The link follows the re-upload; what shipped did not change, so the notes
+      // do not either.
+      expect(entry.builds?.[0].download_url).toBe('https://x/fixed.exe')
+      expect(noteBlocks(entry)).toEqual([{ os: [], desc: '修复：启动白屏' }])
+    }
   })
 
   it('does not let a superseded upload force the build the card links', () => {

--- a/src/pages/Changelog/utils.test.ts
+++ b/src/pages/Changelog/utils.test.ts
@@ -25,7 +25,7 @@ describe('parseUpdateDesc', () => {
     // reported as a feature, but a reader still sees every line an author wrote.
     const parsed = parseUpdateDesc('Windows 桌面端 1.0.0 版本发布')
     expect(parsed.added).toEqual([])
-    expect(parsed.other).toEqual([{ text: 'Windows 桌面端 1.0.0 版本发布', group: undefined, announces: '1.0.0' }])
+    expect(parsed.other).toEqual([{ text: 'Windows 桌面端 1.0.0 版本发布', group: undefined, announces: { version: '1.0.0', subject: 'Windows 桌面端' } }])
   })
 
   it('marks the announcement wherever the note happens to file it', () => {
@@ -33,7 +33,7 @@ describe('parseUpdateDesc', () => {
     // sentence stop inflating 新增 — under a heading, behind a prefix, or bare.
     for (const desc of ['新增\n- Windows 桌面端 1.0.0 版本发布', '新增：Windows 桌面端 1.0.0 版本发布']) {
       expect(parseUpdateDesc(desc).added).toEqual([
-        { text: 'Windows 桌面端 1.0.0 版本发布', group: undefined, announces: '1.0.0' },
+        { text: 'Windows 桌面端 1.0.0 版本发布', group: undefined, announces: { version: '1.0.0', subject: 'Windows 桌面端' } },
       ])
     }
   })
@@ -99,24 +99,42 @@ describe('parseUpdateDesc', () => {
 })
 
 describe('announcesOnly', () => {
-  it('is true only for a note that announces the very release it sits on', () => {
-    expect(announcesOnly('Windows 桌面端 1.0.0 版本发布', '1.0.0')).toBe(true)
-    expect(announcesOnly('Windows 桌面端 1.0.0 版本发布', 'v1.0')).toBe(true)
+  it('is true only for a note announcing this release, on this platform', () => {
+    expect(announcesOnly('Windows 桌面端 1.0.0 版本发布', '1.0.0', 'windows')).toBe(true)
+    expect(announcesOnly('Windows 桌面端 1.0.0 版本发布', 'v1.0', 'windows')).toBe(true)
+    // No subject at all can only be about the release it sits on.
+    expect(announcesOnly('1.0.0 版本发布', '1.0.0', 'windows')).toBe(true)
+    // A full stop is punctuation, not a change of meaning.
+    expect(announcesOnly('Windows 桌面端 1.0.0 版本发布。', '1.0.0', 'windows')).toBe(true)
+  })
+
+  it('keeps a note whose subject is something else that reached this number', () => {
+    // A version number names no particular thing: the plugin market can reach 2.0
+    // in the same train that takes the desktop app to 2.0.0. Matching on the number
+    // alone read this as the card repeating itself and deleted the news.
+    expect(announcesOnly('插件市场 2.0 正式上线', '2.0.0', 'windows')).toBe(false)
+    expect(announcesOnly('深色模式 3.0 正式发布', '3.0.0', 'windows')).toBe(false)
+    // And the Windows note on a card does not get to announce macOS.
+    expect(announcesOnly('Mac 桌面端 1.0.0 版本发布', '1.0.0', 'windows')).toBe(false)
   })
 
   it('keeps a note announcing anything other than this release', () => {
-    // Same sentence, different subject: the plugin market shipping 2.0 is news on
-    // the 1.0.0 card, not a restatement of its headline.
-    expect(announcesOnly('插件市场 2.0 正式上线', '1.0.0')).toBe(false)
-    expect(announcesOnly('白屏崩溃已解决，伴随 1.0.0 版本发布', '1.0.0')).toBe(false)
+    expect(announcesOnly('插件市场 2.0 正式上线', '1.0.0', 'windows')).toBe(false)
+    expect(announcesOnly('白屏崩溃已解决，伴随 1.0.0 版本发布', '1.0.0', 'windows')).toBe(false)
   })
 
   it('keeps a note that announces the release and then says something', () => {
-    expect(announcesOnly('Windows 桌面端 1.0.0 版本发布\n修复：启动白屏', '1.0.0')).toBe(false)
+    expect(announcesOnly('Windows 桌面端 1.0.0 版本发布\n修复：启动白屏', '1.0.0', 'windows')).toBe(false)
+  })
+
+  it('is unmoved by a credit line, which the card reads from elsewhere', () => {
+    // The block goes; the credits do not, because entryContributors() reads them
+    // off the entry rather than off the blocks that survived.
+    expect(announcesOnly('Windows 桌面端 1.0.0 版本发布\n@contributors: alice, bob', '1.0.0', 'windows')).toBe(true)
   })
 
   it('is false for a note with nothing in it, which has its own handling', () => {
-    expect(announcesOnly('', '1.0.0')).toBe(false)
+    expect(announcesOnly('', '1.0.0', 'windows')).toBe(false)
   })
 })
 
@@ -228,6 +246,26 @@ describe('groupReleases', () => {
     for (const feed of [rows, [...rows].reverse()]) {
       const [entry] = groupReleases(feed)
       expect(entry.builds?.[0].download_url).toBe(latestDesktopDownloads(feed)[0].download_url)
+    }
+  })
+
+  it('shows the newest notes filed, whatever order three uploads arrive in', () => {
+    // The build the card links and the notes it shows need not come from the same
+    // row: a re-upload that only fixes a link is saved with the notes box empty.
+    // Folding "keep what is there when the new one is blank" hands the card
+    // whichever non-blank row happened to be seen first, which the feed decides.
+    const older = release({ os: 'windows', app_version: '1.0.0', download_url: 'https://x/1.exe', created_at: '2026-08-20 10:00:00', update_desc: '修复：启动白屏' })
+    const newer = release({ os: 'windows', app_version: '1.0.0', download_url: 'https://x/2.exe', created_at: '2026-08-20 12:00:00', update_desc: '修复：托盘图标丢失' })
+    const relink = release({ os: 'windows', app_version: '1.0.0', download_url: 'https://x/3.exe', created_at: '2026-08-20 18:00:00', update_desc: '  ' })
+
+    const orders = [
+      [older, newer, relink], [older, relink, newer], [newer, older, relink],
+      [newer, relink, older], [relink, older, newer], [relink, newer, older],
+    ]
+    for (const feed of orders) {
+      const [entry] = groupReleases(feed)
+      expect(entry.builds?.[0].download_url).toBe('https://x/3.exe')
+      expect(noteBlocks(entry)).toEqual([{ os: [], desc: '修复：托盘图标丢失' }])
     }
   })
 
@@ -565,6 +603,19 @@ describe('latestDesktopDownloads', () => {
     }
   })
 
+  it('sees a prerelease token however the qualifier is spelled', () => {
+    // semver's own separator is the dot, and an architecture is as likely to be
+    // written x86_64 as x86. Splitting on the hyphen alone left both unread, and
+    // the band then offered a release candidate over the stable it precedes.
+    const stable = release({ os: 'windows', app_version: '1.0.0', download_url: 'https://x/stable.exe', created_at: '2026-01-01 00:00:00' })
+    for (const spelling of ['1.0.1-x86.rc1', '1.0.1-x86_64-rc1']) {
+      const rc = release({ os: 'windows', app_version: spelling, download_url: 'https://x/rc.exe', created_at: '2026-02-01 00:00:00' })
+      for (const feed of [[stable, rc], [rc, stable]]) {
+        expect(latestDesktopDownloads(feed).map((build) => build.download_url)).toEqual(['https://x/stable.exe'])
+      }
+    }
+  })
+
   it('does not read a word that merely starts like a qualifier as one', () => {
     const older = release({ os: 'windows', app_version: '1.2.2', download_url: 'https://x/old.exe', created_at: '2026-01-01 00:00:00' })
     const prebuilt = release({ os: 'windows', app_version: '1.2.3-prebuilt', download_url: 'https://x/new.exe', created_at: '2026-02-01 00:00:00' })
@@ -743,6 +794,15 @@ describe('offerVersionLabel', () => {
     // The band sits above a button handing over the release candidate; "v1.0.0"
     // there would name a release nobody can download yet.
     expect(offerVersionLabel([offer('1.0.0-rc1')])).toBe('v1.0.0-rc1')
+  })
+
+  it('reads two architectures of one version as one release', () => {
+    // isPrerelease already says -x64 is an architecture rather than a release
+    // distinction; the label has to agree, or the band drops the version line for
+    // a release that has one.
+    expect(offerVersionLabel([offer('1.0.0-x64'), { ...offer('1.0.0-arm64'), os: 'macos' }])).toBe('v1.0.0')
+    // A prerelease among them is a different release, and still says nothing.
+    expect(offerVersionLabel([offer('1.0.0-x64'), { ...offer('1.0.0-rc1'), os: 'macos' }])).toBeNull()
   })
 
   it('says nothing about a version string it cannot read', () => {

--- a/src/pages/Changelog/utils.test.ts
+++ b/src/pages/Changelog/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { detectViewerOS, forcedPlatforms, formatVersion, isHandheld, getVersionSeverity, groupReleases, latestDesktopDownloads, noteBlocks, offerVersionLabel, offeredAbove, orderBuilds, parseContributors, parseUpdateDesc, safeDownloadUrl } from './utils'
+import { detectViewerOS, forcedPlatforms, formatVersion, isHandheld, isPrerelease, getVersionSeverity, groupReleases, latestDesktopDownloads, noteBlocks, offerVersionLabel, offeredAbove, orderBuilds, parseContributors, parseUpdateDesc, safeDownloadUrl } from './utils'
 import type { AppVersion } from './utils'
 
 describe('parseContributors', () => {
@@ -590,6 +590,26 @@ describe('latestDesktopDownloads', () => {
       for (const feed of [[stable, rc], [rc, stable]]) {
         expect(latestDesktopDownloads(feed).map((build) => build.download_url)).toEqual(['https://x/stable.exe'])
       }
+    }
+  })
+
+  it('does not let build metadata after a + decide a release is a candidate', () => {
+    // semver reads everything past the + as belonging to the release it hangs off,
+    // so no wording there makes the release a candidate. Ranking it as one held a
+    // newer stable build back behind an older release.
+    for (const version of ['2.0.0+rc1', '2.0.0+x64-rc1', '2.0.0+win-beta', '2.0.0+build.rc1', '1.2.3+arm64']) {
+      expect(isPrerelease(version)).toBe(false)
+    }
+    // A qualifier ahead of the metadata still counts.
+    expect(isPrerelease('2.0.0-rc1+build5')).toBe(true)
+  })
+
+  it('offers the newest stable build even when its metadata mentions a candidate', () => {
+    const older = release({ os: 'windows', app_version: '1.9.0', download_url: 'https://x/old.exe', created_at: '2026-01-01 00:00:00' })
+    const newer = release({ os: 'windows', app_version: '2.0.0+x64-rc1', download_url: 'https://x/new.exe', created_at: '2026-02-01 00:00:00' })
+
+    for (const feed of [[older, newer], [newer, older]]) {
+      expect(latestDesktopDownloads(feed).map((build) => build.download_url)).toEqual(['https://x/new.exe'])
     }
   })
 

--- a/src/pages/Changelog/utils.test.ts
+++ b/src/pages/Changelog/utils.test.ts
@@ -20,10 +20,18 @@ describe('parseContributors', () => {
 })
 
 describe('parseUpdateDesc', () => {
-  it('files a platform-first release announcement under added', () => {
+  it('drops a line that only announces the release it belongs to', () => {
+    // The card header says v1.0.0, Windows and Initial Release already. Kept, the
+    // line reads as a feature, and the card's own counter then reports 新增 1.
     const parsed = parseUpdateDesc('Windows 桌面端 1.0.0 版本发布')
-    expect(parsed.added).toEqual([{ text: 'Windows 桌面端 1.0.0 版本发布', group: undefined }])
+    expect(parsed.added).toEqual([])
     expect(parsed.other).toEqual([])
+  })
+
+  it('keeps an announcement that names a feature rather than a version', () => {
+    expect(parseUpdateDesc('深色模式正式发布').added).toEqual([{ text: '深色模式正式发布', group: undefined }])
+    // A version buried mid-sentence is not the sentence announcing itself.
+    expect(parseUpdateDesc('支持 1.5x 倍速播放正式上线').added).toHaveLength(1)
   })
 
   it('keeps an explicit prefix ahead of the release-announcement fallback', () => {
@@ -102,12 +110,21 @@ describe('groupReleases', () => {
       { os: 'windows', download_url: 'https://x/setup.exe', created_at: '2026-08-20 16:34:04', is_force: 0, update_desc: 'Windows 桌面端 1.0.0 版本发布' },
       { os: 'macos', download_url: 'https://x/octo.dmg', created_at: '2026-08-20 14:18:06', is_force: 0, update_desc: 'Mac 桌面端 1.0.0 版本发布' },
     ])
-    // The card is dated by the newest build, and every build's notes are reachable.
+    // The card is dated by the newest build.
     expect(entry.created_at).toBe('2026-08-20 16:34:04')
-    expect(noteBlocks(entry).map((block) => block.desc)).toEqual([
-      'Windows 桌面端 1.0.0 版本发布',
-      'Mac 桌面端 1.0.0 版本发布',
+    // Both notes only announce the release the card is already titled after, so
+    // the card renders no body rather than two platform headings over two lines
+    // that repeat its header.
+    expect(noteBlocks(entry)).toEqual([])
+  })
+
+  it('keeps the platforms that said something when another only announced itself', () => {
+    const [entry] = groupReleases([
+      release({ os: 'windows', app_version: '1.0.0', update_desc: 'Windows 桌面端 1.0.0 版本发布' }),
+      release({ os: 'macos', app_version: '1.0.0', update_desc: '修复：外接显示器下的窗口错位' }),
     ])
+
+    expect(noteBlocks(entry)).toEqual([{ os: ['macos'], desc: '修复：外接显示器下的窗口错位' }])
   })
 
   it('keeps identical per-OS notes from being repeated on the card', () => {

--- a/src/pages/Changelog/utils.test.ts
+++ b/src/pages/Changelog/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { detectViewerOS, formatVersion, isHandheld, getVersionSeverity, groupReleases, latestDesktopDownloads, noteBlocks, offerVersionLabel, offeredAbove, orderBuilds, parseContributors, parseUpdateDesc, safeDownloadUrl } from './utils'
+import { detectViewerOS, forcedPlatforms, formatVersion, isHandheld, getVersionSeverity, groupReleases, latestDesktopDownloads, noteBlocks, offerVersionLabel, offeredAbove, orderBuilds, parseContributors, parseUpdateDesc, safeDownloadUrl } from './utils'
 import type { AppVersion } from './utils'
 
 describe('parseContributors', () => {
@@ -579,6 +579,25 @@ describe('offeredAbove', () => {
   it('is false for a card that has no builds at all', () => {
     const [entry] = groupReleases([release({ os: 'ios', app_version: '3.4.1', download_url: 'https://apps.apple.com/x' })])
     expect(offeredAbove(entry, [offer('windows', 'https://x/a.exe')])).toBe(false)
+  })
+})
+
+describe('forcedPlatforms', () => {
+  const forced = (rows: [string, 0 | 1][]) =>
+    forcedPlatforms(groupReleases(rows.map(([os, is_force]) =>
+      release({ os, is_force, app_version: '2.0.0', download_url: `https://x/${os}` })))[0])
+
+  it('names the platforms being told to upgrade when the others are not', () => {
+    // A macOS visitor reading an unqualified 必须升级 is being told to do something
+    // nobody is asking of them.
+    expect(forced([['windows', 1], ['macos', 0]])).toEqual(['windows'])
+  })
+
+  it('says nothing to qualify when the card speaks for every platform it holds', () => {
+    expect(forced([['windows', 1], ['macos', 1]])).toEqual([])
+    expect(forced([['windows', 0], ['macos', 0]])).toEqual([])
+    // A single build already has its platform named beside the version.
+    expect(forced([['windows', 1]])).toEqual([])
   })
 })
 

--- a/src/pages/Changelog/utils.test.ts
+++ b/src/pages/Changelog/utils.test.ts
@@ -70,6 +70,17 @@ describe('parseUpdateDesc', () => {
     }
   })
 
+  it('marks an announcement whichever separator its version carries', () => {
+    // Unmarked meant counted: a release announcing itself was reported as a feature
+    // whenever the version was spelled with a separator this rule did not read.
+    for (const version of ['1.0.0-rc1', '1.0.0_rc1', '1.0.0.rc1', '1.0.0+arm64']) {
+      const parsed = parseUpdateDesc(`Windows 桌面端 ${version} 版本发布`)
+      const items = [...parsed.added, ...parsed.other]
+      expect(items).toHaveLength(1)
+      expect(items[0].announces?.version).toBe(version)
+    }
+  })
+
   it('keeps an announcement that names a feature rather than a version', () => {
     expect(parseUpdateDesc('深色模式正式发布').added).toEqual([{ text: '深色模式正式发布', group: undefined }])
     // A number in a feature's name is not the sentence announcing a release: the
@@ -748,11 +759,23 @@ describe('formatVersion', () => {
     expect(formatVersion('1.0.1_rc1')).toBe('1.0.1_rc1')
   })
 
+  it('reads a qualifier the same way whichever separator opens it', () => {
+    // Three expressions used to read a qualifier and had drifted into three
+    // alphabets, so the same build was a prerelease to the ranking, a stable
+    // release to the title, and a feature to the counter.
+    expect(formatVersion('1.0.1_rc1')).toBe('1.0.1_rc1')
+    expect(formatVersion('1.0.1.rc1')).toBe('1.0.1.rc1')
+    expect(formatVersion('1.0.1-rc1')).toBe('1.0.1-rc1')
+  })
+
   it('does not read the separator of a date-shaped version as a qualifier', () => {
     // isPrerelease splits on the dot as well, but a version is written with dots:
     // accepting one here renders a 2026.04.16 web version as 2026.4.16.16.
     expect(formatVersion('2026.04.16')).toBe('2026.4.16')
     expect(formatVersion('2026.08.03')).toBe('2026.8.3')
+    // A dot opener is only a qualifier when a letter follows it. The fourth part of
+    // a Windows-style version is a number and stays part of the number.
+    expect(formatVersion('1.0.0.1')).toBe('1.0.0')
   })
 
   it('hands back a string it cannot read a version out of', () => {
@@ -783,8 +806,12 @@ describe('offerVersionLabel', () => {
     }
   })
 
-  it('still labels a lone prerelease, which misdescribes nothing', () => {
+  it('still labels a lone prerelease, in the spelling it was written in', () => {
+    // Not just v1.0.0: the label sits above the button handing that build over, so
+    // dropping the qualifier names a release the visitor is not being given.
     expect(offerVersionLabel([offer('1.0.0-rc1')])).toBe('v1.0.0-rc1')
+    expect(offerVersionLabel([offer('1.0.0_rc1')])).toBe('v1.0.0_rc1')
+    expect(offerVersionLabel([offer('1.0.0.rc1')])).toBe('v1.0.0.rc1')
     expect(offerVersionLabel([offer('1.0.0-rc1'), { ...offer('1.0.0-rc1'), os: 'macos' }])).toBe('v1.0.0-rc1')
   })
 

--- a/src/pages/Changelog/utils.test.ts
+++ b/src/pages/Changelog/utils.test.ts
@@ -38,6 +38,21 @@ describe('parseUpdateDesc', () => {
     }
   })
 
+  it('never marks a line that reports a change on its way to the announcement', () => {
+    // Chinese writes without spaces, so any slack in the rule swallows meaning:
+    // these read as bare announcements while the fix they report disappears, and
+    // only the spaced variant — the unusual one — survived.
+    for (const desc of [
+      '2.0.0修复若干问题后正式发布',
+      'Windows 桌面端 1.0.0修复白屏后正式发布。',
+      '1.0.0解决登录崩溃后正式上线',
+    ]) {
+      const items = Object.values(parseUpdateDesc(desc)).flat()
+      expect(items).toHaveLength(1)
+      expect(items[0].announces).toBeUndefined()
+    }
+  })
+
   it('never marks a line that says anything besides the announcement', () => {
     // Marking these would let a card drop them, and a reader cannot tell a note
     // that was never written from one a regex removed.
@@ -776,6 +791,9 @@ describe('formatVersion', () => {
     // Build metadata after '+' distinguishes two releases just as a '-' suffix does,
     // now that formatting alike is what decides whether two installers are one.
     expect(formatVersion('1.2.3+arm64')).toBe('1.2.3+arm64')
+    // isPrerelease reads underscores in a qualifier; the two readers have to agree,
+    // or a card is titled v1.0.0-x86 for a build called 1.0.0-x86_64.
+    expect(formatVersion('1.0.0-x86_64')).toBe('1.0.0-x86_64')
   })
 
   it('hands back a string it cannot read a version out of', () => {

--- a/src/pages/Changelog/utils.ts
+++ b/src/pages/Changelog/utils.ts
@@ -3,6 +3,9 @@ export type ChangeCategory = 'security' | 'removed' | 'fixed' | 'added' | 'chang
 export interface ChangeItem {
   text: string
   group?: string
+  /** The version this line announces, when the line is an announcement of a release
+   *  rather than of anything in it. Counted by nothing; still shown. */
+  announces?: string
 }
 
 export interface ParsedChanges {
@@ -56,19 +59,24 @@ const CATEGORY_PATTERNS: [ChangeCategory, RegExp][] = [
 const RELEASE_ANNOUNCEMENT = /(?:正式|首次|版本)(?:发布|上线)$/
 
 /**
- * The same announcement, naming a version: "Windows 桌面端 1.0.0 版本发布".
+ * The same announcement, naming the version it announces: "Windows 桌面端 1.0.0
+ * 版本发布". The captured version is what lets a card tell an announcement of
+ * itself from an announcement of something else that happens to have a version.
  *
- * The card header already carries every word of it — the version, the platform
- * badges, the severity tag — so the line adds nothing, and filing it under 新增
- * additionally claims that shipping is a feature, which the per-card counters then
- * add up ("新增 2" for a release with no features at all). Such a line is dropped.
+ * Such a line is marked, never dropped. Filing it under 新增 claims that shipping
+ * is a feature and the per-card counters then add it up ("新增 2" for a release with
+ * no features at all) — but a wrong heading is a labelling bug a reader can see
+ * through, while a deleted line leaves nothing to see. Marked lines are shown and
+ * not counted.
  *
- * The version has to be adjacent to the announcement, not merely somewhere in the
- * sentence: "1.5x 倍速播放正式上线" announces a feature that has a number in its
- * name, and stays under 新增 where the rule above puts it. So does "深色模式正式
- * 发布", which names no version at all.
+ * Anchored at both ends, and the run before the version may hold neither digits nor
+ * punctuation, so only a line that is an announcement start to finish qualifies:
+ *   - "白屏崩溃已解决，伴随 1.0.0 版本发布" reports a fix and mentions the release;
+ *   - "协议从 1.0 升级到 2.0 正式上线" names two versions and is a change between them;
+ *   - "1.5x 倍速播放正式上线" and "深色模式正式发布" announce features, not releases.
+ * None of them are announcements of a release, and none are marked.
  */
-const VERSION_ANNOUNCEMENT = /\d+\.\d+(?:\.\d+)?\S*\s*(?:正式|首次|版本)(?:发布|上线)$/
+const VERSION_ANNOUNCEMENT = /^[^\d，。；、,;:：]*?(\d+\.\d+(?:\.\d+)?)\S*\s*(?:正式|首次|版本)(?:发布|上线)$/
 
 const PREFIX_STRIP = /^(安全|漏洞|CVE|security|移除|删除|废弃|下线|remove|deprecat\w*|修复|修正|解决|fix|bug|新增|新功能|新加|添加|支持|feat(?:ure)?|优化|改进|提升|更新|调整|升级|重构|改为|改善|chore|refactor|perf)[：:：]?\s*/i
 
@@ -95,8 +103,8 @@ export function parseUpdateDesc(desc: string): ParsedChanges {
   let currentSection: ChangeCategory | null = null
   let currentGroup: string | undefined
 
-  const push = (cat: ChangeCategory, text: string) => {
-    result[cat].push({ text, group: currentGroup })
+  const push = (cat: ChangeCategory, text: string, announces?: string) => {
+    result[cat].push(announces === undefined ? { text, group: currentGroup } : { text, group: currentGroup, announces })
   }
 
   for (const raw of lines) {
@@ -143,6 +151,11 @@ export function parseUpdateDesc(desc: string): ParsedChanges {
     const isHeader = /^.+[：:]\s*$/.test(line)
     const cat = classifyLine(line)
     const stripped = stripPrefix(line)
+    // Asked of the line with any 新增/修复 prefix removed, and asked before the
+    // branches below place it: an announcement is one whether it was written bare,
+    // under a section heading, or behind a prefix of its own, and all three shapes
+    // were inflating the counters.
+    const announces = VERSION_ANNOUNCEMENT.exec(stripped || line)?.[1]
 
     // bare keyword line like "新增" / "修复" — section header, not item
     if (cat !== 'other' && !stripped) {
@@ -156,11 +169,13 @@ export function parseUpdateDesc(desc: string): ParsedChanges {
       currentGroup = undefined
     } else if (currentSection) {
       // explicit section in effect — respect it, ignore per-line prefix classification
-      push(currentSection, stripped || line)
+      push(currentSection, stripped || line, announces)
     } else if (cat !== 'other') {
-      push(cat, stripped)
-    } else if (VERSION_ANNOUNCEMENT.test(line)) {
-      continue
+      push(cat, stripped, announces)
+    } else if (announces !== undefined) {
+      // Nobody filed it anywhere, and it announces a release: 其他 is where it
+      // belongs, rather than the 新增 the fallback below would give it.
+      push('other', line, announces)
     } else if (RELEASE_ANNOUNCEMENT.test(line)) {
       push('added', line)
     } else {
@@ -261,7 +276,10 @@ export interface ReleaseEntry extends AppVersion {
  * and the beta wins.
  */
 const VERSION_SUFFIX = /\d+\.\d+(?:\.\d+)?((?:-[0-9A-Za-z.]+)+)/
-const PRERELEASE_TOKEN = /^(alpha|beta|rc|pre|preview|dev|snapshot|canary|nightly)/i
+/* Anchored at both ends of the token: a qualifier is the word itself, optionally
+   numbered (-rc1, -beta.2). Matching on prefix alone reads -prebuilt as a
+   prerelease and ranks a finished build below the release before it. */
+const PRERELEASE_TOKEN = /^(alpha|beta|rc|pre|preview|dev|snapshot|canary|nightly)(\d|\.|$)/i
 
 export function isPrerelease(version: string): boolean {
   const suffix = VERSION_SUFFIX.exec(version.replace(/\(.*\)/, ''))
@@ -426,11 +444,20 @@ export function forcedPlatforms(entry: ReleaseEntry): string[] {
   return forced.length === entry.builds.length ? [] : forced.map((build) => build.os)
 }
 
-/** Whether a note still says anything once release announcements are dropped. */
-export function hasVisibleChanges(desc: string): boolean {
-  // Read off the parse result rather than a second list of categories to keep in
-  // step with the first one.
-  return Object.values(parseUpdateDesc(desc)).some((items) => items.length > 0)
+/**
+ * Whether a note says nothing the card it belongs to does not already say: every
+ * line in it announces this very release.
+ *
+ * The version is what settles it. "Windows 桌面端 1.0.0 版本发布" on the 1.0.0 card
+ * repeats the headline, the platform badge and the severity tag beneath which it is
+ * printed; the same sentence about anything else — "插件市场 2.0 正式上线" — is news,
+ * and is kept and shown whatever card it lands on.
+ */
+export function announcesOnly(desc: string, appVersion: string): boolean {
+  const items = Object.values(parseUpdateDesc(desc)).flat()
+  if (items.length === 0) return false
+  const own = formatVersion(appVersion.trim().replace(/^v/i, ''))
+  return items.every((item) => item.announces !== undefined && formatVersion(item.announces) === own)
 }
 
 /**
@@ -444,17 +471,19 @@ export function hasVisibleChanges(desc: string): boolean {
  * is the common case; only genuinely differing notes are shown per OS.
  */
 export function noteBlocks(entry: ReleaseEntry, viewerOS: ViewerOS | null = null): NoteBlock[] {
+  const saysNothingNew = (desc: string) => !desc || announcesOnly(desc, entry.app_version)
+
   if (!entry.builds) {
-    return hasVisibleChanges(entry.update_desc) ? [{ os: [], desc: entry.update_desc }] : []
+    return saysNothingNew(entry.update_desc.trim()) ? [] : [{ os: [], desc: entry.update_desc }]
   }
 
   const blocks: NoteBlock[] = []
   const byDesc = new Map<string, NoteBlock>()
   for (const build of orderBuilds(entry.builds, viewerOS)) {
     const desc = build.update_desc.trim()
-    // A note that was only ever "1.0.0 版本发布" parses to nothing; rendering it
-    // would leave a platform heading standing over an empty list.
-    if (!hasVisibleChanges(desc)) continue
+    // A note that only announces this very release would render as a platform
+    // heading over a line repeating the headline above it.
+    if (saysNothingNew(desc)) continue
     const shared = byDesc.get(desc)
     if (shared) {
       shared.os.push(build.os)
@@ -526,12 +555,21 @@ function documentBase(): string {
  *   - a scheme need not be http(s) to parse — `javascript:` and `data:` resolve
  *     perfectly well, and only the resolved protocol says so.
  *
- * Control characters are stripped before any of that, because browsers ignore them
- * inside a URL and "java\tscript:" therefore runs.
+ * The value resolved is the value returned, not a cleaned copy of it: the parser
+ * already ignores the tab, newline and carriage return that hide a scheme, so
+ * "java\tscript:" resolves to javascript: and is refused on its protocol. Deciding
+ * on a stripped string and handing back the original would approve one URL and
+ * publish another — and a space, say, is not ignored but percent-encoded, so the two
+ * are not the same link.
  *
- * A scheme still has to be written in full (`https://host`, not `https:host`): both
- * reach the same place, but only one of them looks like what it does, and a link
- * this page did not have to accept is one it does not.
+ * The stripped copy is consulted for one question only, which is about the shape of
+ * the string rather than where it goes: a scheme has to be written in full
+ * (`https://host`, not `https:host`). Both reach the same place, but only one of
+ * them looks like what it does.
+ *
+ * One deliberate relaxation over the pattern-matching this replaces: a single
+ * leading backslash is now allowed. The parser folds `\evil.com` to the same-origin
+ * path `/evil.com`, so refusing it was over-rejection rather than a safety property.
  *
  * Returns the original string when it is safe to link, null when it is not.
  */
@@ -539,18 +577,18 @@ export function safeDownloadUrl(url: string | null | undefined): string | null {
   const trimmed = (url ?? '').trim()
   if (!trimmed) return null
 
-  const probe = trimmed.replace(/[\u0000-\u0020\u007F]/g, '')
   const base = documentBase()
 
   let resolved: URL
   try {
-    resolved = new URL(probe, base)
+    resolved = new URL(trimmed, base)
   } catch {
     return null
   }
 
   if (resolved.protocol !== 'http:' && resolved.protocol !== 'https:') return null
 
+  const probe = trimmed.replace(/[\u0000-\u0020\u007F]/g, '')
   const scheme = URL_SCHEME.exec(probe)
   if (!scheme) {
     // Carries no scheme of its own, so it may only be a path on this origin.
@@ -738,9 +776,10 @@ export function parseContributors(desc: string): Contributor[] {
 }
 
 /* Everything after the triple that a semver qualifier can carry: -rc1, -beta.2,
-   -x64. Kept rather than dropped, so a card titled v1.0.0 is never a 1.0.0-rc1 and
-   two installers only count as one release when they really are one. */
-const VERSION_QUALIFIER = /\d+\.\d+(?:\.\d+)?(-[0-9A-Za-z][0-9A-Za-z.-]*)/
+   -x64, +arm64. Kept rather than dropped, so a card titled v1.0.0 is never a
+   1.0.0-rc1 — and, now that formatting alike is what "one release" means, so that
+   two strings only collapse into one label when they really are one release. */
+const VERSION_QUALIFIER = /\d+\.\d+(?:\.\d+)?([-+][0-9A-Za-z][0-9A-Za-z.+-]*)/
 
 export function formatVersion(raw: string): string {
   const semver = parseSemVer(raw)

--- a/src/pages/Changelog/utils.ts
+++ b/src/pages/Changelog/utils.ts
@@ -81,9 +81,16 @@ const RELEASE_ANNOUNCEMENT = /(?:正式|首次|版本)(?:发布|上线)$/
  * particular thing — the plugin market can reach 2.0 in the same train that takes
  * the desktop app to 2.0.0 — so the subject is what says which thing shipped, and
  * announcesOnly() reads it before letting a card drop anything.
+ *
+ * Nothing at all is allowed between the version and the verb. There used to be a
+ * `\S*` there to absorb a qualifier, and once the qualifier moved into the capture
+ * above it had no work left — but it went on matching, and Chinese writes without
+ * spaces, so "1.0.0修复白屏后正式发布" read as a bare announcement and a card threw
+ * the fix away. A run of non-space characters is not decoration in a language that
+ * does not separate words.
  */
 const VERSION_ANNOUNCEMENT =
-  /^([^\d，。；、,;:：]*?)(\d+\.\d+(?:\.\d+)?(?:[-+][0-9A-Za-z][0-9A-Za-z._+-]*)?)\S*\s*(?:正式|首次|版本)(?:发布|上线)$/
+  /^([^\d，。；、,;:：]*?)(\d+\.\d+(?:\.\d+)?(?:[-+][0-9A-Za-z][0-9A-Za-z._+-]*)?)\s*(?:正式|首次|版本)(?:发布|上线)$/
 
 /* Trailing sentence punctuation is common in these notes and says nothing about
    what the line is; both announcement rules anchor on the verb at the end. */
@@ -860,7 +867,7 @@ export function parseContributors(desc: string): Contributor[] {
    -x64, +arm64. Kept rather than dropped, so a card titled v1.0.0 is never a
    1.0.0-rc1 — and, now that formatting alike is what "one release" means, so that
    two strings only collapse into one label when they really are one release. */
-const VERSION_QUALIFIER = /\d+\.\d+(?:\.\d+)?([-+][0-9A-Za-z][0-9A-Za-z.+-]*)/
+const VERSION_QUALIFIER = /\d+\.\d+(?:\.\d+)?([-+][0-9A-Za-z][0-9A-Za-z._+-]*)/
 
 export function formatVersion(raw: string): string {
   const semver = parseSemVer(raw)

--- a/src/pages/Changelog/utils.ts
+++ b/src/pages/Changelog/utils.ts
@@ -578,6 +578,22 @@ export function groupReleases(raw: AppVersion[]): ReleaseEntry[] {
  * matching installer. Returns null whenever we cannot be sure — mobile, ChromeOS,
  * anything unrecognised — and the page then shows every build with equal weight.
  */
+/**
+ * Whether the visitor is on a phone or a tablet, where a Windows or macOS installer
+ * is not merely unrecognised but unusable.
+ *
+ * detectViewerOS() already returns null for these, but null is equally what an
+ * unrecognised desktop returns — and that visitor is precisely the one who still
+ * needs the installer offered. Handheld is therefore asked as its own question
+ * rather than read off the absence of an answer to the other one.
+ */
+export function isHandheld(userAgent: string, maxTouchPoints = 0): boolean {
+  if (/Android|iPhone|iPod|iPad|Windows Phone|IEMobile/i.test(userAgent)) return true
+  // iPadOS 13+ ships a desktop Safari UA claiming "Macintosh"; the touch points are
+  // what still give it away.
+  return /Mac OS X|Macintosh/i.test(userAgent) && maxTouchPoints > 1
+}
+
 export function detectViewerOS(userAgent: string, maxTouchPoints = 0): ViewerOS | null {
   if (/Android/i.test(userAgent)) return null
   if (/iPhone|iPod/i.test(userAgent)) return null

--- a/src/pages/Changelog/utils.ts
+++ b/src/pages/Changelog/utils.ts
@@ -94,8 +94,24 @@ const RELEASE_ANNOUNCEMENT = /(?:正式|首次|版本)(?:发布|上线)$/
  * the fix away. A run of non-space characters is not decoration in a language that
  * does not separate words.
  */
-const VERSION_ANNOUNCEMENT =
-  /^([^\d，。；、,;:：]*?)(\d+\.\d+(?:\.\d+)?(?:[-+][0-9A-Za-z][0-9A-Za-z._+-]*)?)\s*(?:正式|首次|版本)(?:发布|上线)$/
+/**
+ * One definition of what a version qualifier looks like, for every reader of one.
+ *
+ * There were three, and they had drifted into three different alphabets — ranking
+ * accepted `-._`, display accepted `-+_`, the announcement rule accepted `-+` — so
+ * each disagreement surfaced as a version the page named wrongly: a lone 1.0.0.rc1
+ * labelled v1.0.0 above the button handing out the candidate, and a 1.0.0_rc1
+ * announcement counted as a feature. Widening them one at a time is what produced
+ * the drift; they share the expression now.
+ *
+ * A `.` opener must be letter-led, and that is the whole subtlety: the dot is also
+ * the version separator, so `.rc1` is a qualifier while the `.16` of a 2026.04.16
+ * web version and the `.1` of a four-part Windows version are part of the number.
+ */
+const QUALIFIER = String.raw`(?:[-+_][0-9A-Za-z]|\.[A-Za-z])[0-9A-Za-z._+-]*`
+
+const VERSION_ANNOUNCEMENT = new RegExp(
+  String.raw`^([^\d，。；、,;:：]*?)(\d+\.\d+(?:\.\d+)?(?:${QUALIFIER})?)\s*(?:正式|首次|版本)(?:发布|上线)$`)
 
 /* Trailing sentence punctuation is common in these notes and says nothing about
    what the line is; both announcement rules anchor on the verb at the end. */
@@ -299,7 +315,7 @@ export interface ReleaseEntry extends AppVersion {
  * `Octo 2.0.0-beta` as a prerelease, or the pair compares as stable-versus-nothing
  * and the beta wins.
  */
-const VERSION_SUFFIX = /\d+\.\d+(?:\.\d+)?((?:[-._][0-9A-Za-z]+)+)/
+const VERSION_SUFFIX = new RegExp(String.raw`\d+\.\d+(?:\.\d+)?(${QUALIFIER})`)
 /* Anchored at both ends of the token: a qualifier is the word itself, optionally
    numbered (-rc1, -beta.2). Matching on prefix alone reads -prebuilt as a
    prerelease and ranks a finished build below the release before it. */
@@ -831,15 +847,8 @@ export function parseContributors(desc: string): Contributor[] {
   return []
 }
 
-/* Everything after the triple that a semver qualifier can carry: -rc1, -beta.2,
-   -x64, +arm64, _rc1. Kept rather than dropped, so a card titled v1.0.0 is never a
-   1.0.0-rc1.
-
-   The opener stops at `-+_` deliberately, though isPrerelease() also splits on `.`:
-   the dot is the version separator itself, so accepting it here reads the ".16" of
-   a 2026.04.16 web version as a qualifier and renders it as 2026.4.16.16. Ranking
-   can afford to be lenient about a separator; display cannot. */
-const VERSION_QUALIFIER = /\d+\.\d+(?:\.\d+)?([-+_][0-9A-Za-z][0-9A-Za-z._+-]*)/
+/* The same expression ranking reads, under the name display uses it by. */
+const VERSION_QUALIFIER = VERSION_SUFFIX
 
 export function formatVersion(raw: string): string {
   const semver = parseSemVer(raw)

--- a/src/pages/Changelog/utils.ts
+++ b/src/pages/Changelog/utils.ts
@@ -344,26 +344,21 @@ export interface DesktopDownload extends DesktopBuild {
 /**
  * The version line for the offer, or null when the installers do not share one.
  *
- * formatVersion() drops a `-suffix`, so a prerelease would be badged as the stable
- * release it is not — above a button that hands over the prerelease. Prereleases
- * therefore keep their version string verbatim. (formatVersion itself is left alone:
- * the timeline cards badge the same way, and moving them apart would be worse than
- * moving them together later.)
+ * One comparison, on formatVersion() output. That was unsafe while formatVersion
+ * dropped a `-suffix`: Windows on 1.0.0 and macOS on 1.0.0-rc1 formatted alike, so
+ * the band badged v1.0.0 above a button handing over the RC. Now that the qualifier
+ * survives formatting, formatting alike is the same question as being one release —
+ * and 1.0 written beside 1.0.0 still is one, said two ways.
+ *
+ * A string no version can be read out of is not labelled at all: a `v` in front of
+ * it would claim more than the string says.
  */
 export function offerVersionLabel(offers: DesktopDownload[]): string | null {
-  // Written the same way, modulo a `v` prefix: label it.
-  const raw = Array.from(new Set(offers.map((offer) => offer.app_version.trim().replace(/^v/i, ''))))
-  if (raw.length === 1) return isPrerelease(raw[0]) ? raw[0] : `v${formatVersion(raw[0])}`
+  if (offers.length === 0) return null
+  if (offers.some((offer) => parseSemVer(offer.app_version) === null)) return null
 
-  // Written differently with a prerelease among them: say nothing. formatVersion()
-  // drops a `-suffix`, so comparing formatted versions here would collapse Windows
-  // on 1.0.0 and macOS on 1.0.0-rc1 into one version and badge the RC as stable —
-  // above the button that hands it over.
-  if (offers.some((offer) => isPrerelease(offer.app_version))) return null
-
-  // All stable and formatting alike (1.0 and 1.0.0) — one version, said once.
-  const formatted = Array.from(new Set(offers.map((offer) => formatVersion(offer.app_version))))
-  return formatted.length === 1 ? `v${formatted[0]}` : null
+  const formatted = new Set(offers.map((offer) => formatVersion(offer.app_version.trim().replace(/^v/i, ''))))
+  return formatted.size === 1 ? `v${[...formatted][0]}` : null
 }
 
 /**
@@ -690,10 +685,16 @@ export function parseContributors(desc: string): Contributor[] {
   return []
 }
 
+/* Everything after the triple that a semver qualifier can carry: -rc1, -beta.2,
+   -x64. Kept rather than dropped, so a card titled v1.0.0 is never a 1.0.0-rc1 and
+   two installers only count as one release when they really are one. */
+const VERSION_QUALIFIER = /\d+\.\d+(?:\.\d+)?(-[0-9A-Za-z][0-9A-Za-z.-]*)/
+
 export function formatVersion(raw: string): string {
   const semver = parseSemVer(raw)
   if (!semver) return raw
   const build = parseBuildNumber(raw)
-  const base = `${semver[0]}.${semver[1]}.${semver[2]}`
+  const qualifier = VERSION_QUALIFIER.exec(raw.replace(/\(.*\)/, ''))
+  const base = `${semver[0]}.${semver[1]}.${semver[2]}${qualifier ? qualifier[1] : ''}`
   return build !== null ? `${base}(${build})` : base
 }

--- a/src/pages/Changelog/utils.ts
+++ b/src/pages/Changelog/utils.ts
@@ -417,26 +417,6 @@ export function forcedPlatforms(entry: ReleaseEntry): string[] {
 }
 
 /**
- * Everyone credited anywhere in a release, read from the entry itself.
- *
- * Not from the note blocks a card ends up rendering: a block can be dropped for
- * saying nothing new, and the credits on it are not part of what it said.
- */
-export function entryContributors(entry: ReleaseEntry): Contributor[] {
-  const descs = entry.builds ? entry.builds.map((build) => build.update_desc) : [entry.update_desc]
-  const seen = new Set<string>()
-  const all: Contributor[] = []
-  for (const desc of descs) {
-    for (const contributor of parseContributors(desc)) {
-      if (seen.has(contributor.name)) continue
-      seen.add(contributor.name)
-      all.push(contributor)
-    }
-  }
-  return all
-}
-
-/**
  * The note blocks a card should render.
  *
  * Per-OS notes are NOT merged into one document. parseUpdateDesc() is stateful —
@@ -509,7 +489,10 @@ const URL_SCHEME = /^([a-z][a-z0-9+.-]*):/i
 const NO_DOCUMENT_BASE = 'https://changelog.invalid/'
 
 function documentBase(): string {
-  return typeof window === 'undefined' || !window.location ? NO_DOCUMENT_BASE : window.location.href
+  // document.baseURI, not location.href: a <base> element changes what the browser
+  // resolves an href against, and the guard has to ask the question the browser
+  // will answer.
+  return typeof document === 'undefined' || !document.baseURI ? NO_DOCUMENT_BASE : document.baseURI
 }
 
 /**

--- a/src/pages/Changelog/utils.ts
+++ b/src/pages/Changelog/utils.ts
@@ -410,6 +410,20 @@ export interface NoteBlock {
   desc: string
 }
 
+/**
+ * The platforms a card forces an upgrade on, when that is fewer than all of them.
+ *
+ * One card carries every OS build of a version and is_force is per build, so a card
+ * can force Windows and not macOS. Empty means the badge needs no qualifier: either
+ * every build forces the upgrade, or the card carries a single build and the
+ * platform badge beside it already says which one.
+ */
+export function forcedPlatforms(entry: ReleaseEntry): string[] {
+  if (!entry.builds || entry.builds.length < 2) return []
+  const forced = entry.builds.filter((build) => build.is_force === 1)
+  return forced.length === entry.builds.length ? [] : forced.map((build) => build.os)
+}
+
 /** Whether a note still says anything once release announcements are dropped. */
 export function hasVisibleChanges(desc: string): boolean {
   const parsed = parseUpdateDesc(desc)

--- a/src/pages/Changelog/utils.ts
+++ b/src/pages/Changelog/utils.ts
@@ -3,9 +3,17 @@ export type ChangeCategory = 'security' | 'removed' | 'fixed' | 'added' | 'chang
 export interface ChangeItem {
   text: string
   group?: string
-  /** What this line announces, when it announces a release rather than anything in
-   *  it: the version, and the subject it names ahead of the version. Counted by
-   *  nothing; still shown. */
+  /**
+   * What this line announces, when it announces a release rather than anything in
+   * it: the version, and the subject it names ahead of the version.
+   *
+   * Only the presence of the mark is read today — a marked line is shown wherever
+   * its author filed it and counted nowhere, whatever it announces. Comparing the
+   * version and subject against the card would count an announcement of something
+   * else, but that comparison is what four rounds of review found ways to get
+   * wrong, and being wrong there used to mean deleting a line. Under-counting a
+   * line that is on the page beats deleting one that is not.
+   */
   announces?: { version: string; subject: string }
 }
 
@@ -324,11 +332,19 @@ const PRERELEASE_TOKEN = /^(alpha|beta|rc|pre|preview|dev|snapshot|canary|nightl
 export function isPrerelease(version: string): boolean {
   const suffix = VERSION_SUFFIX.exec(version.replace(/\(.*\)/, ''))
   if (!suffix) return false
+
+  // Everything from a `+` on is build metadata, which semver reads as belonging to
+  // the release it hangs off rather than as a version of its own — so 2.0.0+x64-rc1
+  // is the stable 2.0.0, however the metadata is worded. Display keeps it (a card
+  // for +arm64 says +arm64); ranking cannot see it, or a stable release would be
+  // held back behind an older one on the strength of a word after the plus.
+  const qualifier = suffix[1].split('+')[0]
+
   // Every token, not just the first: 1.0.0-x86-rc1 names an architecture before it
   // names the release candidate it is. Split on every separator a qualifier is
   // written with — semver's own is the dot (1.0.0-x86.rc1), and an architecture is
   // as likely to be spelled x86_64 as x86.
-  return suffix[1].split(/[-._]/).some((token) => token !== '' && PRERELEASE_TOKEN.test(token))
+  return qualifier.split(/[-._]/).some((token) => token !== '' && PRERELEASE_TOKEN.test(token))
 }
 
 /** Ranked so a stable release outranks any prerelease, and both outrank a version

--- a/src/pages/Changelog/utils.ts
+++ b/src/pages/Changelog/utils.ts
@@ -3,9 +3,10 @@ export type ChangeCategory = 'security' | 'removed' | 'fixed' | 'added' | 'chang
 export interface ChangeItem {
   text: string
   group?: string
-  /** The version this line announces, when the line is an announcement of a release
-   *  rather than of anything in it. Counted by nothing; still shown. */
-  announces?: string
+  /** What this line announces, when it announces a release rather than anything in
+   *  it: the version, and the subject it names ahead of the version. Counted by
+   *  nothing; still shown. */
+  announces?: { version: string; subject: string }
 }
 
 export interface ParsedChanges {
@@ -75,8 +76,18 @@ const RELEASE_ANNOUNCEMENT = /(?:正式|首次|版本)(?:发布|上线)$/
  *   - "协议从 1.0 升级到 2.0 正式上线" names two versions and is a change between them;
  *   - "1.5x 倍速播放正式上线" and "深色模式正式发布" announce features, not releases.
  * None of them are announcements of a release, and none are marked.
+ *
+ * Both the subject and the whole version are captured. A version number names no
+ * particular thing — the plugin market can reach 2.0 in the same train that takes
+ * the desktop app to 2.0.0 — so the subject is what says which thing shipped, and
+ * announcesOnly() reads it before letting a card drop anything.
  */
-const VERSION_ANNOUNCEMENT = /^[^\d，。；、,;:：]*?(\d+\.\d+(?:\.\d+)?)\S*\s*(?:正式|首次|版本)(?:发布|上线)$/
+const VERSION_ANNOUNCEMENT =
+  /^([^\d，。；、,;:：]*?)(\d+\.\d+(?:\.\d+)?(?:[-+][0-9A-Za-z][0-9A-Za-z._+-]*)?)\S*\s*(?:正式|首次|版本)(?:发布|上线)$/
+
+/* Trailing sentence punctuation is common in these notes and says nothing about
+   what the line is; both announcement rules anchor on the verb at the end. */
+const TRAILING_STOP = /[。．.！!、，,;；]+$/
 
 const PREFIX_STRIP = /^(安全|漏洞|CVE|security|移除|删除|废弃|下线|remove|deprecat\w*|修复|修正|解决|fix|bug|新增|新功能|新加|添加|支持|feat(?:ure)?|优化|改进|提升|更新|调整|升级|重构|改为|改善|chore|refactor|perf)[：:：]?\s*/i
 
@@ -103,7 +114,7 @@ export function parseUpdateDesc(desc: string): ParsedChanges {
   let currentSection: ChangeCategory | null = null
   let currentGroup: string | undefined
 
-  const push = (cat: ChangeCategory, text: string, announces?: string) => {
+  const push = (cat: ChangeCategory, text: string, announces?: ChangeItem['announces']) => {
     result[cat].push(announces === undefined ? { text, group: currentGroup } : { text, group: currentGroup, announces })
   }
 
@@ -151,11 +162,12 @@ export function parseUpdateDesc(desc: string): ParsedChanges {
     const isHeader = /^.+[：:]\s*$/.test(line)
     const cat = classifyLine(line)
     const stripped = stripPrefix(line)
-    // Asked of the line with any 新增/修复 prefix removed, and asked before the
-    // branches below place it: an announcement is one whether it was written bare,
-    // under a section heading, or behind a prefix of its own, and all three shapes
-    // were inflating the counters.
-    const announces = VERSION_ANNOUNCEMENT.exec(stripped || line)?.[1]
+    // Asked of the line with any 新增/修复 prefix removed and any full stop trimmed,
+    // and asked before the branches below place it: an announcement is one whether
+    // it was written bare, under a section heading, or behind a prefix of its own,
+    // and all three shapes were inflating the counters.
+    const announced = VERSION_ANNOUNCEMENT.exec((stripped || line).replace(TRAILING_STOP, ''))
+    const announces = announced === null ? undefined : { version: announced[2], subject: announced[1].trim() }
 
     // bare keyword line like "新增" / "修复" — section header, not item
     if (cat !== 'other' && !stripped) {
@@ -172,11 +184,11 @@ export function parseUpdateDesc(desc: string): ParsedChanges {
       push(currentSection, stripped || line, announces)
     } else if (cat !== 'other') {
       push(cat, stripped, announces)
-    } else if (announces !== undefined) {
+    } else if (announces) {
       // Nobody filed it anywhere, and it announces a release: 其他 is where it
       // belongs, rather than the 新增 the fallback below would give it.
       push('other', line, announces)
-    } else if (RELEASE_ANNOUNCEMENT.test(line)) {
+    } else if (RELEASE_ANNOUNCEMENT.test(line.replace(TRAILING_STOP, ''))) {
       push('added', line)
     } else {
       push('other', line)
@@ -275,7 +287,7 @@ export interface ReleaseEntry extends AppVersion {
  * `Octo 2.0.0-beta` as a prerelease, or the pair compares as stable-versus-nothing
  * and the beta wins.
  */
-const VERSION_SUFFIX = /\d+\.\d+(?:\.\d+)?((?:-[0-9A-Za-z.]+)+)/
+const VERSION_SUFFIX = /\d+\.\d+(?:\.\d+)?((?:-[0-9A-Za-z._]+)+)/
 /* Anchored at both ends of the token: a qualifier is the word itself, optionally
    numbered (-rc1, -beta.2). Matching on prefix alone reads -prebuilt as a
    prerelease and ranks a finished build below the release before it. */
@@ -284,9 +296,11 @@ const PRERELEASE_TOKEN = /^(alpha|beta|rc|pre|preview|dev|snapshot|canary|nightl
 export function isPrerelease(version: string): boolean {
   const suffix = VERSION_SUFFIX.exec(version.replace(/\(.*\)/, ''))
   if (!suffix) return false
-  // Every hyphenated token, not just the first: 1.0.0-x86-rc1 names an
-  // architecture before it names the release candidate it is.
-  return suffix[1].split('-').some((token) => token !== '' && PRERELEASE_TOKEN.test(token))
+  // Every token, not just the first: 1.0.0-x86-rc1 names an architecture before it
+  // names the release candidate it is. Split on every separator a qualifier is
+  // written with — semver's own is the dot (1.0.0-x86.rc1), and an architecture is
+  // as likely to be spelled x86_64 as x86.
+  return suffix[1].split(/[-._]/).some((token) => token !== '' && PRERELEASE_TOKEN.test(token))
 }
 
 /** Ranked so a stable release outranks any prerelease, and both outrank a version
@@ -347,6 +361,11 @@ function supersedes(candidate: AppVersion, current: DesktopDownload): boolean {
  * Rows alike down to the second still need an answer, or the fold in
  * latestDesktopDownloads() returns whichever arrived first and the
  * order-independence above is only most of a total order.
+ *
+ * It stops at the URL rather than going on to is_force and update_desc, and that is
+ * enough: two rows agreeing on version, second and URL are the same installer, and
+ * the notes are no longer decided here — groupReleases() picks those separately, by
+ * the newest row that filed any.
  */
 function supersedesSameVersion(
   candidate: { created_at: string; download_url: string },
@@ -364,11 +383,12 @@ export interface DesktopDownload extends DesktopBuild {
 /**
  * The version line for the offer, or null when the installers do not share one.
  *
- * One comparison, on formatVersion() output. That was unsafe while formatVersion
- * dropped a `-suffix`: Windows on 1.0.0 and macOS on 1.0.0-rc1 formatted alike, so
- * the band badged v1.0.0 above a button handing over the RC. Now that the qualifier
- * survives formatting, formatting alike is the same question as being one release —
- * and 1.0 written beside 1.0.0 still is one, said two ways.
+ * Formatting alike is the first answer, and 1.0 written beside 1.0.0 is one release
+ * said two ways. Where the strings differ it is the qualifier that differs, and not
+ * every qualifier makes a different release: -x64 beside -arm64 is one version built
+ * twice, which isPrerelease() already says in as many words, while -rc1 beside 1.0.0
+ * is the release candidate and the release it precedes. So an architecture falls
+ * back to the version the two builds share; a prerelease among them does not.
  *
  * A string no version can be read out of is not labelled at all: a `v` in front of
  * it would claim more than the string says.
@@ -378,7 +398,16 @@ export function offerVersionLabel(offers: DesktopDownload[]): string | null {
   if (offers.some((offer) => parseSemVer(offer.app_version) === null)) return null
 
   const formatted = new Set(offers.map((offer) => formatVersion(offer.app_version.trim().replace(/^v/i, ''))))
-  return formatted.size === 1 ? `v${[...formatted][0]}` : null
+  if (formatted.size === 1) return `v${[...formatted][0]}`
+
+  if (offers.some((offer) => isPrerelease(offer.app_version))) return null
+
+  const shared = new Set(offers.map((offer) => {
+    const triple = parseSemVer(offer.app_version)!
+    const build = parseBuildNumber(offer.app_version)
+    return `${triple[0]}.${triple[1]}.${triple[2]}${build !== null ? `(${build})` : ''}`
+  }))
+  return shared.size === 1 ? `v${[...shared][0]}` : null
 }
 
 /**
@@ -444,20 +473,64 @@ export function forcedPlatforms(entry: ReleaseEntry): string[] {
   return forced.length === entry.builds.length ? [] : forced.map((build) => build.os)
 }
 
+/* What a note may call the platform it is announcing. A card knows which platform
+   each of its notes came from, and that is the half of "which release is this
+   about" that a version number cannot supply. */
+const PLATFORM_NAMED: Record<string, RegExp> = {
+  windows: /windows|视窗/i,
+  macos: /mac\b|macos|苹果/i,
+  linux: /linux/i,
+  web: /web|网页/i,
+  android: /android|安卓/i,
+  ios: /ios|iphone|苹果/i,
+  chrome: /chrome/i,
+  'openclaw-plugin': /openclaw/i,
+}
+
 /**
  * Whether a note says nothing the card it belongs to does not already say: every
- * line in it announces this very release.
+ * line in it announces this very release, on this very platform.
  *
- * The version is what settles it. "Windows 桌面端 1.0.0 版本发布" on the 1.0.0 card
- * repeats the headline, the platform badge and the severity tag beneath which it is
- * printed; the same sentence about anything else — "插件市场 2.0 正式上线" — is news,
- * and is kept and shown whatever card it lands on.
+ * Both halves are needed. A version number names no particular thing — the plugin
+ * market can reach 2.0 in the same train that takes the desktop app to 2.0.0 — so
+ * matching on the number alone would read "插件市场 2.0 正式上线" as the 2.0.0 card
+ * repeating itself and drop a line that is news. The subject settles it: a note is
+ * about this release when it names this platform, or names nothing at all.
+ *
+ * Credits are not items and are not consulted here: entryContributors() reads them
+ * off the entry rather than off the blocks that survive, so dropping a block cannot
+ * take a credit with it and this does not have to hold a block open to protect one.
  */
-export function announcesOnly(desc: string, appVersion: string): boolean {
+export function announcesOnly(desc: string, appVersion: string, os: string): boolean {
   const items = Object.values(parseUpdateDesc(desc)).flat()
   if (items.length === 0) return false
+
   const own = formatVersion(appVersion.trim().replace(/^v/i, ''))
-  return items.every((item) => item.announces !== undefined && formatVersion(item.announces) === own)
+  const platform = PLATFORM_NAMED[os]
+  return items.every(({ announces }) =>
+    announces !== undefined
+    && formatVersion(announces.version) === own
+    && (announces.subject === '' || (platform !== undefined && platform.test(announces.subject))))
+}
+
+/**
+ * Everyone credited anywhere in a release, read from the entry itself.
+ *
+ * Not from the note blocks a card ends up rendering: a block can be dropped for
+ * saying nothing new, and the credits on it are not part of what it said.
+ */
+export function entryContributors(entry: ReleaseEntry): Contributor[] {
+  const descs = entry.builds ? entry.builds.map((build) => build.update_desc) : [entry.update_desc]
+  const seen = new Set<string>()
+  const all: Contributor[] = []
+  for (const desc of descs) {
+    for (const contributor of parseContributors(desc)) {
+      if (seen.has(contributor.name)) continue
+      seen.add(contributor.name)
+      all.push(contributor)
+    }
+  }
+  return all
 }
 
 /**
@@ -471,10 +544,10 @@ export function announcesOnly(desc: string, appVersion: string): boolean {
  * is the common case; only genuinely differing notes are shown per OS.
  */
 export function noteBlocks(entry: ReleaseEntry, viewerOS: ViewerOS | null = null): NoteBlock[] {
-  const saysNothingNew = (desc: string) => !desc || announcesOnly(desc, entry.app_version)
+  const saysNothingNew = (desc: string, os: string) => !desc || announcesOnly(desc, entry.app_version, os)
 
   if (!entry.builds) {
-    return saysNothingNew(entry.update_desc.trim()) ? [] : [{ os: [], desc: entry.update_desc }]
+    return saysNothingNew(entry.update_desc.trim(), entry.os) ? [] : [{ os: [], desc: entry.update_desc }]
   }
 
   const blocks: NoteBlock[] = []
@@ -483,7 +556,7 @@ export function noteBlocks(entry: ReleaseEntry, viewerOS: ViewerOS | null = null
     const desc = build.update_desc.trim()
     // A note that only announces this very release would render as a platform
     // heading over a line repeating the headline above it.
-    if (saysNothingNew(desc)) continue
+    if (saysNothingNew(desc, build.os)) continue
     const shared = byDesc.get(desc)
     if (shared) {
       shared.os.push(build.os)
@@ -613,6 +686,9 @@ export function groupReleases(raw: AppVersion[]): ReleaseEntry[] {
   // Index by grouping key rather than only checking the last entry, so a release
   // landing between two web deploys no longer splits that day in two.
   const desktopByVersion = new Map<string, number>()
+  // Which row the notes on each build came from, so a later row can be compared
+  // against it rather than against the build the card happens to link.
+  const noteSource = new Map<DesktopBuild, AppVersion>()
   const webByDate = new Map<string, number>()
   const webMembers = new Map<number, AppVersion[]>()
 
@@ -631,28 +707,33 @@ export function groupReleases(raw: AppVersion[]): ReleaseEntry[] {
         // The per-OS links live in `builds`; a single inherited URL would read as
         // authoritative for a card that offers several installers.
         result.push({ ...item, download_url: '', builds: [build] })
+        if (build.update_desc.trim()) noteSource.set(build, item)
         continue
       }
       const entry = result[at]
       const sameOS = entry.builds!.find((existing) => existing.os === item.os)
       if (!sameOS) {
         entry.builds!.push(build)
-      } else if (supersedesSameVersion(item, sameOS)) {
-        // Same OS re-uploaded for this version: the card has to follow the newer
-        // build, whatever order the feed happens to arrive in — and has to pick the
-        // same one the band above it offers.
-        Object.assign(sameOS, build, {
-          // Re-uploading to fix a broken link is done with the notes box left
-          // empty. It is the same release either way, so the notes already on the
-          // card still describe it; taking them away would empty the card over a
-          // change that was never made to what shipped.
-          update_desc: build.update_desc.trim() ? build.update_desc : sameOS.update_desc,
-        })
-      } else if (!sameOS.update_desc.trim()) {
-        // The same rule read from the other side. The feed arrives in updated_at
-        // order, so the blank re-upload can be the row seen first, and then it is
-        // the superseded row that carries the only notes this release has.
-        sameOS.update_desc = build.update_desc
+        if (build.update_desc.trim()) noteSource.set(build, item)
+        continue
+      }
+
+      // Two questions, answered separately, because one row can win the first and
+      // another the second: a re-upload that only fixes a broken link is saved with
+      // the notes box empty, so the build the card links and the notes it shows do
+      // not have to come from the same row.
+      if (supersedesSameVersion(item, sameOS)) {
+        const keep = sameOS.update_desc
+        Object.assign(sameOS, build, { update_desc: keep })
+      }
+
+      // Whichever row filed the newest notes owns them, whatever order the feed
+      // arrived in. Folding "keep what is there if the new one is blank" instead
+      // would hand the card whichever non-blank row happened to be seen first.
+      const source = noteSource.get(sameOS)
+      if (item.update_desc.trim() && (source === undefined || supersedesSameVersion(item, source))) {
+        sameOS.update_desc = item.update_desc
+        noteSource.set(sameOS, item)
       }
       continue
     }

--- a/src/pages/Changelog/utils.ts
+++ b/src/pages/Changelog/utils.ts
@@ -202,7 +202,7 @@ export function getVersionSeverity(version: string, prevVersion?: string): Versi
   // those says the opposite: a stream sitting on 1.0.0 while its build number
   // advances, and a release candidate. Any other version with no predecessor is
   // simply the oldest one we know about.
-  if (!prevVersion) return /^v?1\.0\.0$/.test(version.trim()) ? 'initial' : 'unknown'
+  if (!prevVersion) return /^v?1\.0\.0$/i.test(version.trim()) ? 'initial' : 'unknown'
 
   const prev = parseSemVer(prevVersion)
   if (!prev) return 'unknown'
@@ -261,12 +261,15 @@ export interface ReleaseEntry extends AppVersion {
  * `Octo 2.0.0-beta` as a prerelease, or the pair compares as stable-versus-nothing
  * and the beta wins.
  */
-const VERSION_SUFFIX = /\d+\.\d+(?:\.\d+)?-([0-9A-Za-z]+)/
+const VERSION_SUFFIX = /\d+\.\d+(?:\.\d+)?((?:-[0-9A-Za-z.]+)+)/
 const PRERELEASE_TOKEN = /^(alpha|beta|rc|pre|preview|dev|snapshot|canary|nightly)/i
 
 export function isPrerelease(version: string): boolean {
   const suffix = VERSION_SUFFIX.exec(version.replace(/\(.*\)/, ''))
-  return suffix !== null && PRERELEASE_TOKEN.test(suffix[1])
+  if (!suffix) return false
+  // Every hyphenated token, not just the first: 1.0.0-x86-rc1 names an
+  // architecture before it names the release candidate it is.
+  return suffix[1].split('-').some((token) => token !== '' && PRERELEASE_TOKEN.test(token))
 }
 
 /** Ranked so a stable release outranks any prerelease, and both outrank a version

--- a/src/pages/Changelog/utils.ts
+++ b/src/pages/Changelog/utils.ts
@@ -64,11 +64,17 @@ const RELEASE_ANNOUNCEMENT = /(?:正式|首次|版本)(?:发布|上线)$/
  * 版本发布". The captured version is what lets a card tell an announcement of
  * itself from an announcement of something else that happens to have a version.
  *
- * Such a line is marked, never dropped. Filing it under 新增 claims that shipping
- * is a feature and the per-card counters then add it up ("新增 2" for a release with
- * no features at all) — but a wrong heading is a labelling bug a reader can see
- * through, while a deleted line leaves nothing to see. Marked lines are shown and
- * not counted.
+ * The mark decides one thing only: counting. Filing such a line under 新增 claims
+ * that shipping is a feature and the per-card counters then add it up ("新增 2" for a
+ * release with no features at all), so a marked line is shown wherever its author
+ * filed it and counted nowhere.
+ *
+ * It used to decide a second thing — whether a card rendered the note at all — and
+ * that is gone. Four rounds of review found four ways for a rule reading free text
+ * to mistake content for an announcement, each one narrower than the last, and the
+ * cost of being wrong was an admin's line vanishing from a public page with nothing
+ * to show a reader that it had. Deciding what to count fails visibly; deciding what
+ * to delete does not.
  *
  * Anchored at both ends, and the run before the version may hold neither digits nor
  * punctuation, so only a line that is an announcement start to finish qualifies:
@@ -77,10 +83,9 @@ const RELEASE_ANNOUNCEMENT = /(?:正式|首次|版本)(?:发布|上线)$/
  *   - "1.5x 倍速播放正式上线" and "深色模式正式发布" announce features, not releases.
  * None of them are announcements of a release, and none are marked.
  *
- * Both the subject and the whole version are captured. A version number names no
+ * The subject and the whole version are captured because a version number names no
  * particular thing — the plugin market can reach 2.0 in the same train that takes
- * the desktop app to 2.0.0 — so the subject is what says which thing shipped, and
- * announcesOnly() reads it before letting a card drop anything.
+ * the desktop app to 2.0.0 — and a reader of the mark should be able to tell which.
  *
  * Nothing at all is allowed between the version and the verb. There used to be a
  * `\S*` there to absorb a qualifier, and once the qualifier moved into the capture
@@ -294,7 +299,7 @@ export interface ReleaseEntry extends AppVersion {
  * `Octo 2.0.0-beta` as a prerelease, or the pair compares as stable-versus-nothing
  * and the beta wins.
  */
-const VERSION_SUFFIX = /\d+\.\d+(?:\.\d+)?((?:-[0-9A-Za-z._]+)+)/
+const VERSION_SUFFIX = /\d+\.\d+(?:\.\d+)?((?:[-._][0-9A-Za-z]+)+)/
 /* Anchored at both ends of the token: a qualifier is the word itself, optionally
    numbered (-rc1, -beta.2). Matching on prefix alone reads -prebuilt as a
    prerelease and ranks a finished build below the release before it. */
@@ -480,46 +485,6 @@ export function forcedPlatforms(entry: ReleaseEntry): string[] {
   return forced.length === entry.builds.length ? [] : forced.map((build) => build.os)
 }
 
-/* What a note may call the platform it is announcing. A card knows which platform
-   each of its notes came from, and that is the half of "which release is this
-   about" that a version number cannot supply. */
-const PLATFORM_NAMED: Record<string, RegExp> = {
-  windows: /windows|视窗/i,
-  macos: /mac\b|macos|苹果/i,
-  linux: /linux/i,
-  web: /web|网页/i,
-  android: /android|安卓/i,
-  ios: /ios|iphone|苹果/i,
-  chrome: /chrome/i,
-  'openclaw-plugin': /openclaw/i,
-}
-
-/**
- * Whether a note says nothing the card it belongs to does not already say: every
- * line in it announces this very release, on this very platform.
- *
- * Both halves are needed. A version number names no particular thing — the plugin
- * market can reach 2.0 in the same train that takes the desktop app to 2.0.0 — so
- * matching on the number alone would read "插件市场 2.0 正式上线" as the 2.0.0 card
- * repeating itself and drop a line that is news. The subject settles it: a note is
- * about this release when it names this platform, or names nothing at all.
- *
- * Credits are not items and are not consulted here: entryContributors() reads them
- * off the entry rather than off the blocks that survive, so dropping a block cannot
- * take a credit with it and this does not have to hold a block open to protect one.
- */
-export function announcesOnly(desc: string, appVersion: string, os: string): boolean {
-  const items = Object.values(parseUpdateDesc(desc)).flat()
-  if (items.length === 0) return false
-
-  const own = formatVersion(appVersion.trim().replace(/^v/i, ''))
-  const platform = PLATFORM_NAMED[os]
-  return items.every(({ announces }) =>
-    announces !== undefined
-    && formatVersion(announces.version) === own
-    && (announces.subject === '' || (platform !== undefined && platform.test(announces.subject))))
-}
-
 /**
  * Everyone credited anywhere in a release, read from the entry itself.
  *
@@ -551,19 +516,15 @@ export function entryContributors(entry: ReleaseEntry): Contributor[] {
  * is the common case; only genuinely differing notes are shown per OS.
  */
 export function noteBlocks(entry: ReleaseEntry, viewerOS: ViewerOS | null = null): NoteBlock[] {
-  const saysNothingNew = (desc: string, os: string) => !desc || announcesOnly(desc, entry.app_version, os)
-
   if (!entry.builds) {
-    return saysNothingNew(entry.update_desc.trim(), entry.os) ? [] : [{ os: [], desc: entry.update_desc }]
+    return entry.update_desc.trim() ? [{ os: [], desc: entry.update_desc }] : []
   }
 
   const blocks: NoteBlock[] = []
   const byDesc = new Map<string, NoteBlock>()
   for (const build of orderBuilds(entry.builds, viewerOS)) {
     const desc = build.update_desc.trim()
-    // A note that only announces this very release would render as a platform
-    // heading over a line repeating the headline above it.
-    if (saysNothingNew(desc, build.os)) continue
+    if (!desc) continue
     const shared = byDesc.get(desc)
     if (shared) {
       shared.os.push(build.os)

--- a/src/pages/Changelog/utils.ts
+++ b/src/pages/Changelog/utils.ts
@@ -1,7 +1,5 @@
 export type ChangeCategory = 'security' | 'removed' | 'fixed' | 'added' | 'changed' | 'other'
 
-const CHANGE_CATEGORIES: readonly ChangeCategory[] = ['security', 'removed', 'fixed', 'added', 'changed', 'other']
-
 export interface ChangeItem {
   text: string
   group?: string
@@ -58,18 +56,19 @@ const CATEGORY_PATTERNS: [ChangeCategory, RegExp][] = [
 const RELEASE_ANNOUNCEMENT = /(?:正式|首次|版本)(?:发布|上线)$/
 
 /**
- * A line that announces the release itself and nothing else: it names a version,
- * optionally behind a platform, and stops.
+ * The same announcement, naming a version: "Windows 桌面端 1.0.0 版本发布".
  *
  * The card header already carries every word of it — the version, the platform
  * badges, the severity tag — so the line adds nothing, and filing it under 新增
  * additionally claims that shipping is a feature, which the per-card counters then
- * add up ("新增 2" for a release with no features at all).
+ * add up ("新增 2" for a release with no features at all). Such a line is dropped.
  *
- * The version number is what makes it droppable. "深色模式正式发布" ends the same
- * way but names a feature, so it has no version and stays where it was.
+ * The version has to be adjacent to the announcement, not merely somewhere in the
+ * sentence: "1.5x 倍速播放正式上线" announces a feature that has a number in its
+ * name, and stays under 新增 where the rule above puts it. So does "深色模式正式
+ * 发布", which names no version at all.
  */
-const VERSION_ANNOUNCEMENT = /\d+\.\d+(?:\.\d+)?\S*\s*(?:版本)?(?:正式|首次)?(?:发布|上线)$/
+const VERSION_ANNOUNCEMENT = /\d+\.\d+(?:\.\d+)?\S*\s*(?:正式|首次|版本)(?:发布|上线)$/
 
 const PREFIX_STRIP = /^(安全|漏洞|CVE|security|移除|删除|废弃|下线|remove|deprecat\w*|修复|修正|解决|fix|bug|新增|新功能|新加|添加|支持|feat(?:ure)?|优化|改进|提升|更新|调整|升级|重构|改为|改善|chore|refactor|perf)[：:：]?\s*/i
 
@@ -429,8 +428,9 @@ export function forcedPlatforms(entry: ReleaseEntry): string[] {
 
 /** Whether a note still says anything once release announcements are dropped. */
 export function hasVisibleChanges(desc: string): boolean {
-  const parsed = parseUpdateDesc(desc)
-  return CHANGE_CATEGORIES.some((category) => parsed[category].length > 0)
+  // Read off the parse result rather than a second list of categories to keep in
+  // step with the first one.
+  return Object.values(parseUpdateDesc(desc)).some((items) => items.length > 0)
 }
 
 /**
@@ -610,6 +610,11 @@ export function groupReleases(raw: AppVersion[]): ReleaseEntry[] {
           // change that was never made to what shipped.
           update_desc: build.update_desc.trim() ? build.update_desc : sameOS.update_desc,
         })
+      } else if (!sameOS.update_desc.trim()) {
+        // The same rule read from the other side. The feed arrives in updated_at
+        // order, so the blank re-upload can be the row seen first, and then it is
+        // the superseded row that carries the only notes this release has.
+        sameOS.update_desc = build.update_desc
       }
       continue
     }
@@ -663,6 +668,19 @@ export function groupReleases(raw: AppVersion[]): ReleaseEntry[] {
  * matching installer. Returns null whenever we cannot be sure — mobile, ChromeOS,
  * anything unrecognised — and the page then shows every build with equal weight.
  */
+export function detectViewerOS(userAgent: string, maxTouchPoints = 0): ViewerOS | null {
+  if (/Android/i.test(userAgent)) return null
+  if (/iPhone|iPod/i.test(userAgent)) return null
+  if (/CrOS/i.test(userAgent)) return null
+  if (/Windows NT/i.test(userAgent)) return 'windows'
+  // iPadOS 13+ ships a desktop Safari UA claiming "Macintosh"; the touch points
+  // are what still give it away.
+  if (/iPad/i.test(userAgent)) return null
+  if (/Mac OS X|Macintosh/i.test(userAgent)) return maxTouchPoints > 1 ? null : 'macos'
+  if (/Linux|X11/i.test(userAgent)) return 'linux'
+  return null
+}
+
 /**
  * Whether the visitor is on a phone or a tablet, where a Windows or macOS installer
  * is not merely unrecognised but unusable.
@@ -677,19 +695,6 @@ export function isHandheld(userAgent: string, maxTouchPoints = 0): boolean {
   // iPadOS 13+ ships a desktop Safari UA claiming "Macintosh"; the touch points are
   // what still give it away.
   return /Mac OS X|Macintosh/i.test(userAgent) && maxTouchPoints > 1
-}
-
-export function detectViewerOS(userAgent: string, maxTouchPoints = 0): ViewerOS | null {
-  if (/Android/i.test(userAgent)) return null
-  if (/iPhone|iPod/i.test(userAgent)) return null
-  if (/CrOS/i.test(userAgent)) return null
-  if (/Windows NT/i.test(userAgent)) return 'windows'
-  // iPadOS 13+ ships a desktop Safari UA claiming "Macintosh"; the touch points
-  // are what still give it away.
-  if (/iPad/i.test(userAgent)) return null
-  if (/Mac OS X|Macintosh/i.test(userAgent)) return maxTouchPoints > 1 ? null : 'macos'
-  if (/Linux|X11/i.test(userAgent)) return 'linux'
-  return null
 }
 
 export interface Contributor {

--- a/src/pages/Changelog/utils.ts
+++ b/src/pages/Changelog/utils.ts
@@ -3,18 +3,6 @@ export type ChangeCategory = 'security' | 'removed' | 'fixed' | 'added' | 'chang
 export interface ChangeItem {
   text: string
   group?: string
-  /**
-   * What this line announces, when it announces a release rather than anything in
-   * it: the version, and the subject it names ahead of the version.
-   *
-   * Only the presence of the mark is read today — a marked line is shown wherever
-   * its author filed it and counted nowhere, whatever it announces. Comparing the
-   * version and subject against the card would count an announcement of something
-   * else, but that comparison is what four rounds of review found ways to get
-   * wrong, and being wrong there used to mean deleting a line. Under-counting a
-   * line that is on the page beats deleting one that is not.
-   */
-  announces?: { version: string; subject: string }
 }
 
 export interface ParsedChanges {
@@ -67,64 +55,6 @@ const CATEGORY_PATTERNS: [ChangeCategory, RegExp][] = [
  */
 const RELEASE_ANNOUNCEMENT = /(?:正式|首次|版本)(?:发布|上线)$/
 
-/**
- * The same announcement, naming the version it announces: "Windows 桌面端 1.0.0
- * 版本发布". The captured version is what lets a card tell an announcement of
- * itself from an announcement of something else that happens to have a version.
- *
- * The mark decides one thing only: counting. Filing such a line under 新增 claims
- * that shipping is a feature and the per-card counters then add it up ("新增 2" for a
- * release with no features at all), so a marked line is shown wherever its author
- * filed it and counted nowhere.
- *
- * It used to decide a second thing — whether a card rendered the note at all — and
- * that is gone. Four rounds of review found four ways for a rule reading free text
- * to mistake content for an announcement, each one narrower than the last, and the
- * cost of being wrong was an admin's line vanishing from a public page with nothing
- * to show a reader that it had. Deciding what to count fails visibly; deciding what
- * to delete does not.
- *
- * Anchored at both ends, and the run before the version may hold neither digits nor
- * punctuation, so only a line that is an announcement start to finish qualifies:
- *   - "白屏崩溃已解决，伴随 1.0.0 版本发布" reports a fix and mentions the release;
- *   - "协议从 1.0 升级到 2.0 正式上线" names two versions and is a change between them;
- *   - "1.5x 倍速播放正式上线" and "深色模式正式发布" announce features, not releases.
- * None of them are announcements of a release, and none are marked.
- *
- * The subject and the whole version are captured because a version number names no
- * particular thing — the plugin market can reach 2.0 in the same train that takes
- * the desktop app to 2.0.0 — and a reader of the mark should be able to tell which.
- *
- * Nothing at all is allowed between the version and the verb. There used to be a
- * `\S*` there to absorb a qualifier, and once the qualifier moved into the capture
- * above it had no work left — but it went on matching, and Chinese writes without
- * spaces, so "1.0.0修复白屏后正式发布" read as a bare announcement and a card threw
- * the fix away. A run of non-space characters is not decoration in a language that
- * does not separate words.
- */
-/**
- * One definition of what a version qualifier looks like, for every reader of one.
- *
- * There were three, and they had drifted into three different alphabets — ranking
- * accepted `-._`, display accepted `-+_`, the announcement rule accepted `-+` — so
- * each disagreement surfaced as a version the page named wrongly: a lone 1.0.0.rc1
- * labelled v1.0.0 above the button handing out the candidate, and a 1.0.0_rc1
- * announcement counted as a feature. Widening them one at a time is what produced
- * the drift; they share the expression now.
- *
- * A `.` opener must be letter-led, and that is the whole subtlety: the dot is also
- * the version separator, so `.rc1` is a qualifier while the `.16` of a 2026.04.16
- * web version and the `.1` of a four-part Windows version are part of the number.
- */
-const QUALIFIER = String.raw`(?:[-+_][0-9A-Za-z]|\.[A-Za-z])[0-9A-Za-z._+-]*`
-
-const VERSION_ANNOUNCEMENT = new RegExp(
-  String.raw`^([^\d，。；、,;:：]*?)(\d+\.\d+(?:\.\d+)?(?:${QUALIFIER})?)\s*(?:正式|首次|版本)(?:发布|上线)$`)
-
-/* Trailing sentence punctuation is common in these notes and says nothing about
-   what the line is; both announcement rules anchor on the verb at the end. */
-const TRAILING_STOP = /[。．.！!、，,;；]+$/
-
 const PREFIX_STRIP = /^(安全|漏洞|CVE|security|移除|删除|废弃|下线|remove|deprecat\w*|修复|修正|解决|fix|bug|新增|新功能|新加|添加|支持|feat(?:ure)?|优化|改进|提升|更新|调整|升级|重构|改为|改善|chore|refactor|perf)[：:：]?\s*/i
 
 function stripPrefix(line: string): string {
@@ -150,8 +80,8 @@ export function parseUpdateDesc(desc: string): ParsedChanges {
   let currentSection: ChangeCategory | null = null
   let currentGroup: string | undefined
 
-  const push = (cat: ChangeCategory, text: string, announces?: ChangeItem['announces']) => {
-    result[cat].push(announces === undefined ? { text, group: currentGroup } : { text, group: currentGroup, announces })
+  const push = (cat: ChangeCategory, text: string) => {
+    result[cat].push({ text, group: currentGroup })
   }
 
   for (const raw of lines) {
@@ -198,12 +128,6 @@ export function parseUpdateDesc(desc: string): ParsedChanges {
     const isHeader = /^.+[：:]\s*$/.test(line)
     const cat = classifyLine(line)
     const stripped = stripPrefix(line)
-    // Asked of the line with any 新增/修复 prefix removed and any full stop trimmed,
-    // and asked before the branches below place it: an announcement is one whether
-    // it was written bare, under a section heading, or behind a prefix of its own,
-    // and all three shapes were inflating the counters.
-    const announced = VERSION_ANNOUNCEMENT.exec((stripped || line).replace(TRAILING_STOP, ''))
-    const announces = announced === null ? undefined : { version: announced[2], subject: announced[1].trim() }
 
     // bare keyword line like "新增" / "修复" — section header, not item
     if (cat !== 'other' && !stripped) {
@@ -217,14 +141,10 @@ export function parseUpdateDesc(desc: string): ParsedChanges {
       currentGroup = undefined
     } else if (currentSection) {
       // explicit section in effect — respect it, ignore per-line prefix classification
-      push(currentSection, stripped || line, announces)
+      push(currentSection, stripped || line)
     } else if (cat !== 'other') {
-      push(cat, stripped, announces)
-    } else if (announces) {
-      // Nobody filed it anywhere, and it announces a release: 其他 is where it
-      // belongs, rather than the 新增 the fallback below would give it.
-      push('other', line, announces)
-    } else if (RELEASE_ANNOUNCEMENT.test(line.replace(TRAILING_STOP, ''))) {
+      push(cat, stripped)
+    } else if (RELEASE_ANNOUNCEMENT.test(line)) {
       push('added', line)
     } else {
       push('other', line)
@@ -264,7 +184,7 @@ export function getVersionSeverity(version: string, prevVersion?: string): Versi
   // those says the opposite: a stream sitting on 1.0.0 while its build number
   // advances, and a release candidate. Any other version with no predecessor is
   // simply the oldest one we know about.
-  if (!prevVersion) return /^v?1\.0\.0$/i.test(version.trim()) ? 'initial' : 'unknown'
+  if (!prevVersion) return /^v?1\.0\.0$/.test(version.trim()) ? 'initial' : 'unknown'
 
   const prev = parseSemVer(prevVersion)
   if (!prev) return 'unknown'
@@ -323,28 +243,12 @@ export interface ReleaseEntry extends AppVersion {
  * `Octo 2.0.0-beta` as a prerelease, or the pair compares as stable-versus-nothing
  * and the beta wins.
  */
-const VERSION_SUFFIX = new RegExp(String.raw`\d+\.\d+(?:\.\d+)?(${QUALIFIER})`)
-/* Anchored at both ends of the token: a qualifier is the word itself, optionally
-   numbered (-rc1, -beta.2). Matching on prefix alone reads -prebuilt as a
-   prerelease and ranks a finished build below the release before it. */
-const PRERELEASE_TOKEN = /^(alpha|beta|rc|pre|preview|dev|snapshot|canary|nightly)(\d|\.|$)/i
+const VERSION_SUFFIX = /\d+\.\d+(?:\.\d+)?-([0-9A-Za-z]+)/
+const PRERELEASE_TOKEN = /^(alpha|beta|rc|pre|preview|dev|snapshot|canary|nightly)/i
 
 export function isPrerelease(version: string): boolean {
   const suffix = VERSION_SUFFIX.exec(version.replace(/\(.*\)/, ''))
-  if (!suffix) return false
-
-  // Everything from a `+` on is build metadata, which semver reads as belonging to
-  // the release it hangs off rather than as a version of its own — so 2.0.0+x64-rc1
-  // is the stable 2.0.0, however the metadata is worded. Display keeps it (a card
-  // for +arm64 says +arm64); ranking cannot see it, or a stable release would be
-  // held back behind an older one on the strength of a word after the plus.
-  const qualifier = suffix[1].split('+')[0]
-
-  // Every token, not just the first: 1.0.0-x86-rc1 names an architecture before it
-  // names the release candidate it is. Split on every separator a qualifier is
-  // written with — semver's own is the dot (1.0.0-x86.rc1), and an architecture is
-  // as likely to be spelled x86_64 as x86.
-  return qualifier.split(/[-._]/).some((token) => token !== '' && PRERELEASE_TOKEN.test(token))
+  return suffix !== null && PRERELEASE_TOKEN.test(suffix[1])
 }
 
 /** Ranked so a stable release outranks any prerelease, and both outrank a version
@@ -427,38 +331,26 @@ export interface DesktopDownload extends DesktopBuild {
 /**
  * The version line for the offer, or null when the installers do not share one.
  *
- * Formatting alike is the first answer, and 1.0 written beside 1.0.0 is one release
- * said two ways. Where the strings differ it is the qualifier that differs, and not
- * every qualifier makes a different release: -x64 beside -arm64 is one version built
- * twice, which isPrerelease() already says in as many words, while -rc1 beside 1.0.0
- * is the release candidate and the release it precedes. So an architecture falls
- * back to the version the two builds share; a prerelease among them does not.
- *
- * A string no version can be read out of is not labelled at all: a `v` in front of
- * it would claim more than the string says.
+ * formatVersion() drops a `-suffix`, so a prerelease would be badged as the stable
+ * release it is not — above a button that hands over the prerelease. Prereleases
+ * therefore keep their version string verbatim. (formatVersion itself is left alone:
+ * the timeline cards badge the same way, and moving them apart would be worse than
+ * moving them together later.)
  */
 export function offerVersionLabel(offers: DesktopDownload[]): string | null {
-  if (offers.length === 0) return null
-  if (offers.some((offer) => parseSemVer(offer.app_version) === null)) return null
+  // Written the same way, modulo a `v` prefix: label it.
+  const raw = Array.from(new Set(offers.map((offer) => offer.app_version.trim().replace(/^v/i, ''))))
+  if (raw.length === 1) return isPrerelease(raw[0]) ? raw[0] : `v${formatVersion(raw[0])}`
 
-  // Asked before anything else, because "these two format alike" and "these two are
-  // one release" are different claims and only the second is what a label makes. A
-  // qualifier spelled 1.0.0_rc1 is one isPrerelease() reads and formatVersion() does
-  // not, so formatting alike put v1.0.0 over the button handing out the candidate.
-  if (offers.some((offer) => isPrerelease(offer.app_version))) {
-    const single = new Set(offers.map((offer) => offer.app_version.trim().replace(/^v/i, '')))
-    return single.size === 1 ? `v${formatVersion([...single][0])}` : null
-  }
+  // Written differently with a prerelease among them: say nothing. formatVersion()
+  // drops a `-suffix`, so comparing formatted versions here would collapse Windows
+  // on 1.0.0 and macOS on 1.0.0-rc1 into one version and badge the RC as stable —
+  // above the button that hands it over.
+  if (offers.some((offer) => isPrerelease(offer.app_version))) return null
 
-  const formatted = new Set(offers.map((offer) => formatVersion(offer.app_version.trim().replace(/^v/i, ''))))
-  if (formatted.size === 1) return `v${[...formatted][0]}`
-
-  const shared = new Set(offers.map((offer) => {
-    const triple = parseSemVer(offer.app_version)!
-    const build = parseBuildNumber(offer.app_version)
-    return `${triple[0]}.${triple[1]}.${triple[2]}${build !== null ? `(${build})` : ''}`
-  }))
-  return shared.size === 1 ? `v${[...shared][0]}` : null
+  // All stable and formatting alike (1.0 and 1.0.0) — one version, said once.
+  const formatted = Array.from(new Set(offers.map((offer) => formatVersion(offer.app_version))))
+  return formatted.length === 1 ? `v${formatted[0]}` : null
 }
 
 /**
@@ -863,14 +755,10 @@ export function parseContributors(desc: string): Contributor[] {
   return []
 }
 
-/* The same expression ranking reads, under the name display uses it by. */
-const VERSION_QUALIFIER = VERSION_SUFFIX
-
 export function formatVersion(raw: string): string {
   const semver = parseSemVer(raw)
   if (!semver) return raw
   const build = parseBuildNumber(raw)
-  const qualifier = VERSION_QUALIFIER.exec(raw.replace(/\(.*\)/, ''))
-  const base = `${semver[0]}.${semver[1]}.${semver[2]}${qualifier ? qualifier[1] : ''}`
+  const base = `${semver[0]}.${semver[1]}.${semver[2]}`
   return build !== null ? `${base}(${build})` : base
 }

--- a/src/pages/Changelog/utils.ts
+++ b/src/pages/Changelog/utils.ts
@@ -586,7 +586,13 @@ export function groupReleases(raw: AppVersion[]): ReleaseEntry[] {
         // Same OS re-uploaded for this version: the card has to follow the newer
         // build, whatever order the feed happens to arrive in — and has to pick the
         // same one the band above it offers.
-        Object.assign(sameOS, build)
+        Object.assign(sameOS, build, {
+          // Re-uploading to fix a broken link is done with the notes box left
+          // empty. It is the same release either way, so the notes already on the
+          // card still describe it; taking them away would empty the card over a
+          // change that was never made to what shipped.
+          update_desc: build.update_desc.trim() ? build.update_desc : sameOS.update_desc,
+        })
       }
       continue
     }

--- a/src/pages/Changelog/utils.ts
+++ b/src/pages/Changelog/utils.ts
@@ -486,18 +486,35 @@ export function orderBuilds(builds: DesktopBuild[], viewerOS: ViewerOS | null): 
 
 const URL_SCHEME = /^([a-z][a-z0-9+.-]*):/i
 
+/* A base no page is ever served from, so "does this stay on our own origin" still
+   has an answer where there is no document to ask — a test, a build step. */
+const NO_DOCUMENT_BASE = 'https://changelog.invalid/'
+
+function documentBase(): string {
+  return typeof window === 'undefined' || !window.location ? NO_DOCUMENT_BASE : window.location.href
+}
+
 /**
  * download_url is admin-entered and lands in an `href` on the public What's New
  * page, so only a plain http(s) link — or a path-relative one, which stays on this
  * origin and cannot execute script — is ever handed to the browser.
  *
- * Three things browsers do that a naive check misses:
- *   - control characters are ignored, so "java\tscript:" runs;
- *   - `\` is folded to `/` against an http(s) base, so `//host`, `\\host`, `/\host`
- *     and `\/host` are all network-path references that resolve to another origin
- *     despite carrying no scheme;
- *   - a scheme with no authority is still absolute, so `http:host` on an https page
- *     navigates to http://host rather than to a path.
+ * Where the link goes is settled by resolving it, not by reading the string: the
+ * URL parser is the same one the browser will use on the href, so there is no gap
+ * between the rule and the behaviour for a cleverly written string to live in.
+ * Two things it decides that pattern-matching kept getting wrong:
+ *   - `\` folds to `/` against an http(s) base, so `//host`, `\\host`, `/\host` and
+ *     `\/host` are authorities rather than the paths they look like, and land on
+ *     another origin while carrying no scheme;
+ *   - a scheme need not be http(s) to parse — `javascript:` and `data:` resolve
+ *     perfectly well, and only the resolved protocol says so.
+ *
+ * Control characters are stripped before any of that, because browsers ignore them
+ * inside a URL and "java\tscript:" therefore runs.
+ *
+ * A scheme still has to be written in full (`https://host`, not `https:host`): both
+ * reach the same place, but only one of them looks like what it does, and a link
+ * this page did not have to accept is one it does not.
  *
  * Returns the original string when it is safe to link, null when it is not.
  */
@@ -506,16 +523,23 @@ export function safeDownloadUrl(url: string | null | undefined): string | null {
   if (!trimmed) return null
 
   const probe = trimmed.replace(/[\u0000-\u0020\u007F]/g, '')
-  // No relative download path starts with a backslash, and any pair of leading
-  // slashes in either direction is an authority, not a path.
-  if (probe.startsWith('\\') || /^[/\\][/\\]/.test(probe)) return null
+  const base = documentBase()
+
+  let resolved: URL
+  try {
+    resolved = new URL(probe, base)
+  } catch {
+    return null
+  }
+
+  if (resolved.protocol !== 'http:' && resolved.protocol !== 'https:') return null
 
   const scheme = URL_SCHEME.exec(probe)
-  if (!scheme) return trimmed
-
-  const protocol = scheme[1].toLowerCase()
-  if (protocol !== 'http' && protocol !== 'https') return null
-  return probe.toLowerCase().startsWith(`${protocol}://`) ? trimmed : null
+  if (!scheme) {
+    // Carries no scheme of its own, so it may only be a path on this origin.
+    return resolved.origin === new URL(base).origin ? trimmed : null
+  }
+  return probe.toLowerCase().startsWith(`${scheme[1].toLowerCase()}://`) ? trimmed : null
 }
 
 function byNewestFirst(a: { created_at: string }, b: { created_at: string }): number {

--- a/src/pages/Changelog/utils.ts
+++ b/src/pages/Changelog/utils.ts
@@ -1,5 +1,7 @@
 export type ChangeCategory = 'security' | 'removed' | 'fixed' | 'added' | 'changed' | 'other'
 
+const CHANGE_CATEGORIES: readonly ChangeCategory[] = ['security', 'removed', 'fixed', 'added', 'changed', 'other']
+
 export interface ChangeItem {
   text: string
   group?: string
@@ -54,6 +56,20 @@ const CATEGORY_PATTERNS: [ChangeCategory, RegExp][] = [
  * in 上线 ("问题：功能无法上线") stays where it belongs.
  */
 const RELEASE_ANNOUNCEMENT = /(?:正式|首次|版本)(?:发布|上线)$/
+
+/**
+ * A line that announces the release itself and nothing else: it names a version,
+ * optionally behind a platform, and stops.
+ *
+ * The card header already carries every word of it — the version, the platform
+ * badges, the severity tag — so the line adds nothing, and filing it under 新增
+ * additionally claims that shipping is a feature, which the per-card counters then
+ * add up ("新增 2" for a release with no features at all).
+ *
+ * The version number is what makes it droppable. "深色模式正式发布" ends the same
+ * way but names a feature, so it has no version and stays where it was.
+ */
+const VERSION_ANNOUNCEMENT = /\d+\.\d+(?:\.\d+)?\S*\s*(?:版本)?(?:正式|首次)?(?:发布|上线)$/
 
 const PREFIX_STRIP = /^(安全|漏洞|CVE|security|移除|删除|废弃|下线|remove|deprecat\w*|修复|修正|解决|fix|bug|新增|新功能|新加|添加|支持|feat(?:ure)?|优化|改进|提升|更新|调整|升级|重构|改为|改善|chore|refactor|perf)[：:：]?\s*/i
 
@@ -144,6 +160,8 @@ export function parseUpdateDesc(desc: string): ParsedChanges {
       push(currentSection, stripped || line)
     } else if (cat !== 'other') {
       push(cat, stripped)
+    } else if (VERSION_ANNOUNCEMENT.test(line)) {
+      continue
     } else if (RELEASE_ANNOUNCEMENT.test(line)) {
       push('added', line)
     } else {
@@ -381,6 +399,12 @@ export interface NoteBlock {
   desc: string
 }
 
+/** Whether a note still says anything once release announcements are dropped. */
+export function hasVisibleChanges(desc: string): boolean {
+  const parsed = parseUpdateDesc(desc)
+  return CHANGE_CATEGORIES.some((category) => parsed[category].length > 0)
+}
+
 /**
  * The note blocks a card should render.
  *
@@ -393,14 +417,16 @@ export interface NoteBlock {
  */
 export function noteBlocks(entry: ReleaseEntry, viewerOS: ViewerOS | null = null): NoteBlock[] {
   if (!entry.builds) {
-    return entry.update_desc.trim() ? [{ os: [], desc: entry.update_desc }] : []
+    return hasVisibleChanges(entry.update_desc) ? [{ os: [], desc: entry.update_desc }] : []
   }
 
   const blocks: NoteBlock[] = []
   const byDesc = new Map<string, NoteBlock>()
   for (const build of orderBuilds(entry.builds, viewerOS)) {
     const desc = build.update_desc.trim()
-    if (!desc) continue
+    // A note that was only ever "1.0.0 版本发布" parses to nothing; rendering it
+    // would leave a platform heading standing over an empty list.
+    if (!hasVisibleChanges(desc)) continue
     const shared = byDesc.get(desc)
     if (shared) {
       shared.os.push(build.os)

--- a/src/pages/Changelog/utils.ts
+++ b/src/pages/Changelog/utils.ts
@@ -313,10 +313,26 @@ function supersedes(candidate: AppVersion, current: DesktopDownload): boolean {
     if (a.triple[i] !== b.triple[i]) return a.triple[i] > b.triple[i]
   }
   if (a.build !== b.build) return a.build > b.build
+  return supersedesSameVersion(candidate, current)
+}
+
+/**
+ * The tail of that order, for two rows already known to carry one version — which
+ * is how groupReleases() meets them, having keyed the card by app_version.
+ *
+ * Shared rather than restated: the card links a build and the band above it offers
+ * one, and if the two break a tie differently the same visitor is handed two
+ * different installers for the release they are reading about.
+ *
+ * Rows alike down to the second still need an answer, or the fold in
+ * latestDesktopDownloads() returns whichever arrived first and the
+ * order-independence above is only most of a total order.
+ */
+function supersedesSameVersion(
+  candidate: { created_at: string; download_url: string },
+  current: { created_at: string; download_url: string },
+): boolean {
   if (candidate.created_at !== current.created_at) return candidate.created_at > current.created_at
-  // Rows alike down to the second still need one answer, or the fold returns
-  // whichever arrived first and the order-independence above is only most of a
-  // total order.
   return candidate.download_url > current.download_url
 }
 
@@ -547,9 +563,10 @@ export function groupReleases(raw: AppVersion[]): ReleaseEntry[] {
       const sameOS = entry.builds!.find((existing) => existing.os === item.os)
       if (!sameOS) {
         entry.builds!.push(build)
-      } else if (item.created_at > sameOS.created_at) {
+      } else if (supersedesSameVersion(item, sameOS)) {
         // Same OS re-uploaded for this version: the card has to follow the newer
-        // build, whatever order the feed happens to arrive in.
+        // build, whatever order the feed happens to arrive in — and has to pick the
+        // same one the band above it offers.
         Object.assign(sameOS, build)
       }
       continue

--- a/src/pages/Changelog/utils.ts
+++ b/src/pages/Changelog/utils.ts
@@ -409,10 +409,17 @@ export function offerVersionLabel(offers: DesktopDownload[]): string | null {
   if (offers.length === 0) return null
   if (offers.some((offer) => parseSemVer(offer.app_version) === null)) return null
 
+  // Asked before anything else, because "these two format alike" and "these two are
+  // one release" are different claims and only the second is what a label makes. A
+  // qualifier spelled 1.0.0_rc1 is one isPrerelease() reads and formatVersion() does
+  // not, so formatting alike put v1.0.0 over the button handing out the candidate.
+  if (offers.some((offer) => isPrerelease(offer.app_version))) {
+    const single = new Set(offers.map((offer) => offer.app_version.trim().replace(/^v/i, '')))
+    return single.size === 1 ? `v${formatVersion([...single][0])}` : null
+  }
+
   const formatted = new Set(offers.map((offer) => formatVersion(offer.app_version.trim().replace(/^v/i, ''))))
   if (formatted.size === 1) return `v${[...formatted][0]}`
-
-  if (offers.some((offer) => isPrerelease(offer.app_version))) return null
 
   const shared = new Set(offers.map((offer) => {
     const triple = parseSemVer(offer.app_version)!
@@ -825,10 +832,14 @@ export function parseContributors(desc: string): Contributor[] {
 }
 
 /* Everything after the triple that a semver qualifier can carry: -rc1, -beta.2,
-   -x64, +arm64. Kept rather than dropped, so a card titled v1.0.0 is never a
-   1.0.0-rc1 — and, now that formatting alike is what "one release" means, so that
-   two strings only collapse into one label when they really are one release. */
-const VERSION_QUALIFIER = /\d+\.\d+(?:\.\d+)?([-+][0-9A-Za-z][0-9A-Za-z._+-]*)/
+   -x64, +arm64, _rc1. Kept rather than dropped, so a card titled v1.0.0 is never a
+   1.0.0-rc1.
+
+   The opener stops at `-+_` deliberately, though isPrerelease() also splits on `.`:
+   the dot is the version separator itself, so accepting it here reads the ".16" of
+   a 2026.04.16 web version as a qualifier and renders it as 2026.4.16.16. Ranking
+   can afford to be lenient about a separator; display cannot. */
+const VERSION_QUALIFIER = /\d+\.\d+(?:\.\d+)?([-+_][0-9A-Za-z][0-9A-Za-z._+-]*)/
 
 export function formatVersion(raw: string): string {
   const semver = parseSemVer(raw)


### PR DESCRIPTION
Follows #140 and #141.

Opening the changelog on a phone turned up a page that scrolls sideways and a band
of buttons no phone can use. This fixes those, and takes four correctness items off
the review backlog those two PRs left behind.

An earlier revision of this branch also rewrote the version-string handling. That is
**removed** — see *What was taken back out* at the end.

## The page scrolled sideways on every phone

A release note that quotes code — a dotted config key, a file path — carries one
unbreakable word past 60 characters, and nothing in the note styling let it break.
The word set the min-content width of the note column, the timeline row (a fixed
72px date gutter, a 40px rail, and a content column that cannot shrink below its
longest word) then measured wider than the viewport, and the whole document
scrolled horizontally.

Worth recording how it hides: inline text spilling out of an in-bounds block leaves
the block's own rect alone while still extending the document's scrollable width, so
"which element sticks out" finds nothing. It took measuring every text node's client
rects to locate it.

This predates both earlier PRs — the same 564px document width against a 430px
viewport reproduces on e0c2bc3.

Notes now break inside a word: `overflow-wrap: anywhere`, with `word-break:
break-word` ahead of it for Safari below 15.4, which drops the `anywhere` keyword.
The deprecated alias is the one that also shrinks min-content there — the
`break-word` value of `overflow-wrap` does not, and min-content is what set the
floor.

Two more things were setting a floor on the page width, and are lifted with it:

- the contributor tooltip was `opacity: 0` rather than absent, and an absolutely
  positioned hidden name still counts toward scroll width — a page scrolling
  sideways to reveal a name that on a touch device can never be triggered;
- the avatar row is `flex-shrink: 0`, and ten 24px avatars plus a "+N" badge come to
  184px against roughly 200px of note column on a 360px phone. Below 420px it shows
  five and drops its label; the badge still counts everyone left out.

Measured at 320 / 360 / 375 / 390 / 393 / 430px with a handheld user agent, and at
320 / 360 / 420 / 500px with a desktop one: document width equals viewport width at
every one.

## A band of installers no phone can run

The band above the timeline hands the visitor a Windows or macOS installer, and took
a third of the first screen on a device that can run neither, pushing What's New
below the fold.

Hiding it whenever `detectViewerOS()` returns null would overshoot: null is equally
the answer for a desktop whose user agent nothing recognises, and that visitor is
exactly who the band is for. `isHandheld()` asks the other question directly. On a
handheld the band becomes one quiet line naming the app, its version and its
platforms — the offer survives as news, only the dead buttons go.

**No installer buttons render anywhere on a handheld**, the release cards and the
spotlight included. An earlier revision kept them on the cards, reasoning that a
card should hold its links when the band rendered none; that read the situation
backwards — the band did not fail to make the offer, it withdrew it — and left every
card re-offering the buttons under a sentence saying downloading here is impossible.

The gate is the user agent and not the viewport width, deliberately: the compact
line reads 在电脑上打开本页即可下载, which is the wrong sentence for someone already on
a computer with a narrow window. That case was measured rather than assumed — see
the widths above.

## Correctness items from the earlier reviews

- **One comparator, not two.** The card links a build and the band offers one; each
  picked a winner among rows for the same OS and version, but the band ordered by
  upload time then URL while the card kept whichever arrived first on a tie. Two
  uploads saved in the same second had the page name one version and hand over a
  file from another row. Two rows agreeing on timestamp *and* URL still resolve by
  arrival order; that residual is documented where the comparator stops.
- **Notes survive a blank re-upload, in any arrival order.** Fixing a broken link is
  done from a form with the notes box empty, and the newer row replaced the older
  one whole. The build the card links and the notes it shows need not come from the
  same row, so they are chosen separately: the newest upload wins the link, the
  newest upload that filed any notes wins the notes. Verified across all six arrival
  orders of a three-upload version.
- **必须升级 names its platforms.** It is set per build while a card holds every OS
  build of a version, so a card could tell macOS visitors to do something nobody was
  asking of them. (The spotlight card at the top of the page renders no force badge
  at all — pre-existing, unchanged here, and worth its own issue.)
- **The URL guard resolves instead of pattern-matching.** Each rule in it was added
  after a shape got through, which only ever covers the shapes someone thought of.
  Links are now resolved against `document.baseURI` with the same parser the browser
  will use on the href, and the resolved protocol and origin decide. The value
  resolved is the value returned, so nothing is approved on the strength of a string
  that is not the one published. One deliberate relaxation: a single leading
  backslash resolves to a same-origin path and is allowed, where the old blanket
  refusal was over-rejection.

## Verification

`npm test` 194 passing (+19 over `main`'s 175), `tsc` and `vite build` clean.

The rendering changes are the mobile ones described above. Everything the page
*derives* from a production-shaped feed is unchanged from `main`: same cards, same
order, same builds, same notes, same parsed items, same severities, same installers,
same offer label, same URLs accepted — checked row by row against `main`'s own
functions over ~120 production rows.

## What was taken back out

An earlier revision rewrote how the page reads a version string — a shared qualifier
expression, `formatVersion` preserving qualifiers, an `offerVersionLabel` rewrite,
`isPrerelease` reading every token — and added a rule that inferred a release
announcement from free Chinese prose in order to keep it out of the change counters.

All of it is removed, restoring `main`'s behaviour exactly. Two reasons:

- **It never fires.** Of roughly 120 rows in the production feed, every
  `app_version` is a plain triple or `1.0.0(62)`. Not one carries a `-`, `_` or `+`
  qualifier, which is the only shape any of that code reads.
- **It was guessing at a field nobody validates.** Every blocking finding across
  eight review rounds landed in those two areas, each fix produced the next spelling
  within a round, and the announcement rule twice deleted admin-authored lines from
  a public page before it was retired.

One consequence is visible and intended: the 1.0.0 card again shows "新增 2" for a
release whose notes are two lines announcing itself. That is `main`'s behaviour, and
removing it is a write-side change, not another rule here.

What that code was reaching for belongs on the write side, where `app_version` can
be a validated shape and a release channel can be a field rather than something
inferred from prose. `download_url` wants the same treatment — the guard in this PR
is a last line, not the only one it should have. That is the next PR, and the
findings the reviews left open are worth fixing against a validated field rather
than by adding another expression here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUmovPkkCwhbQNRKUYAbia