### PR TITLE
feat(app-bots): give the platform list an ownership dimension

### DIFF
--- a/src/api/app-bot.ts
+++ b/src/api/app-bot.ts
@@ -24,6 +24,8 @@ export interface AppBot {
   welcome_msg: string
   scope: AppBotScope
   space_id: string | null
+  /** Only present on a mixed (scope=all / scope=space) platform listing. */
+  space_name?: string
   status: AppBotStatus
   token?: string
   connect?: BotConnectInfo
@@ -68,13 +70,25 @@ export interface ListParams {
   status?: number
 }
 
+/**
+ * Ownership filter for the platform listing. A server that predates the scope parameter
+ * ignores it and answers with platform bots only, which is exactly what the 'platform'
+ * option shows — so an older server degrades to the previous behaviour rather than erroring.
+ */
+export type AppBotScopeFilter = 'platform' | 'space' | 'all'
+
+export interface PlatformListParams extends ListParams {
+  scope?: AppBotScopeFilter
+  space_id?: string
+}
+
 // --- Helpers ---
 
 const unwrap = <T>(p: Promise<{ data: T }>): Promise<T> => p.then((r) => r.data)
 
 // --- Platform App Bot (Super Admin) ---
 
-export const listAppBots = (params: ListParams = {}): Promise<AppBotListResp> =>
+export const listAppBots = (params: PlatformListParams = {}): Promise<AppBotListResp> =>
   unwrap(api.get<AppBotListResp>('/v1/admin/app_bot', { params }))
 
 export const getAppBot = (id: string): Promise<AppBot> =>

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -15,6 +15,21 @@ interface LoginResponse {
 export const login = (params: LoginParams) =>
   api.post<LoginResponse>('/v1/manager/login', params).then((res) => res.data)
 
+// 空间控制台自有登录（普通用户身份）。此前空间控制台没有登录入口，只能寄生于同一
+// 标签页 sessionStorage 里恰好存在的 IM 会话 token —— 换标签页就进不去，且与超管会话互斥。
+// 服务端 /v1/user/login 是 IM Web 用的同一个端点，空间管理员用自己的账号登录即可。
+export interface UserLoginResponse {
+  token: string
+  uid: string
+  name: string
+  username?: string
+}
+
+export const userLogin = (params: LoginParams) =>
+  api
+    .post<UserLoginResponse>('/v1/user/login', { ...params, flag: 1 })
+    .then((res) => res.data)
+
 export const getManagerMe = () =>
   api.get<ManagerMe>('/v1/manager/me').then((res) => ({
     ...res.data,

--- a/src/i18n/locales/en-US/appBots.json
+++ b/src/i18n/locales/en-US/appBots.json
@@ -96,5 +96,11 @@
   "edit.toast.updated": "Updated",
   "list.platformOnly.title": "This list shows platform-level app bots only",
   "list.platformOnly.desc": "Space-level app bots, including any moved from the platform into a space, are managed in that space’s own console.",
-  "list.platformOnly.link": "Open the space console"
+  "list.platformOnly.link": "Open the space console",
+  "column.ownership": "Ownership",
+  "list.scopeFilter.platform": "Platform",
+  "list.scopeFilter.space": "Spaces",
+  "list.scopeFilter.all": "All owners",
+  "scope.platform": "Platform",
+  "scope.space": "Space"
 }

--- a/src/i18n/locales/en-US/appBots.json
+++ b/src/i18n/locales/en-US/appBots.json
@@ -93,5 +93,8 @@
   "form.welcome.extra": "Message automatically sent on a user's first connection; leave empty to use the default prompt",
   "form.welcome.placeholder": "Hi! I'm the xx assistant. How can I help you?",
   "edit.title": "Edit {{name}}",
-  "edit.toast.updated": "Updated"
+  "edit.toast.updated": "Updated",
+  "list.platformOnly.title": "This list shows platform-level app bots only",
+  "list.platformOnly.desc": "Space-level app bots, including any moved from the platform into a space, are managed in that space’s own console.",
+  "list.platformOnly.link": "Open the space console"
 }

--- a/src/i18n/locales/en-US/nav.json
+++ b/src/i18n/locales/en-US/nav.json
@@ -13,5 +13,6 @@
   "expertMarket": "Expert Market",
   "backup": "Backups",
   "download": "Downloads",
-  "systemSkill": "Skill Market"
+  "systemSkill": "Skill Market",
+  "spaceConsole": "Space console"
 }

--- a/src/i18n/locales/en-US/spaceAdmin.json
+++ b/src/i18n/locales/en-US/spaceAdmin.json
@@ -38,12 +38,19 @@
   "validate.logoTooLong": "Logo cannot exceed {{max}} characters",
   "validate.descriptionTooLong": "Space description cannot exceed {{max}} characters",
   "entry.loading": "Entering space admin…",
-  "entry.noToken.title": "No login session detected",
-  "entry.noToken.subtitle": "Please sign in within the app before entering space admin, or sign in with a super admin account.",
-  "entry.noToken.action": "Go to sign in",
   "entry.noSpace.title": "No manageable spaces",
   "entry.noSpace.subtitle": "You are not an admin or owner of any space yet.",
   "entry.noSpace.action": "Back to sign in",
   "entry.error.title": "Failed to load space",
-  "entry.error.action": "Retry"
+  "entry.error.action": "Retry",
+  "entry.login.title": "Space console",
+  "entry.login.subtitle": "Sign in with your account to manage the spaces you administer.",
+  "entry.login.superNotice": "You are signed in as a super administrator. The space console is a separate identity; signing in here switches you to a space administrator.",
+  "entry.login.username": "Username",
+  "entry.login.password": "Password",
+  "entry.login.usernameRequired": "Enter your username",
+  "entry.login.passwordRequired": "Enter your password",
+  "entry.login.submit": "Sign in",
+  "entry.login.toSuper": "Sign in as super administrator instead",
+  "entry.login.noToken": "Login returned no token"
 }

--- a/src/i18n/locales/zh-CN/appBots.json
+++ b/src/i18n/locales/zh-CN/appBots.json
@@ -96,5 +96,11 @@
   "edit.toast.updated": "已更新",
   "list.platformOnly.title": "这里只列平台级应用 Bot",
   "list.platformOnly.desc": "空间级应用 Bot（含从平台移入空间的）在各自空间的控制台管理。",
-  "list.platformOnly.link": "前往空间控制台"
+  "list.platformOnly.link": "前往空间控制台",
+  "column.ownership": "归属",
+  "list.scopeFilter.platform": "平台级",
+  "list.scopeFilter.space": "空间级",
+  "list.scopeFilter.all": "全部归属",
+  "scope.platform": "平台级",
+  "scope.space": "空间级"
 }

