### PR TITLE
feat(space-console): give the space console its own sign-in

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -15,6 +15,21 @@ interface LoginResponse {
 export const login = (params: LoginParams) =>
   api.post<LoginResponse>('/v1/manager/login', params).then((res) => res.data)
 
+// 空间控制台自有登录（普通用户身份）。此前空间控制台没有登录入口，只能寄生于同一
+// 标签页 sessionStorage 里恰好存在的 IM 会话 token —— 换标签页就进不去，且与超管会话互斥。
+// 服务端 /v1/user/login 是 IM Web 用的同一个端点，空间管理员用自己的账号登录即可。
+export interface UserLoginResponse {
+  token: string
+  uid: string
+  name: string
+  username?: string
+}
+
+export const userLogin = (params: LoginParams) =>
+  api
+    .post<UserLoginResponse>('/v1/user/login', { ...params, flag: 1 })
+    .then((res) => res.data)
+
 export const getManagerMe = () =>
   api.get<ManagerMe>('/v1/manager/me').then((res) => ({
     ...res.data,

--- a/src/i18n/locales/en-US/appBots.json
+++ b/src/i18n/locales/en-US/appBots.json
@@ -93,5 +93,8 @@
   "form.welcome.extra": "Message automatically sent on a user's first connection; leave empty to use the default prompt",
   "form.welcome.placeholder": "Hi! I'm the xx assistant. How can I help you?",
   "edit.title": "Edit {{name}}",
-  "edit.toast.updated": "Updated"
+  "edit.toast.updated": "Updated",
+  "list.platformOnly.title": "This list shows platform-level app bots only",
+  "list.platformOnly.desc": "Space-level app bots, including any moved from the platform into a space, are managed in that space’s own console.",
+  "list.platformOnly.link": "Open the space console"
 }

--- a/src/i18n/locales/en-US/nav.json
+++ b/src/i18n/locales/en-US/nav.json
@@ -13,5 +13,6 @@
   "expertMarket": "Expert Market",
   "backup": "Backups",
   "download": "Downloads",
-  "systemSkill": "Skill Market"
+  "systemSkill": "Skill Market",
+  "spaceConsole": "Space console"
 }

--- a/src/i18n/locales/en-US/spaceAdmin.json
+++ b/src/i18n/locales/en-US/spaceAdmin.json
@@ -38,12 +38,19 @@
   "validate.logoTooLong": "Logo cannot exceed {{max}} characters",
   "validate.descriptionTooLong": "Space description cannot exceed {{max}} characters",
   "entry.loading": "Entering space admin…",
-  "entry.noToken.title": "No login session detected",
-  "entry.noToken.subtitle": "Please sign in within the app before entering space admin, or sign in with a super admin account.",
-  "entry.noToken.action": "Go to sign in",
   "entry.noSpace.title": "No manageable spaces",
   "entry.noSpace.subtitle": "You are not an admin or owner of any space yet.",
   "entry.noSpace.action": "Back to sign in",
   "entry.error.title": "Failed to load space",
-  "entry.error.action": "Retry"
+  "entry.error.action": "Retry",
+  "entry.login.title": "Space console",
+  "entry.login.subtitle": "Sign in with your account to manage the spaces you administer.",
+  "entry.login.superNotice": "You are signed in as a super administrator. The space console is a separate identity; signing in here switches you to a space administrator.",
+  "entry.login.username": "Username",
+  "entry.login.password": "Password",
+  "entry.login.usernameRequired": "Enter your username",
+  "entry.login.passwordRequired": "Enter your password",
+  "entry.login.submit": "Sign in",
+  "entry.login.toSuper": "Sign in as super administrator instead",
+  "entry.login.noToken": "Login returned no token"
 }

--- a/src/i18n/locales/zh-CN/appBots.json
+++ b/src/i18n/locales/zh-CN/appBots.json
@@ -93,5 +93,8 @@
   "form.welcome.extra": "用户首次连接时自动发送的消息，留空则使用默认提示",
   "form.welcome.placeholder": "你好！我是 xx 助手，有什么可以帮你的？",
   "edit.title": "编辑 {{name}}",
-  "edit.toast.updated": "已更新"
+  "edit.toast.updated": "已更新",
+  "list.platformOnly.title": "这里只列平台级应用 Bot",
+  "list.platformOnly.desc": "空间级应用 Bot（含从平台移入空间的）在各自空间的控制台管理。",
+  "list.platformOnly.link": "前往空间控制台"
 }