--- a/src/i18n/locales/zh-CN/appBots.json
+++ b/src/i18n/locales/zh-CN/appBots.json
@@ -93,5 +93,8 @@
   "form.welcome.extra": "用户首次连接时自动发送的消息，留空则使用默认提示",
   "form.welcome.placeholder": "你好！我是 xx 助手，有什么可以帮你的？",
   "edit.title": "编辑 {{name}}",
-  "edit.toast.updated": "已更新"
+  "edit.toast.updated": "已更新",
+  "list.platformOnly.title": "这里只列平台级应用 Bot",
+  "list.platformOnly.desc": "空间级应用 Bot（含从平台移入空间的）在各自空间的控制台管理。",
+  "list.platformOnly.link": "前往空间控制台"
 }

--- a/src/i18n/locales/zh-CN/nav.json
+++ b/src/i18n/locales/zh-CN/nav.json
@@ -13,5 +13,6 @@
   "expertMarket": "专家市场",
   "backup": "备份管理",
   "download": "下载配置",
-  "systemSkill": "Skill 市场"
+  "systemSkill": "Skill 市场",
+  "spaceConsole": "空间控制台"
 }

--- a/src/i18n/locales/zh-CN/spaceAdmin.json
+++ b/src/i18n/locales/zh-CN/spaceAdmin.json
@@ -38,12 +38,19 @@
   "validate.logoTooLong": "Logo 不能超过 {{max}} 个字符",
   "validate.descriptionTooLong": "空间描述不能超过 {{max}} 个字符",
   "entry.loading": "正在进入空间管理…",
-  "entry.noToken.title": "未检测到登录态",
-  "entry.noToken.subtitle": "请先在应用内登录后再进入空间管理，或使用超级管理员账号登录。",
-  "entry.noToken.action": "去登录",
   "entry.noSpace.title": "暂无可管理的空间",
   "entry.noSpace.subtitle": "你还不是任何空间的管理员或拥有者。",
   "entry.noSpace.action": "返回登录",
   "entry.error.title": "加载空间失败",
-  "entry.error.action": "重试"
+  "entry.error.action": "重试",
+  "entry.login.title": "空间控制台",
+  "entry.login.subtitle": "用你的账号登录，管理你是管理员的空间。",
+  "entry.login.superNotice": "你当前是超级管理员身份。空间控制台是另一套身份，登录后将切换为空间管理员。",
+  "entry.login.username": "用户名",
+  "entry.login.password": "密码",
+  "entry.login.usernameRequired": "请输入用户名",
+  "entry.login.passwordRequired": "请输入密码",
+  "entry.login.submit": "登录",
+  "entry.login.toSuper": "改用超级管理员登录",
+  "entry.login.noToken": "登录未返回 token"
 }

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -120,6 +120,11 @@ const MainLayout: React.FC = () => {
     if (appBotsAvailable === true) {
       list.push({ key: '/app-bots', icon: <RobotOutlined />, label: t('nav:appBots'), group: 'management' })
     }
+    if (appBotsAvailable === true) {
+      // 空间级 Bot / 成员 / 邀请在各空间自己的控制台管理，超管这边只能看到平台级。
+      // 没有这个入口时，空间控制台只能靠手敲 URL 进入。
+      list.push({ key: '/space', icon: <AppstoreOutlined />, label: t('nav:spaceConsole'), group: 'management' })
+    }
     if (hasManagerCapability(managerCapabilities, 'system_setting')) {
       list.push({ key: '/system-setting', icon: <SettingOutlined />, label: t('nav:systemSetting'), group: 'system' })
     }

--- a/src/pages/AppBots/index.tsx
+++ b/src/pages/AppBots/index.tsx
@@ -10,6 +10,7 @@ import {
   message,
   Typography,
   Avatar,
+  Alert,
 } from 'antd'
 import { PlusOutlined, SearchOutlined, RobotOutlined } from '@ant-design/icons'
 import type { ColumnsType } from 'antd/es/table'
@@ -247,6 +248,24 @@ export default function AppBotsPage({ spaceId }: Props) {
           </Button>
         </Space>
       </div>
+
+      {!spaceId && (
+        // 这张表只列平台级 Bot（服务端 /v1/admin/app_bot 按 scope 过滤，见 botInRouteScope
+        // 的跨租户防护）。空间级 Bot 在各自空间的控制台管理。没有这句提示时，
+        // 一个被移到空间的 Bot 会从这页凭空消失，用户无从知道它去哪了。
+        <Alert
+          type="info"
+          showIcon
+          style={{ marginBottom: 16 }}
+          message={t('list.platformOnly.title')}
+          description={
+            <span>
+              {t('list.platformOnly.desc')}{' '}
+              <Typography.Link href="/admin/space">{t('list.platformOnly.link')}</Typography.Link>
+            </span>
+          }
+        />
+      )}
 
       <Table
         rowKey="id"

--- a/src/pages/AppBots/index.tsx
+++ b/src/pages/AppBots/index.tsx
@@ -19,6 +19,7 @@ import type { TFunction } from 'i18next'
 import {
   listAppBots,
   listSpaceAppBots,
+  type AppBotScopeFilter,
   deleteAppBot,
   deleteSpaceAppBot,
   publishAppBot,
@@ -55,6 +56,15 @@ const statusOptions = (t: TFunction) => [
   { value: '2', label: t('status.unpublished') },
 ]
 
+// Ownership filter, platform console only. 'platform' is the default so the page opens on
+// exactly what it has always shown; a server without scope support answers the same way
+// for every option, which degrades to that same platform-only list instead of erroring.
+const scopeOptions = (t: TFunction) => [
+  { value: 'platform', label: t('list.scopeFilter.platform') },
+  { value: 'space', label: t('list.scopeFilter.space') },
+  { value: 'all', label: t('list.scopeFilter.all') },
+]
+
 interface Props {
   spaceId?: string
 }
@@ -67,6 +77,7 @@ export default function AppBotsPage({ spaceId }: Props) {
   const [keyword, setKeyword] = useState('')
   const [debouncedKeyword, setDebouncedKeyword] = useState('')
   const [statusFilter, setStatusFilter] = useState('')
+  const [scopeFilter, setScopeFilter] = useState<AppBotScopeFilter>('platform')
   const [loading, setLoading] = useState(false)
   const [createOpen, setCreateOpen] = useState(false)
   const [editBot, setEditBot] = useState<AppBot | null>(null)
@@ -98,7 +109,7 @@ export default function AppBotsPage({ spaceId }: Props) {
       }
       const resp = spaceId
         ? await listSpaceAppBots(spaceId, params)
-        : await listAppBots(params)
+        : await listAppBots({ ...params, scope: scopeFilter })
       setData(resp.list || [])
       setTotal(resp.count || 0)
     } catch (err) {
@@ -106,7 +117,7 @@ export default function AppBotsPage({ spaceId }: Props) {
     } finally {
       setLoading(false)
     }
-  }, [page, debouncedKeyword, statusFilter, spaceId])
+  }, [page, debouncedKeyword, statusFilter, scopeFilter, spaceId])
 
   useEffect(() => {
     fetchList()
@@ -169,6 +180,23 @@ export default function AppBotsPage({ spaceId }: Props) {
         <span style={{ fontFamily: 'monospace', fontSize: 12 }}>{uid}</span>
       ),
     },
+    ...(spaceId
+      ? []
+      : [
+          {
+            // Which space owns this bot. Without it, a listing that spans scopes cannot be
+            // read: two bots look identical while only one of them is manageable here.
+            title: t('column.ownership'),
+            key: 'ownership',
+            width: 160,
+            render: (_: unknown, record: AppBot) =>
+              record.scope === 'space' ? (
+                <Tag color="blue">{record.space_name || record.space_id || t('scope.space')}</Tag>
+              ) : (
+                <Tag>{t('scope.platform')}</Tag>
+              ),
+          } as ColumnsType<AppBot>[number],
+        ]),
     {
       title: t('column.status'),
       dataIndex: 'status',
@@ -224,6 +252,14 @@ export default function AppBotsPage({ spaceId }: Props) {
           {spaceId ? t('list.title.space') : t('list.title.platform')}
         </Typography.Title>
         <Space>
+          {!spaceId && (
+            <Select
+              value={scopeFilter}
+              onChange={(v) => { setScopeFilter(v); setPage(1) }}
+              options={scopeOptions(t)}
+              style={{ width: 130 }}
+            />
+          )}
           <Select
             value={statusFilter}
             onChange={(v) => { setStatusFilter(v); setPage(1) }}
@@ -249,7 +285,7 @@ export default function AppBotsPage({ spaceId }: Props) {
         </Space>
       </div>
 
-      {!spaceId && (
+      {!spaceId && scopeFilter === 'platform' && (
         // 这张表只列平台级 Bot（服务端 /v1/admin/app_bot 按 scope 过滤，见 botInRouteScope
         // 的跨租户防护）。空间级 Bot 在各自空间的控制台管理。没有这句提示时，
         // 一个被移到空间的 Bot 会从这页凭空消失，用户无从知道它去哪了。

--- a/src/pages/AppBots/ownership.test.ts
+++ b/src/pages/AppBots/ownership.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import enUS from '../../i18n/locales/en-US/appBots.json'
+import zhCN from '../../i18n/locales/zh-CN/appBots.json'
+import listSource from './index.tsx?raw'
+import apiSource from '../../api/app-bot.ts?raw'
+
+// A bot that moves to space scope used to drop out of the platform list with nothing to
+// explain it. The list now carries an ownership dimension: a filter to choose what you
+// are looking at, and a column that says which space owns each row.
+describe('app bot ownership', () => {
+  it('asks the server for a scope and defaults to the historical platform-only view', () => {
+    expect(apiSource).toContain("export type AppBotScopeFilter = 'platform' | 'space' | 'all'")
+    expect(apiSource).toContain('scope?: AppBotScopeFilter')
+    expect(listSource).toContain("useState<AppBotScopeFilter>('platform')")
+    expect(listSource).toContain('scope: scopeFilter')
+  })
+
+  it('refetches when the ownership filter changes', () => {
+    expect(listSource).toMatch(/\}, \[page, debouncedKeyword, statusFilter, scopeFilter, spaceId\]\)/)
+  })
+
+  it('shows ownership as a column, and only on the platform console', () => {
+    // Inside a space console every row belongs to that space, so the column would be noise.
+    expect(listSource).toMatch(/\.\.\.\(spaceId\s*\?\s*\[\]\s*:\s*\[[\s\S]*?column\.ownership/)
+    expect(listSource).toContain('record.space_name || record.space_id')
+  })
+
+  it('stops claiming the list is platform-only once the filter widens', () => {
+    expect(listSource).toContain("{!spaceId && scopeFilter === 'platform' && (")
+  })
+
+  it('names both owners in both locales, without reusing the templated detail label', () => {
+    for (const bundle of [zhCN, enUS]) {
+      expect(bundle['column.ownership']).toBeTruthy()
+      expect(bundle['list.scopeFilter.platform']).toBeTruthy()
+      expect(bundle['list.scopeFilter.space']).toBeTruthy()
+      expect(bundle['list.scopeFilter.all']).toBeTruthy()
+      expect(bundle['scope.platform']).toBeTruthy()
+      expect(bundle['scope.space']).toBeTruthy()
+      // detail.scope.space interpolates a space id; it is a sentence, not a tag label.
+      expect(bundle['scope.space']).not.toContain('{{')
+    }
+  })
+})

--- a/src/pages/SpaceAdmin/SpaceEntry.test.tsx
+++ b/src/pages/SpaceAdmin/SpaceEntry.test.tsx
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import enUS from '../../i18n/locales/en-US/spaceAdmin.json'
+import zhCN from '../../i18n/locales/zh-CN/spaceAdmin.json'
+import navEN from '../../i18n/locales/en-US/nav.json'
+import navZH from '../../i18n/locales/zh-CN/nav.json'
+import appBotsEN from '../../i18n/locales/en-US/appBots.json'
+import appBotsZH from '../../i18n/locales/zh-CN/appBots.json'
+// 用 Vite 的 ?raw 读源码（不引 node API，`tsc` 在 build 时也编译测试文件，
+// 而本仓库没有 @types/node）。断言的是「这段行为写在了源码里」，不是实现细节的复刻。
+import entrySource from './SpaceEntry.tsx?raw'
+import listSource from '../AppBots/index.tsx?raw'
+
+describe('space console sign-in', () => {
+  // The space console used to have no sign-in of its own: it could only borrow an IM
+  // session token that happened to sit in the same tab's sessionStorage. Open it in a
+  // fresh tab and it was a dead end; arrive as a super admin and it silently bounced
+  // you back to the super dashboard. Both paths now land on a real sign-in form.
+  it('signs in through the user login endpoint rather than borrowing a session token', () => {
+    expect(entrySource).toContain("import { userLogin } from '../../api/auth'")
+    expect(entrySource).toContain('async function handleLogin')
+    expect(entrySource).toContain('await userLogin(values)')
+  })
+
+  it('offers the form when the tab carries no session token', () => {
+    expect(entrySource).toMatch(/const token = readSessionToken\(\)\s*\n\s*if \(!token\) \{[\s\S]*?setStatus\('form'\)/)
+    expect(entrySource).not.toContain("setStatus('no-token')")
+  })
+
+  it('lets a super admin switch identity instead of bouncing them away', () => {
+    expect(entrySource).toMatch(/scope === 'super'[\s\S]*?setCameFromSuper\(true\)[\s\S]*?setStatus\('form'\)/)
+    expect(entrySource).not.toMatch(/scope === 'super'[\s\S]{0,120}navigate\('\/dashboard'/)
+    expect(entrySource).toContain("t('entry.login.superNotice')")
+  })
+
+  it('keeps sign-in copy in both locales', () => {
+    const keys = [
+      'entry.login.title',
+      'entry.login.subtitle',
+      'entry.login.superNotice',
+      'entry.login.username',
+      'entry.login.password',
+      'entry.login.usernameRequired',
+      'entry.login.passwordRequired',
+      'entry.login.submit',
+      'entry.login.toSuper',
+      'entry.login.noToken',
+    ] as const
+    for (const key of keys) {
+      expect(zhCN[key], `zh-CN ${key}`).toBeTruthy()
+      expect(enUS[key], `en-US ${key}`).toBeTruthy()
+    }
+    // The replaced dead-end copy must not linger in either locale.
+    for (const stale of ['entry.noToken.title', 'entry.noToken.subtitle', 'entry.noToken.action']) {
+      expect(Object.keys(zhCN)).not.toContain(stale)
+      expect(Object.keys(enUS)).not.toContain(stale)
+    }
+  })
+})
+
+describe('reaching space-level app bots from the super admin console', () => {
+  it('names the space console in the sidebar', () => {
+    expect(navZH.spaceConsole).toBeTruthy()
+    expect(navEN.spaceConsole).toBeTruthy()
+  })
+
+  it('explains that the platform list omits space-level bots', () => {
+    for (const bundle of [appBotsZH, appBotsEN]) {
+      expect(bundle['list.platformOnly.title']).toBeTruthy()
+      expect(bundle['list.platformOnly.desc']).toBeTruthy()
+      expect(bundle['list.platformOnly.link']).toBeTruthy()
+    }
+    // The notice belongs on the platform list only; inside a space console it would be wrong.
+    expect(listSource).toMatch(/\{!spaceId && \([\s\S]*?list\.platformOnly\.title/)
+    expect(listSource).toContain('href="/admin/space"')
+  })
+})

--- a/src/pages/SpaceAdmin/SpaceEntry.tsx
+++ b/src/pages/SpaceAdmin/SpaceEntry.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
-import { Spin, Result, Button } from 'antd'
+import { Spin, Result, Button, Form, Input, Card, Alert, Typography } from 'antd'
+import { UserOutlined, LockOutlined } from '@ant-design/icons'
 import { useAuthStore } from '../../store/auth'
 import { getMySpaces, getUser } from '../../api/space-user'
+import { userLogin } from '../../api/auth'
 import type { MySpace } from '../../store/auth'
 import { useState } from 'react'
 
@@ -46,7 +48,11 @@ export default function SpaceEntry() {
   const { t } = useTranslation('spaceAdmin')
   const navigate = useNavigate()
   const loginSpace = useAuthStore((s) => s.loginSpace)
-  const [status, setStatus] = useState<'loading' | 'no-token' | 'no-space' | 'error'>('loading')
+  const [status, setStatus] = useState<'loading' | 'form' | 'no-space' | 'error'>('loading')
+  // 'super'：当前浏览器里是超管会话。超管与空间管理员是两套身份，继续即以空间账号登录。
+  const [cameFromSuper, setCameFromSuper] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+  const [formError, setFormError] = useState('')
   const [errorMsg, setErrorMsg] = useState('')
   const onceRef = useRef(false)
 
@@ -55,7 +61,10 @@ export default function SpaceEntry() {
     onceRef.current = true
     const state = useAuthStore.getState()
     if (state.isLoggedIn && state.scope === 'super') {
-      navigate('/dashboard', { replace: true })
+      // 旧行为是把超管静默弹回超管首页：用户点进空间控制台，却在毫无解释的情况下
+      // 回到了原地。改为显式提示 + 登录表单，由用户决定是否切换身份。
+      setCameFromSuper(true)
+      setStatus('form')
       return
     }
     if (state.isLoggedIn && state.scope === 'space' && state.mySpaces.length > 0) {
@@ -83,7 +92,9 @@ export default function SpaceEntry() {
     }
     const token = readSessionToken()
     if (!token) {
-      setStatus('no-token')
+      // 同标签页没有 IM 会话（例如直接打开 /admin/space）。以前这里是死路一条，
+      // 现在给空间控制台自己的登录入口。
+      setStatus('form')
       return
     }
     useAuthStore.setState({
@@ -93,38 +104,57 @@ export default function SpaceEntry() {
       name: '',
       uid: '',
     })
-    getMySpaces()
-      .then(async (list) => {
-        const managed: MySpace[] = (list || []).filter((s) => s.role >= 1)
-        if (managed.length === 0) {
-          useAuthStore.getState().logout()
-          setStatus('no-space')
-          return
-        }
-        const uid =
-          readSessionUid() ||
-          managed.find((s) => s.role === 2)?.creator ||
-          decodeJwtUid(token)
-        let name = ''
-        let resolvedUid = uid
-        if (uid) {
-          try {
-            const u = await getUser(uid)
-            name = u.name || u.username || ''
-            resolvedUid = u.uid || uid
-          } catch {
-            // 静默降级:名字拿不到就用兜底
-          }
-        }
-        loginSpace(token, resolvedUid, name, managed)
-        navigate(`/space/${managed[0].space_id}/members`, { replace: true })
-      })
+    enterWithToken(token, readSessionUid())
       .catch((error: Error) => {
         useAuthStore.getState().logout()
         setErrorMsg(error.message)
         setStatus('error')
       })
+    // enterWithToken 在组件内定义，依赖恒定，无需进依赖数组
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [loginSpace, navigate])
+
+  // 拿到用户 token 之后的共同落地流程：确认有可管理的空间 → 补用户名 → 进控制台。
+  async function enterWithToken(token: string, knownUid: string) {
+    useAuthStore.setState({ scope: 'space', token, isLoggedIn: true, name: '', uid: '' })
+    const list = await getMySpaces()
+    const managed: MySpace[] = (list || []).filter((s) => s.role >= 1)
+    if (managed.length === 0) {
+      useAuthStore.getState().logout()
+      setStatus('no-space')
+      return
+    }
+    const uid = knownUid || managed.find((s) => s.role === 2)?.creator || decodeJwtUid(token)
+    let name = ''
+    let resolvedUid = uid
+    if (uid) {
+      try {
+        const u = await getUser(uid)
+        name = u.name || u.username || ''
+        resolvedUid = u.uid || uid
+      } catch {
+        // 静默降级:名字拿不到就用兜底
+      }
+    }
+    loginSpace(token, resolvedUid, name, managed)
+    navigate(`/space/${managed[0].space_id}/members`, { replace: true })
+  }
+
+  async function handleLogin(values: { username: string; password: string }) {
+    setSubmitting(true)
+    setFormError('')
+    try {
+      const res = await userLogin(values)
+      if (!res.token) throw new Error(t('entry.login.noToken'))
+      await enterWithToken(res.token, res.uid || '')
+    } catch (error) {
+      useAuthStore.getState().logout()
+      setFormError(error instanceof Error ? error.message : String(error))
+      setStatus('form')
+    } finally {
+      setSubmitting(false)
+    }
+  }
 
   if (status === 'loading') {
     return (
@@ -142,18 +172,66 @@ export default function SpaceEntry() {
     )
   }
 
-  if (status === 'no-token') {
+  if (status === 'form') {
     return (
-      <Result
-        status="warning"
-        title={t('entry.noToken.title')}
-        subTitle={t('entry.noToken.subtitle')}
-        extra={
-          <Button type="primary" onClick={() => navigate('/login')}>
-            {t('entry.noToken.action')}
+      <div
+        className="admin-shell"
+        style={{
+          minHeight: '100vh',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: 16,
+        }}
+      >
+        <Card style={{ width: 380 }}>
+          <Typography.Title level={4} style={{ marginTop: 0 }}>
+            {t('entry.login.title')}
+          </Typography.Title>
+          <Typography.Paragraph type="secondary" style={{ marginBottom: 16 }}>
+            {t('entry.login.subtitle')}
+          </Typography.Paragraph>
+          {cameFromSuper && (
+            <Alert
+              type="info"
+              showIcon
+              style={{ marginBottom: 16 }}
+              message={t('entry.login.superNotice')}
+            />
+          )}
+          {formError && (
+            <Alert type="error" showIcon style={{ marginBottom: 16 }} message={formError} />
+          )}
+          <Form layout="vertical" onFinish={handleLogin} disabled={submitting}>
+            <Form.Item
+              name="username"
+              rules={[{ required: true, message: t('entry.login.usernameRequired') }]}
+            >
+              <Input
+                prefix={<UserOutlined />}
+                placeholder={t('entry.login.username')}
+                autoComplete="username"
+              />
+            </Form.Item>
+            <Form.Item
+              name="password"
+              rules={[{ required: true, message: t('entry.login.passwordRequired') }]}
+            >
+              <Input.Password
+                prefix={<LockOutlined />}
+                placeholder={t('entry.login.password')}
+                autoComplete="current-password"
+              />
+            </Form.Item>
+            <Button type="primary" htmlType="submit" block loading={submitting}>
+              {t('entry.login.submit')}
+            </Button>
+          </Form>
+          <Button type="link" block style={{ marginTop: 8 }} onClick={() => navigate('/login')}>
+            {t('entry.login.toSuper')}
           </Button>
-        }
-      />
+        </Card>
+      </div>
     )
   }
 


### PR DESCRIPTION
> Stacked on #143 — it modifies the platform-only notice that PR introduces. The diff shown here therefore contains that commit too; review or merge #143 first and this becomes a single commit.

## The problem

The platform App Bot list is scope-filtered server-side, so a bot that moves into a space disappears from it. Nothing on the page says the list is scoped, and there is no way to look wider, so the bot appears to have been deleted. On our deployment the bot was running the whole time.

This is the second half of #134. The first half — being able to reach the space console at all — is #143.

## What this changes

- **An ownership filter** (Platform / Spaces / All owners) next to the status filter, defaulting to Platform so the page opens on exactly what it showed before.
- **An ownership column** naming the owning space, falling back to the space id when the name is unavailable. Platform console only: inside a space console every row has the same owner, so the column would be noise.
- The platform-only notice from #143 yields once the filter widens, since at that point it would be describing something that is no longer true.

## Server support and degradation

Uses the `scope` parameter proposed in [Mininglamp-OSS/octo-server#799](https://github.com/Mininglamp-OSS/octo-server/pull/799), where rows also gain `space_id` / `space_name`.

Against a server without that change the parameter is ignored and every option returns platform bots — which is what the default option shows — so an older server degrades to the previous behaviour instead of erroring. The column renders `Platform` for those rows.

## Still open from #134

Scope selection in the create dialog. I left it out on purpose: creating a bot directly into a space means a platform admin writing into a space they may not administer, which crosses the boundary `botInRouteScope` draws on the server. With #143 the space console is reachable and has its own create dialog, so a space bot can be created where the authority for it lives. If you would rather have the platform dialog able to create into a space, say how you want the authority checked and I will send that too.