--- a/src/i18n/locales/zh-CN/nav.json
+++ b/src/i18n/locales/zh-CN/nav.json
@@ -13,5 +13,6 @@
   "expertMarket": "专家市场",
   "backup": "备份管理",
   "download": "下载配置",
-  "systemSkill": "Skill 市场"
+  "systemSkill": "Skill 市场",
+  "spaceConsole": "空间控制台"
 }

--- a/src/i18n/locales/zh-CN/spaceAdmin.json
+++ b/src/i18n/locales/zh-CN/spaceAdmin.json
@@ -38,12 +38,19 @@
   "validate.logoTooLong": "Logo 不能超过 {{max}} 个字符",
   "validate.descriptionTooLong": "空间描述不能超过 {{max}} 个字符",
   "entry.loading": "正在进入空间管理…",
-  "entry.noToken.title": "未检测到登录态",
-  "entry.noToken.subtitle": "请先在应用内登录后再进入空间管理，或使用超级管理员账号登录。",
-  "entry.noToken.action": "去登录",
   "entry.noSpace.title": "暂无可管理的空间",
   "entry.noSpace.subtitle": "你还不是任何空间的管理员或拥有者。",
   "entry.noSpace.action": "返回登录",
   "entry.error.title": "加载空间失败",
-  "entry.error.action": "重试"
+  "entry.error.action": "重试",
+  "entry.login.title": "空间控制台",
+  "entry.login.subtitle": "用你的账号登录，管理你是管理员的空间。",
+  "entry.login.superNotice": "你当前是超级管理员身份。空间控制台是另一套身份，登录后将切换为空间管理员。",
+  "entry.login.username": "用户名",
+  "entry.login.password": "密码",
+  "entry.login.usernameRequired": "请输入用户名",
+  "entry.login.passwordRequired": "请输入密码",
+  "entry.login.submit": "登录",
+  "entry.login.toSuper": "改用超级管理员登录",
+  "entry.login.noToken": "登录未返回 token"
 }

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -120,6 +120,11 @@ const MainLayout: React.FC = () => {
     if (appBotsAvailable === true) {
       list.push({ key: '/app-bots', icon: <RobotOutlined />, label: t('nav:appBots'), group: 'management' })
     }
+    if (appBotsAvailable === true) {
+      // 空间级 Bot / 成员 / 邀请在各空间自己的控制台管理，超管这边只能看到平台级。
+      // 没有这个入口时，空间控制台只能靠手敲 URL 进入。
+      list.push({ key: '/space', icon: <AppstoreOutlined />, label: t('nav:spaceConsole'), group: 'management' })
+    }
     if (hasManagerCapability(managerCapabilities, 'system_setting')) {
       list.push({ key: '/system-setting', icon: <SettingOutlined />, label: t('nav:systemSetting'), group: 'system' })
     }

--- a/src/pages/AppBots/index.tsx
+++ b/src/pages/AppBots/index.tsx
@@ -10,6 +10,7 @@ import {
   message,
   Typography,
   Avatar,
+  Alert,
 } from 'antd'
 import { PlusOutlined, SearchOutlined, RobotOutlined } from '@ant-design/icons'
 import type { ColumnsType } from 'antd/es/table'
@@ -247,6 +248,24 @@ export default function AppBotsPage({ spaceId }: Props) {
           </Button>
         </Space>
       </div>
+
+      {!spaceId && (
+        // 这张表只列平台级 Bot（服务端 /v1/admin/app_bot 按 scope 过滤，见 botInRouteScope
+        // 的跨租户防护）。空间级 Bot 在各自空间的控制台管理。没有这句提示时，
+        // 一个被移到空间的 Bot 会从这页凭空消失，用户无从知道它去哪了。
+        <Alert
+          type="info"
+          showIcon
+          style={{ marginBottom: 16 }}
+          message={t('list.platformOnly.title')}
+          description={
+            <span>
+              {t('list.platformOnly.desc')}{' '}
+              <Typography.Link href="/admin/space">{t('list.platformOnly.link')}</Typography.Link>
+            </span>
+          }
+        />
+      )}
 
       <Table
         rowKey="id"

--- a/src/pages/SpaceAdmin/SpaceEntry.test.tsx
+++ b/src/pages/SpaceAdmin/SpaceEntry.test.tsx
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import enUS from '../../i18n/locales/en-US/spaceAdmin.json'
+import zhCN from '../../i18n/locales/zh-CN/spaceAdmin.json'
+import navEN from '../../i18n/locales/en-US/nav.json'
+import navZH from '../../i18n/locales/zh-CN/nav.json'
+import appBotsEN from '../../i18n/locales/en-US/appBots.json'
+import appBotsZH from '../../i18n/locales/zh-CN/appBots.json'
+// 用 Vite 的 ?raw 读源码（不引 node API，`tsc` 在 build 时也编译测试文件，
+// 而本仓库没有 @types/node）。断言的是「这段行为写在了源码里」，不是实现细节的复刻。
+import entrySource from './SpaceEntry.tsx?raw'
+import listSource from '../AppBots/index.tsx?raw'
+
+describe('space console sign-in', () => {
+  // The space console used to have no sign-in of its own: it could only borrow an IM
+  // session token that happened to sit in the same tab's sessionStorage. Open it in a
+  // fresh tab and it was a dead end; arrive as a super admin and it silently bounced
+  // you back to the super dashboard. Both paths now land on a real sign-in form.
+  it('signs in through the user login endpoint rather than borrowing a session token', () => {
+    expect(entrySource).toContain("import { userLogin } from '../../api/auth'")
+    expect(entrySource).toContain('async function handleLogin')
+    expect(entrySource).toContain('await userLogin(values)')
+  })
+
+  it('offers the form when the tab carries no session token', () => {
+    expect(entrySource).toMatch(/const token = readSessionToken\(\)\s*\n\s*if \(!token\) \{[\s\S]*?setStatus\('form'\)/)
+    expect(entrySource).not.toContain("setStatus('no-token')")
+  })
+
+  it('lets a super admin switch identity instead of bouncing them away', () => {
+    expect(entrySource).toMatch(/scope === 'super'[\s\S]*?setCameFromSuper\(true\)[\s\S]*?setStatus\('form'\)/)
+    expect(entrySource).not.toMatch(/scope === 'super'[\s\S]{0,120}navigate\('\/dashboard'/)
+    expect(entrySource).toContain("t('entry.login.superNotice')")
+  })
+
+  it('keeps sign-in copy in both locales', () => {
+    const keys = [
+      'entry.login.title',
+      'entry.login.subtitle',
+      'entry.login.superNotice',
+      'entry.login.username',
+      'entry.login.password',
+      'entry.login.usernameRequired',
+      'entry.login.passwordRequired',
+      'entry.login.submit',
+      'entry.login.toSuper',
+      'entry.login.noToken',
+    ] as const
+    for (const key of keys) {
+      expect(zhCN[key], `zh-CN ${key}`).toBeTruthy()
+      expect(enUS[key], `en-US ${key}`).toBeTruthy()
+    }
+    // The replaced dead-end copy must not linger in either locale.
+    for (const stale of ['entry.noToken.title', 'entry.noToken.subtitle', 'entry.noToken.action']) {
+      expect(Object.keys(zhCN)).not.toContain(stale)
+      expect(Object.keys(enUS)).not.toContain(stale)
+    }
+  })
+})
+
+describe('reaching space-level app bots from the super admin console', () => {
+  it('names the space console in the sidebar', () => {
+    expect(navZH.spaceConsole).toBeTruthy()
+    expect(navEN.spaceConsole).toBeTruthy()
+  })
+
+  it('explains that the platform list omits space-level bots', () => {
+    for (const bundle of [appBotsZH, appBotsEN]) {
+      expect(bundle['list.platformOnly.title']).toBeTruthy()
+      expect(bundle['list.platformOnly.desc']).toBeTruthy()
+      expect(bundle['list.platformOnly.link']).toBeTruthy()
+    }
+    // The notice belongs on the platform list only; inside a space console it would be wrong.
+    expect(listSource).toMatch(/\{!spaceId && \([\s\S]*?list\.platformOnly\.title/)
+    expect(listSource).toContain('href="/admin/space"')
+  })
+})

--- a/src/pages/SpaceAdmin/SpaceEntry.tsx
+++ b/src/pages/SpaceAdmin/SpaceEntry.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
-import { Spin, Result, Button } from 'antd'
+import { Spin, Result, Button, Form, Input, Card, Alert, Typography } from 'antd'
+import { UserOutlined, LockOutlined } from '@ant-design/icons'
 import { useAuthStore } from '../../store/auth'
 import { getMySpaces, getUser } from '../../api/space-user'
+import { userLogin } from '../../api/auth'
 import type { MySpace } from '../../store/auth'
 import { useState } from 'react'
 
@@ -46,7 +48,11 @@ export default function SpaceEntry() {
   const { t } = useTranslation('spaceAdmin')
   const navigate = useNavigate()
   const loginSpace = useAuthStore((s) => s.loginSpace)
-  const [status, setStatus] = useState<'loading' | 'no-token' | 'no-space' | 'error'>('loading')
+  const [status, setStatus] = useState<'loading' | 'form' | 'no-space' | 'error'>('loading')
+  // 'super'：当前浏览器里是超管会话。超管与空间管理员是两套身份，继续即以空间账号登录。
+  const [cameFromSuper, setCameFromSuper] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+  const [formError, setFormError] = useState('')
   const [errorMsg, setErrorMsg] = useState('')
   const onceRef = useRef(false)
 
@@ -55,7 +61,10 @@ export default function SpaceEntry() {
     onceRef.current = true
     const state = useAuthStore.getState()
     if (state.isLoggedIn && state.scope === 'super') {
-      navigate('/dashboard', { replace: true })
+      // 旧行为是把超管静默弹回超管首页：用户点进空间控制台，却在毫无解释的情况下
+      // 回到了原地。改为显式提示 + 登录表单，由用户决定是否切换身份。
+      setCameFromSuper(true)
+      setStatus('form')
       return
     }
     if (state.isLoggedIn && state.scope === 'space' && state.mySpaces.length > 0) {
@@ -83,7 +92,9 @@ export default function SpaceEntry() {
     }
     const token = readSessionToken()
     if (!token) {
-      setStatus('no-token')
+      // 同标签页没有 IM 会话（例如直接打开 /admin/space）。以前这里是死路一条，
+      // 现在给空间控制台自己的登录入口。
+      setStatus('form')
       return
     }
     useAuthStore.setState({
@@ -93,38 +104,57 @@ export default function SpaceEntry() {
       name: '',
       uid: '',
     })
-    getMySpaces()
-      .then(async (list) => {
-        const managed: MySpace[] = (list || []).filter((s) => s.role >= 1)
-        if (managed.length === 0) {
-          useAuthStore.getState().logout()
-          setStatus('no-space')
-          return
-        }
-        const uid =
-          readSessionUid() ||
-          managed.find((s) => s.role === 2)?.creator ||
-          decodeJwtUid(token)
-        let name = ''
-        let resolvedUid = uid
-        if (uid) {
-          try {
-            const u = await getUser(uid)
-            name = u.name || u.username || ''
-            resolvedUid = u.uid || uid
-          } catch {
-            // 静默降级:名字拿不到就用兜底
-          }
-        }
-        loginSpace(token, resolvedUid, name, managed)
-        navigate(`/space/${managed[0].space_id}/members`, { replace: true })
-      })
+    enterWithToken(token, readSessionUid())
       .catch((error: Error) => {
         useAuthStore.getState().logout()
         setErrorMsg(error.message)
         setStatus('error')
       })
+    // enterWithToken 在组件内定义，依赖恒定，无需进依赖数组
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [loginSpace, navigate])
+
+  // 拿到用户 token 之后的共同落地流程：确认有可管理的空间 → 补用户名 → 进控制台。
+  async function enterWithToken(token: string, knownUid: string) {
+    useAuthStore.setState({ scope: 'space', token, isLoggedIn: true, name: '', uid: '' })
+    const list = await getMySpaces()
+    const managed: MySpace[] = (list || []).filter((s) => s.role >= 1)
+    if (managed.length === 0) {
+      useAuthStore.getState().logout()
+      setStatus('no-space')
+      return
+    }
+    const uid = knownUid || managed.find((s) => s.role === 2)?.creator || decodeJwtUid(token)
+    let name = ''
+    let resolvedUid = uid
+    if (uid) {
+      try {
+        const u = await getUser(uid)
+        name = u.name || u.username || ''
+        resolvedUid = u.uid || uid
+      } catch {
+        // 静默降级:名字拿不到就用兜底
+      }
+    }
+    loginSpace(token, resolvedUid, name, managed)
+    navigate(`/space/${managed[0].space_id}/members`, { replace: true })
+  }
+
+  async function handleLogin(values: { username: string; password: string }) {
+    setSubmitting(true)
+    setFormError('')
+    try {
+      const res = await userLogin(values)
+      if (!res.token) throw new Error(t('entry.login.noToken'))
+      await enterWithToken(res.token, res.uid || '')
+    } catch (error) {
+      useAuthStore.getState().logout()
+      setFormError(error instanceof Error ? error.message : String(error))
+      setStatus('form')
+    } finally {
+      setSubmitting(false)
+    }
+  }
 
   if (status === 'loading') {
     return (
@@ -142,18 +172,66 @@ export default function SpaceEntry() {
     )
   }
 
-  if (status === 'no-token') {
+  if (status === 'form') {
     return (
-      <Result
-        status="warning"
-        title={t('entry.noToken.title')}
-        subTitle={t('entry.noToken.subtitle')}
-        extra={
-          <Button type="primary" onClick={() => navigate('/login')}>
-            {t('entry.noToken.action')}
+      <div
+        className="admin-shell"
+        style={{
+          minHeight: '100vh',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: 16,
+        }}
+      >
+        <Card style={{ width: 380 }}>
+          <Typography.Title level={4} style={{ marginTop: 0 }}>
+            {t('entry.login.title')}
+          </Typography.Title>
+          <Typography.Paragraph type="secondary" style={{ marginBottom: 16 }}>
+            {t('entry.login.subtitle')}
+          </Typography.Paragraph>
+          {cameFromSuper && (
+            <Alert
+              type="info"
+              showIcon
+              style={{ marginBottom: 16 }}
+              message={t('entry.login.superNotice')}
+            />
+          )}
+          {formError && (
+            <Alert type="error" showIcon style={{ marginBottom: 16 }} message={formError} />
+          )}
+          <Form layout="vertical" onFinish={handleLogin} disabled={submitting}>
+            <Form.Item
+              name="username"
+              rules={[{ required: true, message: t('entry.login.usernameRequired') }]}
+            >
+              <Input
+                prefix={<UserOutlined />}
+                placeholder={t('entry.login.username')}
+                autoComplete="username"
+              />
+            </Form.Item>
+            <Form.Item
+              name="password"
+              rules={[{ required: true, message: t('entry.login.passwordRequired') }]}
+            >
+              <Input.Password
+                prefix={<LockOutlined />}
+                placeholder={t('entry.login.password')}
+                autoComplete="current-password"
+              />
+            </Form.Item>
+            <Button type="primary" htmlType="submit" block loading={submitting}>
+              {t('entry.login.submit')}
+            </Button>
+          </Form>
+          <Button type="link" block style={{ marginTop: 8 }} onClick={() => navigate('/login')}>
+            {t('entry.login.toSuper')}
           </Button>
-        }
-      />
+        </Card>
+      </div>
     )
   }
 


### PR DESCRIPTION
## The problem

The space console has no way in of its own.

`SpaceEntry` can only adopt an IM session token that happens to be sitting in the same tab's `sessionStorage`, and the auth store holds a single token whose `super` / `space` scopes are mutually exclusive. Two consequences:

- Opening `/admin/space` in a fresh tab is a dead end. There is no token in that tab and no way to obtain one, so the entry point renders "no token" and the only offered action is the super admin login.
- A signed-in super admin who follows a link there is redirected to `/dashboard` with no explanation. From the outside it looks like the link is broken.

So in practice everything behind the space console — space-scoped app bots, members, invites, join requests — is unreachable, even though the server exposes the complete `/v1/space/:space_id/app_bot` surface and `checkSpaceAdmin` only asks for `space_member.role >= 1`.

We hit this while creating a space-scoped app bot on a self-hosted deployment. The bot was created on the platform App Bot page (which is the only place a create dialog exists), then moved to `scope='space'`. It immediately vanished from that page — correctly, since the platform list is scope-filtered server-side — and the space console was unreachable, so there was no page left anywhere that could publish it. The bot sat at `status=0`, `/v1/bot/register` kept answering `auth_failed`, and the only way forward was an `UPDATE` against the database. That is the part we would like to make unnecessary.

## What this changes

Frontend only. No server changes are needed — the space-scoped API already exists and is complete.

1. **The space console gets a real sign-in.** When the tab carries no session token, `SpaceEntry` renders a sign-in form and authenticates through `POST /v1/user/login`, the same endpoint the IM web client uses. It then confirms via `/v1/space/my` that the account administers at least one space and continues into the console exactly as before. The existing IM-tab flow is untouched: a session token still signs you straight in with no form.

2. **A super admin can switch identity instead of being bounced.** Arriving at `/space` while signed in as a super admin now shows the same form with a notice that continuing signs you in as a space administrator. The two identities remain separate; the difference is that the switch is explicit and explained rather than a silent redirect.

3. **The platform App Bot list says it is platform-scoped**, and links to the space console. A bot moved into a space used to disappear from that page with nothing on screen to say where it went.

4. **The super admin sidebar gains a space console entry**, so reaching it no longer requires typing the URL by hand.

## Notes

- Copy is added to both `zh-CN` and `en-US`. The three now-unused `entry.noToken.*` keys are removed.
- `src/pages/SpaceAdmin/SpaceEntry.test.tsx` covers the new behaviour; `npm test` passes 200 tests.
- Running on our deployment since 2026-08-21.

This overlaps in subject with #134 (ownership column, scope filter, scope selection in the create dialog) but is independent of it: that issue is about seeing and choosing scope, this is about being able to reach the space console at all. #134 also contains a claim of ours that we now know to be wrong — it says the deployed space drawer has no App Bot tab. The tab was there the whole time; we simply could not get into the console, and mistook unreachable for absent. We will correct that on the issue.

Happy to adjust the approach — in particular, if you would rather the space console keep out of `/v1/user/login` and obtain its token some other way, say so and we will rework it.
