### PR TITLE
feat(market): add plugin ratings and metrics

### DIFF
--- a/src/api/expert.test.ts
+++ b/src/api/expert.test.ts
@@ -39,6 +39,7 @@ import {
   listExpertCategories,
   listSquadCategories,
   listSystemExperts,
+  listSystemSquads,
   reuploadExpertContainer,
   reuploadSquadContainer,
   updateExpertCategory,
@@ -328,6 +329,46 @@ describe('getSystemSquad — resolves members independently (review P1)', () => 
 })
 
 describe('listSystemExperts — maps the unified list projection', () => {
+  it('maps marketplace metrics without conflating missing values with a rating', async () => {
+    installGet({
+      '/admin/plugin_categories': expertCategories,
+      '/admin/plugins': {
+        data: [
+          {
+            plugin_id: 'exp-rated',
+            plugin_name: 'Rated',
+            plugin_type: 'expert',
+            rating: 4.5,
+            view_count: 12,
+            install_count: 7,
+            download_count: 3,
+          },
+          {
+            plugin_id: 'exp-unrated',
+            plugin_name: 'Unrated',
+            plugin_type: 'expert',
+          },
+        ],
+        pagination: { total: 2, page: 1, page_size: 20 },
+      },
+    })
+
+    const { items } = await listSystemExperts()
+
+    expect(items[0]).toMatchObject({
+      rating: 4.5,
+      view_count: 12,
+      install_count: 7,
+      download_count: 3,
+    })
+    expect(items[1]).toMatchObject({
+      rating: null,
+      view_count: 0,
+      install_count: 0,
+      download_count: 0,
+    })
+  })
+
   it('resolves category names and flattens pagination', async () => {
     installGet({
       '/admin/plugin_categories': expertCategories,
@@ -362,6 +403,48 @@ describe('listSystemExperts — maps the unified list projection', () => {
     // The unified list endpoint pages by number, not limit/offset.
     expect(mockGet).toHaveBeenCalledWith('/admin/plugins', {
       params: { plugin_type: 'expert', q: '架构', page_size: 20, page: 1 },
+    })
+  })
+})
+
+describe('listSystemSquads — maps marketplace metrics', () => {
+  it('preserves supplied metrics and defaults omitted fields', async () => {
+    installGet({
+      '/admin/plugin_categories': teamCategories,
+      '/admin/plugins': {
+        data: [
+          {
+            plugin_id: 'sq-rated',
+            plugin_name: 'Rated squad',
+            plugin_type: 'expert_team',
+            rating: 3,
+            view_count: 21,
+            install_count: 8,
+            download_count: 5,
+          },
+          {
+            plugin_id: 'sq-unrated',
+            plugin_name: 'Unrated squad',
+            plugin_type: 'expert_team',
+          },
+        ],
+        pagination: { total: 2, page: 1, page_size: 20 },
+      },
+    })
+
+    const { items } = await listSystemSquads()
+
+    expect(items[0]).toMatchObject({
+      rating: 3,
+      view_count: 21,
+      install_count: 8,
+      download_count: 5,
+    })
+    expect(items[1]).toMatchObject({
+      rating: null,
+      view_count: 0,
+      install_count: 0,
+      download_count: 0,
     })
   })
 })

--- a/src/api/expert.test.ts
+++ b/src/api/expert.test.ts
@@ -338,7 +338,7 @@ describe('listSystemExperts — maps the unified list projection', () => {
             plugin_id: 'exp-rated',
             plugin_name: 'Rated',
             plugin_type: 'expert',
-            rating: 4.5,
+            rating: 4,
             view_count: 12,
             install_count: 7,
             download_count: 3,
@@ -356,7 +356,7 @@ describe('listSystemExperts — maps the unified list projection', () => {
     const { items } = await listSystemExperts()
 
     expect(items[0]).toMatchObject({
-      rating: 4.5,
+      rating: 4,
       view_count: 12,
       install_count: 7,
       download_count: 3,

--- a/src/api/expert.ts
+++ b/src/api/expert.ts
@@ -86,6 +86,10 @@ export interface ExpertListItem {
   creator_name: string
   created_by_type?: string
   skill_count?: number
+  rating: number | null
+  view_count: number
+  install_count: number
+  download_count: number
 }
 
 export interface ExpertDetail extends ExpertListItem {
@@ -128,6 +132,10 @@ export interface SquadListItem {
   creator_name: string
   created_by_type?: string
   member_count?: number
+  rating: number | null
+  view_count: number
+  install_count: number
+  download_count: number
 }
 
 export interface SquadDetail extends SquadListItem {
@@ -228,6 +236,10 @@ interface PluginListItemWire {
   visibility?: string
   space_id?: string
   member_count?: number
+  rating?: number | null
+  view_count?: number
+  install_count?: number
+  download_count?: number
   created_at?: string
   updated_at?: string
 }
@@ -347,6 +359,10 @@ function mapPluginToExpertListItem(
     space_id: raw.space_id,
     creator_name: raw.creator_name || raw.publisher || '',
     created_by_type: raw.created_by_type,
+    rating: raw.rating ?? null,
+    view_count: raw.view_count ?? 0,
+    install_count: raw.install_count ?? 0,
+    download_count: raw.download_count ?? 0,
     // The list projection carries no expert_skill relations, so the per-row
     // skill count is unavailable here (the detail load fills it in).
   }
@@ -369,6 +385,10 @@ function mapPluginToSquadListItem(
     space_id: raw.space_id,
     creator_name: raw.creator_name || raw.publisher || '',
     created_by_type: raw.created_by_type,
+    rating: raw.rating ?? null,
+    view_count: raw.view_count ?? 0,
+    install_count: raw.install_count ?? 0,
+    download_count: raw.download_count ?? 0,
     // The list wire projects a typed member_count for expert_team rows.
     member_count: raw.member_count,
   }

--- a/src/api/mcp.test.ts
+++ b/src/api/mcp.test.ts
@@ -675,7 +675,7 @@ describe('connector list — tags and metrics normalization', () => {
                   plugin_id: 'mcp-rated',
                   plugin_name: 'Rated',
                   plugin_type: 'connector',
-                  rating: 4.5,
+                  rating: 4,
                   view_count: 44,
                   install_count: 17,
                   download_count: 6,
@@ -694,7 +694,7 @@ describe('connector list — tags and metrics normalization', () => {
     const { items } = await listSystemMcps()
 
     expect(items[0]).toMatchObject({
-      rating: 4.5,
+      rating: 4,
       view_count: 44,
       install_count: 17,
       download_count: 6,

--- a/src/api/mcp.test.ts
+++ b/src/api/mcp.test.ts
@@ -663,7 +663,50 @@ describe('connector identity anchoring — source/name/key agree, no flip (revie
   })
 })
 
-describe('connector list — tags normalization (crash guard)', () => {
+describe('connector list — tags and metrics normalization', () => {
+  it('maps marketplace metrics and defaults omitted fields', async () => {
+    mockGet.mockImplementation((url: string) =>
+      url.includes('plugin_categories')
+        ? Promise.resolve(CONNECTOR_CATEGORIES)
+        : Promise.resolve({
+            data: {
+              data: [
+                {
+                  plugin_id: 'mcp-rated',
+                  plugin_name: 'Rated',
+                  plugin_type: 'connector',
+                  rating: 4.5,
+                  view_count: 44,
+                  install_count: 17,
+                  download_count: 6,
+                },
+                {
+                  plugin_id: 'mcp-unrated',
+                  plugin_name: 'Unrated',
+                  plugin_type: 'connector',
+                },
+              ],
+              pagination: { total: 2, page: 1, page_size: 20 },
+            },
+          })
+    )
+
+    const { items } = await listSystemMcps()
+
+    expect(items[0]).toMatchObject({
+      rating: 4.5,
+      view_count: 44,
+      install_count: 17,
+      download_count: 6,
+    })
+    expect(items[1]).toMatchObject({
+      rating: null,
+      view_count: 0,
+      install_count: 0,
+      download_count: 0,
+    })
+  })
+
   it('coerces string-encoded tags to an array so the page never maps a bare String', async () => {
     mockGet.mockImplementation((url: string) =>
       url.includes('plugin_categories')

--- a/src/api/mcp.ts
+++ b/src/api/mcp.ts
@@ -102,6 +102,10 @@ export interface McpListItem {
   publisher?: string
   tags: string[]
   tool_count: number
+  rating: number | null
+  view_count: number
+  install_count: number
+  download_count: number
   visibility: McpVisibility
   /** Raw unified-plugin visibility (`system`/`space`/`private`) as it
    *  arrives on the wire, before `mapVisibility` collapses it. Drives the
@@ -300,6 +304,10 @@ interface PluginListItemWire {
   icon?: string
   icon_url?: string
   tool_count?: number
+  rating?: number | null
+  view_count?: number
+  install_count?: number
+  download_count?: number
   publisher?: string
   owner_id?: string
   space_id?: string
@@ -571,6 +579,10 @@ function mapMcpListItem(
     // the page's `tags.slice(0,3).map(...)` never hits a bare String (crash).
     tags: normalizeTagsList(raw.tags),
     tool_count: raw.tool_count ?? 0,
+    rating: raw.rating ?? null,
+    view_count: raw.view_count ?? 0,
+    install_count: raw.install_count ?? 0,
+    download_count: raw.download_count ?? 0,
     visibility: mapVisibility(raw.visibility),
     scope: raw.visibility ?? 'system',
     space_id: raw.space_id,

--- a/src/api/plugin.test.ts
+++ b/src/api/plugin.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const patch = vi.hoisted(() => vi.fn())
 vi.mock('./marketplace', () => ({ marketplaceApi: { patch } }))
 
-import { tryUpdatePluginRating, updatePluginRating } from './plugin'
+import { updatePluginRating } from './plugin'
 
 describe('updatePluginRating', () => {
   beforeEach(() => patch.mockReset())
@@ -20,11 +20,11 @@ describe('updatePluginRating', () => {
     expect(patch).toHaveBeenCalledWith('/admin/plugins/plugin-1/rating', { rating: null })
   })
 
-  it('reports partial success without leaving a rejected default for later calls', async () => {
-    patch.mockRejectedValueOnce(new Error('rating failed'))
-    patch.mockResolvedValueOnce({})
-
-    expect(await tryUpdatePluginRating('plugin-1', 4)).toBe(false)
-    expect(await tryUpdatePluginRating('plugin-1', 5)).toBe(true)
-  })
+  it.each([0, 6, 4.5, Number.NaN, Number.POSITIVE_INFINITY])(
+    'rejects invalid rating %s before sending a request',
+    async (rating) => {
+      await expect(updatePluginRating('plugin-1', rating)).rejects.toThrow(RangeError)
+      expect(patch).not.toHaveBeenCalled()
+    },
+  )
 })

--- a/src/api/plugin.test.ts
+++ b/src/api/plugin.test.ts
@@ -1,0 +1,30 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const patch = vi.hoisted(() => vi.fn())
+vi.mock('./marketplace', () => ({ marketplaceApi: { patch } }))
+
+import { tryUpdatePluginRating, updatePluginRating } from './plugin'
+
+describe('updatePluginRating', () => {
+  beforeEach(() => patch.mockReset())
+
+  it('uses the dedicated rating endpoint', async () => {
+    patch.mockResolvedValue({})
+    await updatePluginRating('plugin/a', 5)
+    expect(patch).toHaveBeenCalledWith('/admin/plugins/plugin%2Fa/rating', { rating: 5 })
+  })
+
+  it('clears a rating with null', async () => {
+    patch.mockResolvedValue({})
+    await updatePluginRating('plugin-1', null)
+    expect(patch).toHaveBeenCalledWith('/admin/plugins/plugin-1/rating', { rating: null })
+  })
+
+  it('reports partial success without leaving a rejected default for later calls', async () => {
+    patch.mockRejectedValueOnce(new Error('rating failed'))
+    patch.mockResolvedValueOnce({})
+
+    expect(await tryUpdatePluginRating('plugin-1', 4)).toBe(false)
+    expect(await tryUpdatePluginRating('plugin-1', 5)).toBe(true)
+  })
+})

--- a/src/api/plugin.ts
+++ b/src/api/plugin.ts
@@ -1,0 +1,35 @@
+import { marketplaceApi } from './marketplace'
+
+export interface PluginMetrics {
+  rating: number | null
+  view_count: number
+  install_count: number
+  download_count: number
+}
+
+/** Update only the curated rating. This deliberately uses the dedicated route
+ * instead of the full plugin PATCH, which replaces package metadata. */
+export async function updatePluginRating(
+  pluginId: string,
+  rating: number | null
+): Promise<void> {
+  await marketplaceApi.patch(
+    `/admin/plugins/${encodeURIComponent(pluginId)}/rating`,
+    { rating }
+  )
+}
+
+/** Best-effort helper for create/edit flows where the plugin write has already
+ * committed. False means partial success and must not be reported as a failed
+ * or retryable plugin creation. */
+export async function tryUpdatePluginRating(
+  pluginId: string,
+  rating: number | null
+): Promise<boolean> {
+  try {
+    await updatePluginRating(pluginId, rating)
+    return true
+  } catch {
+    return false
+  }
+}

--- a/src/api/plugin.ts
+++ b/src/api/plugin.ts
@@ -13,23 +13,11 @@ export async function updatePluginRating(
   pluginId: string,
   rating: number | null
 ): Promise<void> {
+  if (rating !== null && (!Number.isInteger(rating) || rating < 1 || rating > 5)) {
+    throw new RangeError('rating must be an integer from 1 to 5, or null')
+  }
   await marketplaceApi.patch(
     `/admin/plugins/${encodeURIComponent(pluginId)}/rating`,
     { rating }
   )
-}
-
-/** Best-effort helper for create/edit flows where the plugin write has already
- * committed. False means partial success and must not be reported as a failed
- * or retryable plugin creation. */
-export async function tryUpdatePluginRating(
-  pluginId: string,
-  rating: number | null
-): Promise<boolean> {
-  try {
-    await updatePluginRating(pluginId, rating)
-    return true
-  } catch {
-    return false
-  }
 }

--- a/src/api/skill.test.ts
+++ b/src/api/skill.test.ts
@@ -42,6 +42,7 @@ import {
   updateAdminSkill,
   updateSkillCategory,
   listSkillCategories,
+  listAdminSkills,
 } from './skill'
 import { ApiError } from './index'
 
@@ -203,6 +204,49 @@ describe('skill icon/publisher round-trip through the translation layer', () => 
     // Tags trimmed, empties dropped, deduped — matches manifest.labels.
     expect(body.plugin.tags).toEqual(['tag-1'])
     expect(body.plugin.manifest_json.labels).toEqual(['tag-1'])
+  })
+})
+
+describe('listAdminSkills — maps marketplace metrics', () => {
+  beforeEach(() => mockGet.mockReset())
+
+  it('preserves supplied metrics and defaults omitted fields', async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        data: [
+          {
+            plugin_id: 'skill-rated',
+            plugin_name: 'Rated skill',
+            plugin_type: 'skill',
+            rating: 4,
+            view_count: 31,
+            install_count: 13,
+            download_count: 9,
+          },
+          {
+            plugin_id: 'skill-unrated',
+            plugin_name: 'Unrated skill',
+            plugin_type: 'skill',
+          },
+        ],
+        pagination: { total: 2, page: 1, page_size: 20 },
+      },
+    })
+
+    const { items } = await listAdminSkills()
+
+    expect(items[0]).toMatchObject({
+      rating: 4,
+      view_count: 31,
+      install_count: 13,
+      download_count: 9,
+    })
+    expect(items[1]).toMatchObject({
+      rating: null,
+      view_count: 0,
+      install_count: 0,
+      download_count: 0,
+    })
   })
 })
 

--- a/src/api/skill.ts
+++ b/src/api/skill.ts
@@ -61,7 +61,9 @@ export interface SkillListItem {
   file_url?: string
   owner_id?: string
   space_id?: string
+  rating: number | null
   view_count: number
+  install_count: number
   download_count: number
   created_at: string
   updated_at: string
@@ -182,7 +184,9 @@ function normalizeSkill<T extends Partial<SkillListItem>>(item: T): SkillListIte
     version: item.version || '',
     file_name: item.file_name || '',
     file_size: item.file_size ?? 0,
+    rating: item.rating ?? null,
     view_count: item.view_count ?? 0,
+    install_count: item.install_count ?? 0,
     download_count: item.download_count ?? 0,
     created_at: item.created_at || '',
     updated_at: item.updated_at || '',
@@ -244,7 +248,9 @@ interface PluginListItemWire {
   visibility?: string
   creator_name?: string
   current_version?: string
+  rating?: number | null
   view_count?: number
+  install_count?: number
   download_count?: number
   created_at?: string
   updated_at?: string
@@ -368,7 +374,9 @@ function mapPluginToSkillListItem(
     file_size: 0,
     owner_id: raw.owner_id,
     space_id: raw.space_id,
+    rating: raw.rating ?? null,
     view_count: raw.view_count ?? 0,
+    install_count: raw.install_count ?? 0,
     download_count: raw.download_count ?? 0,
     created_at: raw.created_at || '',
     updated_at: raw.updated_at || '',

--- a/src/components/PluginMetrics.tsx
+++ b/src/components/PluginMetrics.tsx
@@ -1,0 +1,47 @@
+import { Space, Statistic } from 'antd'
+import { useTranslation } from 'react-i18next'
+import PluginRating from './PluginRating'
+
+interface Props {
+  pluginId: string
+  rating: number | null
+  viewCount: number
+  installCount?: number
+  downloadCount?: number
+  canEditRating?: boolean
+  onRatingChanged?: (rating: number | null) => void
+}
+
+export default function PluginMetrics({
+  pluginId,
+  rating,
+  viewCount,
+  installCount,
+  downloadCount,
+  canEditRating,
+  onRatingChanged,
+}: Props) {
+  const { t } = useTranslation('common')
+  return (
+    <Space size="large" wrap>
+      <Statistic
+        title={t('pluginMetrics.rating')}
+        valueRender={() => (
+          <PluginRating
+            pluginId={pluginId}
+            rating={rating}
+            canEdit={canEditRating}
+            onChanged={onRatingChanged}
+          />
+        )}
+      />
+      <Statistic title={t('pluginMetrics.views')} value={viewCount} />
+      {installCount !== undefined && (
+        <Statistic title={t('pluginMetrics.installs')} value={installCount} />
+      )}
+      {downloadCount !== undefined && (
+        <Statistic title={t('pluginMetrics.downloads')} value={downloadCount} />
+      )}
+    </Space>
+  )
+}

--- a/src/components/PluginRating.test.tsx
+++ b/src/components/PluginRating.test.tsx
@@ -47,7 +47,7 @@ describe('PluginRating', () => {
     expect(host.querySelector('[aria-label="pluginRating.edit"]')).toBeNull()
   })
 
-  it('stops modal wrapper clicks from reaching a table row', async () => {
+  it('closes on a mask click without letting it reach the table row', async () => {
     const rowClick = vi.fn()
     await act(async () => root.render(
       <div onClick={rowClick}><PluginRating pluginId="p1" rating={2} canEdit /></div>
@@ -56,6 +56,15 @@ describe('PluginRating', () => {
     rowClick.mockClear()
     await act(async () => (host.querySelector('[role="dialog"]') as HTMLDivElement).click())
     expect(rowClick).not.toHaveBeenCalled()
+    expect(host.querySelector('[role="dialog"]')).toBeNull()
+  })
+
+  it('does not overwrite an in-progress draft when the rating prop changes', async () => {
+    await act(async () => root.render(<PluginRating pluginId="p1" rating={2} canEdit />))
+    await act(async () => (host.querySelector('[aria-label="pluginRating.edit"]') as HTMLButtonElement).click())
+    await act(async () => (host.querySelector('[data-testid="edit-rate"]') as HTMLButtonElement).click())
+    await act(async () => root.render(<PluginRating pluginId="p1" rating={3} canEdit />))
+    expect(host.querySelector('[data-testid="edit-rate"]')?.getAttribute('data-value')).toBe('4')
   })
 
   it('edits with the dedicated API and reports the new value', async () => {

--- a/src/components/PluginRating.test.tsx
+++ b/src/components/PluginRating.test.tsx
@@ -1,0 +1,63 @@
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const updatePluginRating = vi.hoisted(() => vi.fn())
+const success = vi.hoisted(() => vi.fn())
+
+vi.mock('../api/plugin', () => ({ updatePluginRating }))
+vi.mock('../api', () => ({ ApiError: class ApiError extends Error {} }))
+vi.mock('@ant-design/icons', () => ({ EditOutlined: () => null }))
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }))
+vi.mock('antd', async () => {
+  const React = await vi.importActual<typeof import('react')>('react')
+  return {
+    Space: ({ children, onClick }: { children?: React.ReactNode; onClick?: React.MouseEventHandler }) => React.createElement('div', { onClick }, children),
+    Typography: { Text: ({ children }: { children?: React.ReactNode }) => React.createElement('span', null, children) },
+    Rate: ({ value, disabled, onChange }: { value: number; disabled?: boolean; onChange?: (value: number) => void }) => React.createElement('button', { disabled, 'data-testid': disabled ? 'display-rate' : 'edit-rate', 'data-value': value, onClick: () => onChange?.(4) }, String(value)),
+    Button: ({ children, onClick, 'aria-label': ariaLabel }: { children?: React.ReactNode; onClick?: React.MouseEventHandler; 'aria-label'?: string }) => React.createElement('button', { onClick, 'aria-label': ariaLabel }, children),
+    Modal: ({ open, children, onOk }: { open: boolean; children?: React.ReactNode; onOk?: () => void }) => open ? React.createElement('div', { role: 'dialog' }, children, React.createElement('button', { 'data-testid': 'ok', onClick: onOk }, 'ok')) : null,
+    message: { success, error: vi.fn() },
+  }
+})
+
+import PluginRating from './PluginRating'
+
+describe('PluginRating', () => {
+  let host: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    ;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+    updatePluginRating.mockReset()
+    success.mockReset()
+    host = document.createElement('div')
+    document.body.appendChild(host)
+    root = createRoot(host)
+  })
+
+  afterEach(async () => {
+    await act(async () => root.unmount())
+    host.remove()
+  })
+
+  it('renders an unrated read-only value without an edit action', async () => {
+    await act(async () => root.render(<PluginRating pluginId="p1" rating={null} />))
+    expect(host.textContent).toContain('pluginRating.unrated')
+    expect(host.querySelector('[aria-label="pluginRating.edit"]')).toBeNull()
+  })
+
+  it('edits with the dedicated API and reports the new value', async () => {
+    const changed = vi.fn()
+    updatePluginRating.mockResolvedValue(undefined)
+    await act(async () => root.render(
+      <PluginRating pluginId="p1" rating={2} canEdit onChanged={changed} />
+    ))
+    await act(async () => (host.querySelector('[aria-label="pluginRating.edit"]') as HTMLButtonElement).click())
+    await act(async () => (host.querySelector('[data-testid="edit-rate"]') as HTMLButtonElement).click())
+    await act(async () => (host.querySelector('[data-testid="ok"]') as HTMLButtonElement).click())
+    expect(updatePluginRating).toHaveBeenCalledWith('p1', 4)
+    expect(changed).toHaveBeenCalledWith(4)
+    expect(success).toHaveBeenCalledWith('pluginRating.saved')
+  })
+})

--- a/src/components/PluginRating.test.tsx
+++ b/src/components/PluginRating.test.tsx
@@ -16,7 +16,7 @@ vi.mock('antd', async () => {
     Typography: { Text: ({ children }: { children?: React.ReactNode }) => React.createElement('span', null, children) },
     Rate: ({ value, disabled, onChange }: { value: number; disabled?: boolean; onChange?: (value: number) => void }) => React.createElement('button', { disabled, 'data-testid': disabled ? 'display-rate' : 'edit-rate', 'data-value': value, onClick: () => onChange?.(4) }, String(value)),
     Button: ({ children, onClick, 'aria-label': ariaLabel }: { children?: React.ReactNode; onClick?: React.MouseEventHandler; 'aria-label'?: string }) => React.createElement('button', { onClick, 'aria-label': ariaLabel }, children),
-    Modal: ({ open, children, onOk }: { open: boolean; children?: React.ReactNode; onOk?: () => void }) => open ? React.createElement('div', { role: 'dialog' }, children, React.createElement('button', { 'data-testid': 'ok', onClick: onOk }, 'ok')) : null,
+    Modal: ({ open, children, onOk, wrapProps }: { open: boolean; children?: React.ReactNode; onOk?: () => void; wrapProps?: React.HTMLAttributes<HTMLDivElement> }) => open ? React.createElement('div', { role: 'dialog', ...wrapProps }, children, React.createElement('button', { 'data-testid': 'ok', onClick: onOk }, 'ok')) : null,
     message: { success, error: vi.fn() },
   }
 })
@@ -47,6 +47,17 @@ describe('PluginRating', () => {
     expect(host.querySelector('[aria-label="pluginRating.edit"]')).toBeNull()
   })
 
+  it('stops modal wrapper clicks from reaching a table row', async () => {
+    const rowClick = vi.fn()
+    await act(async () => root.render(
+      <div onClick={rowClick}><PluginRating pluginId="p1" rating={2} canEdit /></div>
+    ))
+    await act(async () => (host.querySelector('[aria-label="pluginRating.edit"]') as HTMLButtonElement).click())
+    rowClick.mockClear()
+    await act(async () => (host.querySelector('[role="dialog"]') as HTMLDivElement).click())
+    expect(rowClick).not.toHaveBeenCalled()
+  })
+
   it('edits with the dedicated API and reports the new value', async () => {
     const changed = vi.fn()
     updatePluginRating.mockResolvedValue(undefined)
@@ -59,5 +70,19 @@ describe('PluginRating', () => {
     expect(updatePluginRating).toHaveBeenCalledWith('p1', 4)
     expect(changed).toHaveBeenCalledWith(4)
     expect(success).toHaveBeenCalledWith('pluginRating.saved')
+  })
+
+  it('ignores repeated save clicks while the first request is pending', async () => {
+    let resolve!: () => void
+    updatePluginRating.mockReturnValue(new Promise<void>((done) => { resolve = done }))
+    await act(async () => root.render(<PluginRating pluginId="p1" rating={2} canEdit />))
+    await act(async () => (host.querySelector('[aria-label="pluginRating.edit"]') as HTMLButtonElement).click())
+    const ok = host.querySelector('[data-testid="ok"]') as HTMLButtonElement
+    await act(async () => {
+      ok.click()
+      ok.click()
+    })
+    expect(updatePluginRating).toHaveBeenCalledTimes(1)
+    await act(async () => resolve())
   })
 })

--- a/src/components/PluginRating.tsx
+++ b/src/components/PluginRating.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Button, Modal, Rate, Space, Typography, message } from 'antd'
 import { EditOutlined } from '@ant-design/icons'
 import { useTranslation } from 'react-i18next'
@@ -26,6 +26,7 @@ export default function PluginRating({
   const [open, setOpen] = useState(false)
   const [draft, setDraft] = useState<number | null>(rating)
   const [saving, setSaving] = useState(false)
+  const savingRef = useRef(false)
 
   useEffect(() => setDraft(rating), [rating])
 
@@ -36,6 +37,8 @@ export default function PluginRating({
   }
 
   const save = async () => {
+    if (savingRef.current) return
+    savingRef.current = true
     setSaving(true)
     try {
       await updatePluginRating(pluginId, draft)
@@ -45,6 +48,7 @@ export default function PluginRating({
     } catch (err) {
       message.error(err instanceof ApiError ? err.message : t('pluginRating.saveFailed'))
     } finally {
+      savingRef.current = false
       setSaving(false)
     }
   }
@@ -73,9 +77,7 @@ export default function PluginRating({
         okText={t('action.confirm')}
         cancelText={t('action.cancel')}
         destroyOnClose
-        modalRender={(node) => (
-          <div onClick={(event) => event.stopPropagation()}>{node}</div>
-        )}
+        wrapProps={{ onClick: (event: React.MouseEvent<HTMLDivElement>) => event.stopPropagation() }}
       >
         <Space direction="vertical" size={12}>
           <Text type="secondary">{t('pluginRating.hint')}</Text>

--- a/src/components/PluginRating.tsx
+++ b/src/components/PluginRating.tsx
@@ -1,0 +1,90 @@
+import { useEffect, useState } from 'react'
+import { Button, Modal, Rate, Space, Typography, message } from 'antd'
+import { EditOutlined } from '@ant-design/icons'
+import { useTranslation } from 'react-i18next'
+import { ApiError } from '../api'
+import { updatePluginRating } from '../api/plugin'
+
+const { Text } = Typography
+
+interface PluginRatingProps {
+  pluginId: string
+  rating: number | null
+  canEdit?: boolean
+  compact?: boolean
+  onChanged?: (rating: number | null) => void
+}
+
+export default function PluginRating({
+  pluginId,
+  rating,
+  canEdit = false,
+  compact = false,
+  onChanged,
+}: PluginRatingProps) {
+  const { t } = useTranslation('common')
+  const [open, setOpen] = useState(false)
+  const [draft, setDraft] = useState<number | null>(rating)
+  const [saving, setSaving] = useState(false)
+
+  useEffect(() => setDraft(rating), [rating])
+
+  const showEditor = (event: React.MouseEvent) => {
+    event.stopPropagation()
+    setDraft(rating)
+    setOpen(true)
+  }
+
+  const save = async () => {
+    setSaving(true)
+    try {
+      await updatePluginRating(pluginId, draft)
+      onChanged?.(draft)
+      message.success(t('pluginRating.saved'))
+      setOpen(false)
+    } catch (err) {
+      message.error(err instanceof ApiError ? err.message : t('pluginRating.saveFailed'))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <>
+      <Space size={compact ? 4 : 8} wrap={false} onClick={(event) => event.stopPropagation()}>
+        <Rate disabled value={rating ?? 0} allowHalf={false} style={{ fontSize: compact ? 14 : 18 }} />
+        {rating === null && <Text type="secondary">{t('pluginRating.unrated')}</Text>}
+        {canEdit && (
+          <Button
+            type="text"
+            size="small"
+            icon={<EditOutlined />}
+            aria-label={t('pluginRating.edit')}
+            onClick={showEditor}
+          />
+        )}
+      </Space>
+      <Modal
+        title={t('pluginRating.title')}
+        open={open}
+        onCancel={() => setOpen(false)}
+        onOk={save}
+        confirmLoading={saving}
+        okText={t('action.confirm')}
+        cancelText={t('action.cancel')}
+        destroyOnClose
+        modalRender={(node) => (
+          <div onClick={(event) => event.stopPropagation()}>{node}</div>
+        )}
+      >
+        <Space direction="vertical" size={12}>
+          <Text type="secondary">{t('pluginRating.hint')}</Text>
+          <Rate value={draft ?? 0} onChange={(value) => setDraft(value || null)} />
+          <Button type="link" danger disabled={draft === null} onClick={() => setDraft(null)}>
+            {t('pluginRating.clear')}
+          </Button>
+        </Space>
+      </Modal>
+    </>
+  )
+}

--- a/src/components/PluginRating.tsx
+++ b/src/components/PluginRating.tsx
@@ -28,7 +28,9 @@ export default function PluginRating({
   const [saving, setSaving] = useState(false)
   const savingRef = useRef(false)
 
-  useEffect(() => setDraft(rating), [rating])
+  useEffect(() => {
+    if (!open) setDraft(rating)
+  }, [rating, open])
 
   const showEditor = (event: React.MouseEvent) => {
     event.stopPropagation()
@@ -77,7 +79,12 @@ export default function PluginRating({
         okText={t('action.confirm')}
         cancelText={t('action.cancel')}
         destroyOnClose
-        wrapProps={{ onClick: (event: React.MouseEvent<HTMLDivElement>) => event.stopPropagation() }}
+        wrapProps={{
+          onClick: (event: React.MouseEvent<HTMLDivElement>) => {
+            event.stopPropagation()
+            if (event.target === event.currentTarget) setOpen(false)
+          },
+        }}
       >
         <Space direction="vertical" size={12}>
           <Text type="secondary">{t('pluginRating.hint')}</Text>

--- a/src/i18n/locales/en-US/common.json
+++ b/src/i18n/locales/en-US/common.json
@@ -28,5 +28,22 @@
   },
   "space": {
     "global": "Global"
+  },
+  "pluginMetrics": {
+    "title": "Metrics",
+    "rating": "Rating",
+    "views": "Views",
+    "installs": "Installs",
+    "downloads": "Downloads"
+  },
+  "pluginRating": {
+    "title": "Set rating",
+    "edit": "Edit rating",
+    "hint": "Choose 1-5 stars, or clear the rating to leave it unrated.",
+    "unrated": "Unrated",
+    "clear": "Clear rating",
+    "saved": "Rating updated",
+    "saveFailed": "Failed to update rating",
+    "partialSuccess": "The content was saved, but its rating was not. Retry from the list or details."
   }
 }

--- a/src/i18n/locales/en-US/expertMarket.json
+++ b/src/i18n/locales/en-US/expertMarket.json
@@ -46,7 +46,9 @@
     "categoryPlaceholder": "Select a category (overrides the package value)",
     "tagsHint": "Type and press Enter to add",
     "categoryRequired": "Select a category for this row first",
-    "cancelled": "Import cancelled — remaining rows kept for later"
+    "cancelled": "Import cancelled. The in-flight row may have committed; the list was refreshed so you can verify before retrying.",
+    "abortUncertain": "The request was aborted, but the server may have completed the import. Check the refreshed list before retrying to avoid a duplicate.",
+    "ratingFailed": "The plugin was imported, but rating failed. Submitting again retries only the rating."
   },
   "list": {
     "name": "Name",
@@ -61,7 +63,9 @@
     "statusInvalid": "Parse failed",
     "statusSaving": "Importing",
     "statusDone": "Imported",
-    "statusFailed": "Import failed"
+    "statusFailed": "Import failed",
+    "statusRatingFailed": "Rating retry needed",
+    "statusUncertain": "Verify import status"
   },
   "reupload": {
     "button": "Re-upload",

--- a/src/i18n/locales/zh-CN/common.json
+++ b/src/i18n/locales/zh-CN/common.json
@@ -28,5 +28,22 @@
   },
   "space": {
     "global": "全局"
+  },
+  "pluginMetrics": {
+    "title": "数据指标",
+    "rating": "评级",
+    "views": "阅读量",
+    "installs": "安装量",
+    "downloads": "下载量"
+  },
+  "pluginRating": {
+    "title": "设置评级",
+    "edit": "修改评级",
+    "hint": "选择 1-5 星；清除后恢复为未评级。",
+    "unrated": "未评级",
+    "clear": "清除评级",
+    "saved": "评级已更新",
+    "saveFailed": "评级更新失败",
+    "partialSuccess": "内容已保存，但评级设置失败；可在列表或详情中重试"
   }
 }

--- a/src/i18n/locales/zh-CN/expertMarket.json
+++ b/src/i18n/locales/zh-CN/expertMarket.json
@@ -46,7 +46,9 @@
     "categoryPlaceholder": "选择分类（可覆盖包内值）",
     "tagsHint": "输入后回车添加",
     "categoryRequired": "请先在该行选择分类",
-    "cancelled": "已取消导入，剩余条目保留待导入"
+    "cancelled": "已取消导入；正在处理的条目提交状态未知，列表已刷新，请核对后再决定是否重试",
+    "abortUncertain": "请求已中止，但服务端可能已完成导入；请先在刷新后的列表中核对，避免重复导入",
+    "ratingFailed": "插件已导入，但评级设置失败；再次提交只会重试评级"
   },
   "list": {
     "name": "名称",
@@ -61,7 +63,9 @@
     "statusInvalid": "解析失败",
     "statusSaving": "导入中",
     "statusDone": "已导入",
-    "statusFailed": "导入失败"
+    "statusFailed": "导入失败",
+    "statusRatingFailed": "评级待重试",
+    "statusUncertain": "提交状态待核对"
   },
   "reupload": {
     "button": "重新上传",

--- a/src/i18n/locales/zh-CN/skillMarket.json
+++ b/src/i18n/locales/zh-CN/skillMarket.json
@@ -32,7 +32,7 @@
     "empty": "暂无 Skill",
     "loadFailed": "加载失败",
     "detailDrawer": { "title": "Skill 详情", "version": "版本", "category": "分类", "tags": "标签", "views": "浏览", "downloads": "下载", "createdAt": "创建时间", "updatedAt": "更新时间", "skillMd": "SKILL.md", "download": "下载 Skill" },
-    "uploadModal": { "title": "上传 Skill", "name": "名称", "nameRequired": "请填写名称", "description": "描述", "category": "分类", "tags": "标签", "tagsHint": "回车添加", "version": "版本", "versionDefault": "1.0.0", "zipFile": "Skill 包 (.zip)", "zipRequired": "请上传 zip 文件", "zipHint": "拖拽或点击上传 .zip 格式的 Skill 包", "submit": "提交", "success": "上传成功", "failed": "上传失败" },
+    "uploadModal": { "title": "上传 Skill", "name": "名称", "nameRequired": "请填写名称", "description": "描述", "category": "分类", "tags": "标签", "tagsHint": "回车添加", "version": "版本", "versionDefault": "1.0.0", "rating": "评级", "zipFile": "Skill 包 (.zip)", "zipRequired": "请上传 zip 文件", "zipHint": "拖拽或点击上传 .zip 格式的 Skill 包", "submit": "提交", "success": "上传成功", "failed": "上传失败" },
     "editModal": { "loading": "加载中…", "title": "编辑 Skill", "name": "名称", "description": "描述", "category": "分类", "tags": "标签", "icon": "图标", "save": "保存", "success": "已更新", "failed": "更新失败" },
     "success": { "deleted": "已删除" },
     "error": { "deleteFailed": "删除失败" }

--- a/src/i18n/locales/zh-CN/skillMarket.json
+++ b/src/i18n/locales/zh-CN/skillMarket.json
@@ -32,7 +32,7 @@
     "empty": "暂无 Skill",
     "loadFailed": "加载失败",
     "detailDrawer": { "title": "Skill 详情", "version": "版本", "category": "分类", "tags": "标签", "views": "浏览", "downloads": "下载", "createdAt": "创建时间", "updatedAt": "更新时间", "skillMd": "SKILL.md", "download": "下载 Skill" },
-    "uploadModal": { "title": "上传 Skill", "name": "名称", "nameRequired": "请填写名称", "description": "描述", "category": "分类", "tags": "标签", "tagsHint": "回车添加", "version": "版本", "versionDefault": "1.0.0", "rating": "评级", "zipFile": "Skill 包 (.zip)", "zipRequired": "请上传 zip 文件", "zipHint": "拖拽或点击上传 .zip 格式的 Skill 包", "submit": "提交", "success": "上传成功", "failed": "上传失败" },
+    "uploadModal": { "title": "上传 Skill", "name": "名称", "nameRequired": "请填写名称", "description": "描述", "category": "分类", "tags": "标签", "tagsHint": "回车添加", "version": "版本", "versionDefault": "1.0.0", "zipFile": "Skill 包 (.zip)", "zipRequired": "请上传 zip 文件", "zipHint": "拖拽或点击上传 .zip 格式的 Skill 包", "submit": "提交", "success": "上传成功", "failed": "上传失败" },
     "editModal": { "loading": "加载中…", "title": "编辑 Skill", "name": "名称", "description": "描述", "category": "分类", "tags": "标签", "icon": "图标", "save": "保存", "success": "已更新", "failed": "更新失败" },
     "success": { "deleted": "已删除" },
     "error": { "deleteFailed": "删除失败" }

--- a/src/pages/ExpertMarket/ExpertDetailDrawer.tsx
+++ b/src/pages/ExpertMarket/ExpertDetailDrawer.tsx
@@ -28,7 +28,7 @@ interface Props {
   open: boolean
   canManage: boolean
   onClose: () => void
-  onChanged: () => void
+  onChanged: (ratingChange?: { id: string; rating: number | null }) => void
   onDeleted: (id: string) => void
 }
 
@@ -180,7 +180,7 @@ export default function ExpertDetailDrawer({
               canEditRating={canManage}
               onRatingChanged={(rating) => {
                 setDetail((current) => current ? { ...current, rating } : current)
-                onChanged()
+                onChanged({ id: detail.expert_id, rating })
               }}
             />
           </DetailSection>

--- a/src/pages/ExpertMarket/ExpertDetailDrawer.tsx
+++ b/src/pages/ExpertMarket/ExpertDetailDrawer.tsx
@@ -18,6 +18,7 @@ import {
 } from '../../api/expert'
 import { DetailSection, McpConfigBlock, SkillMdModal, SkillRefList, loadSkillMd } from './detailParts'
 import ReuploadButton from './ReuploadButton'
+import PluginMetrics from '../../components/PluginMetrics'
 import type { ParsedContainer } from './parseContainer'
 
 const { Text, Paragraph } = Typography
@@ -168,6 +169,21 @@ export default function ExpertDetailDrawer({
               )}
             </div>
           </div>
+
+          <DetailSection title={t('pluginMetrics.title', { ns: 'common' })}>
+            <PluginMetrics
+              pluginId={detail.expert_id}
+              rating={detail.rating}
+              viewCount={detail.view_count}
+              installCount={detail.install_count}
+              downloadCount={detail.download_count}
+              canEditRating={canManage}
+              onRatingChanged={(rating) => {
+                setDetail((current) => current ? { ...current, rating } : current)
+                onChanged()
+              }}
+            />
+          </DetailSection>
 
           <DetailSection title={t('detail.instruction')}>
             <Paragraph style={{ whiteSpace: 'pre-wrap', margin: 0 }}>

--- a/src/pages/ExpertMarket/ExpertTab.tsx
+++ b/src/pages/ExpertMarket/ExpertTab.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { Button, Input, Space as AntSpace, Table, Tag, message } from 'antd'
 import { PlusOutlined, ReloadOutlined, SearchOutlined } from '@ant-design/icons'
 import { useTranslation } from 'react-i18next'
@@ -15,6 +15,7 @@ import { useAuthStore } from '../../store/auth'
 import ExpertDetailDrawer from './ExpertDetailDrawer'
 import UploadModal from './UploadModal'
 import VisibilityTag from '../../components/VisibilityTag'
+import PluginRating from '../../components/PluginRating'
 import { useSpaceNameMap } from '../../hooks/useSpaceNameMap'
 
 const PAGE_SIZE = 20
@@ -33,8 +34,10 @@ export default function ExpertTab() {
   const [categories, setCategories] = useState<ExpertCategory[]>([])
   const [drawerId, setDrawerId] = useState<string | null>(null)
   const [uploadOpen, setUploadOpen] = useState(false)
+  const loadSequence = useRef(0)
 
   const load = async (nextPage = page, kw = keyword) => {
+    const request = ++loadSequence.current
     setLoading(true)
     try {
       const resp = await listSystemExperts({
@@ -42,13 +45,16 @@ export default function ExpertTab() {
         limit: PAGE_SIZE,
         offset: (nextPage - 1) * PAGE_SIZE,
       })
+      if (request !== loadSequence.current) return
       setRows(resp.items)
       setTotal(resp.total)
       setPage(nextPage)
     } catch (err) {
-      message.error(err instanceof ApiError ? err.message : t('loadFailed'))
+      if (request === loadSequence.current) {
+        message.error(err instanceof ApiError ? err.message : t('loadFailed'))
+      }
     } finally {
-      setLoading(false)
+      if (request === loadSequence.current) setLoading(false)
     }
   }
 
@@ -116,6 +122,35 @@ export default function ExpertTab() {
           ),
       },
       {
+        title: t('pluginMetrics.rating', { ns: 'common' }),
+        dataIndex: 'rating',
+        key: 'rating',
+        width: 150,
+        render: (rating: number | null, record) => (
+          <PluginRating compact pluginId={record.expert_id} rating={rating} canEdit={canWrite}
+            onChanged={(next) => {
+              setRows((prev) => prev.map((row) =>
+                row.expert_id === record.expert_id ? { ...row, rating: next } : row
+              ))
+            }}
+          />
+        ),
+      },
+      {
+        title: t('pluginMetrics.views', { ns: 'common' }),
+        dataIndex: 'view_count',
+        key: 'views',
+        width: 90,
+        align: 'right',
+      },
+      {
+        title: t('pluginMetrics.installs', { ns: 'common' }),
+        dataIndex: 'install_count',
+        key: 'installs',
+        width: 90,
+        align: 'right',
+      },
+      {
         title: t('table.visibility', { ns: 'common' }),
         dataIndex: 'scope',
         key: 'scope',
@@ -138,7 +173,7 @@ export default function ExpertTab() {
       },
     ],
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [t, nameOf]
+    [t, nameOf, canWrite]
   )
 
   return (

--- a/src/pages/ExpertMarket/ExpertTab.tsx
+++ b/src/pages/ExpertMarket/ExpertTab.tsx
@@ -17,7 +17,7 @@ import UploadModal from './UploadModal'
 import VisibilityTag from '../../components/VisibilityTag'
 import PluginRating from '../../components/PluginRating'
 import { useSpaceNameMap } from '../../hooks/useSpaceNameMap'
-import { mergeRatingOverrides, recordRatingOverride } from '../../utils/ratingOverrides'
+import { createRatingOverrideLedger, mergeRatingOverrides, ratingOverrideSequence, recordRatingOverride } from '../../utils/ratingOverrides'
 
 const PAGE_SIZE = 20
 
@@ -36,10 +36,11 @@ export default function ExpertTab() {
   const [drawerId, setDrawerId] = useState<string | null>(null)
   const [uploadOpen, setUploadOpen] = useState(false)
   const loadSequence = useRef(0)
-  const ratingOverrides = useRef(new Map<string, number | null>())
+  const ratingOverrides = useRef(createRatingOverrideLedger())
 
   const load = async (nextPage = page, kw = keyword) => {
     const request = ++loadSequence.current
+    const seenRatingSequence = ratingOverrideSequence(ratingOverrides.current)
     setLoading(true)
     try {
       const resp = await listSystemExperts({
@@ -48,7 +49,7 @@ export default function ExpertTab() {
         offset: (nextPage - 1) * PAGE_SIZE,
       })
       if (request !== loadSequence.current) return
-      setRows(mergeRatingOverrides(resp.items, ratingOverrides.current, (item) => item.expert_id))
+      setRows(mergeRatingOverrides(resp.items, ratingOverrides.current, seenRatingSequence, (item) => item.expert_id))
       setTotal(resp.total)
       setPage(nextPage)
     } catch (err) {

--- a/src/pages/ExpertMarket/ExpertTab.tsx
+++ b/src/pages/ExpertMarket/ExpertTab.tsx
@@ -17,6 +17,7 @@ import UploadModal from './UploadModal'
 import VisibilityTag from '../../components/VisibilityTag'
 import PluginRating from '../../components/PluginRating'
 import { useSpaceNameMap } from '../../hooks/useSpaceNameMap'
+import { mergeRatingOverrides, recordRatingOverride } from '../../utils/ratingOverrides'
 
 const PAGE_SIZE = 20
 
@@ -35,6 +36,7 @@ export default function ExpertTab() {
   const [drawerId, setDrawerId] = useState<string | null>(null)
   const [uploadOpen, setUploadOpen] = useState(false)
   const loadSequence = useRef(0)
+  const ratingOverrides = useRef(new Map<string, number | null>())
 
   const load = async (nextPage = page, kw = keyword) => {
     const request = ++loadSequence.current
@@ -46,7 +48,7 @@ export default function ExpertTab() {
         offset: (nextPage - 1) * PAGE_SIZE,
       })
       if (request !== loadSequence.current) return
-      setRows(resp.items)
+      setRows(mergeRatingOverrides(resp.items, ratingOverrides.current, (item) => item.expert_id))
       setTotal(resp.total)
       setPage(nextPage)
     } catch (err) {
@@ -129,6 +131,7 @@ export default function ExpertTab() {
         render: (rating: number | null, record) => (
           <PluginRating compact pluginId={record.expert_id} rating={rating} canEdit={canWrite}
             onChanged={(next) => {
+              recordRatingOverride(ratingOverrides.current, record.expert_id, next)
               setRows((prev) => prev.map((row) =>
                 row.expert_id === record.expert_id ? { ...row, rating: next } : row
               ))
@@ -232,7 +235,15 @@ export default function ExpertTab() {
         open={drawerId !== null}
         canManage={canWrite}
         onClose={() => setDrawerId(null)}
-        onChanged={() => load(page, keyword)}
+        onChanged={(ratingChange) => {
+          if (ratingChange) {
+            recordRatingOverride(ratingOverrides.current, ratingChange.id, ratingChange.rating)
+            setRows((prev) => prev.map((row) =>
+              row.expert_id === ratingChange.id ? { ...row, rating: ratingChange.rating } : row
+            ))
+          }
+          load(page, keyword)
+        }}
         onDeleted={handleDeleted}
       />
 

--- a/src/pages/ExpertMarket/SquadDetailDrawer.tsx
+++ b/src/pages/ExpertMarket/SquadDetailDrawer.tsx
@@ -28,7 +28,7 @@ interface Props {
   open: boolean
   canManage: boolean
   onClose: () => void
-  onChanged: () => void
+  onChanged: (ratingChange?: { id: string; rating: number | null }) => void
   onDeleted: (id: string) => void
 }
 
@@ -176,7 +176,7 @@ export default function SquadDetailDrawer({
               canEditRating={canManage}
               onRatingChanged={(rating) => {
                 setDetail((current) => current ? { ...current, rating } : current)
-                onChanged()
+                onChanged({ id: detail.squad_id, rating })
               }}
             />
           </DetailSection>

--- a/src/pages/ExpertMarket/SquadDetailDrawer.tsx
+++ b/src/pages/ExpertMarket/SquadDetailDrawer.tsx
@@ -18,6 +18,7 @@ import {
 } from '../../api/expert'
 import { DetailSection, McpConfigBlock, SkillMdModal, SkillRefList, loadSkillMd } from './detailParts'
 import ReuploadButton from './ReuploadButton'
+import PluginMetrics from '../../components/PluginMetrics'
 import type { ParsedContainer } from './parseContainer'
 
 const { Text, Paragraph } = Typography
@@ -164,6 +165,21 @@ export default function SquadDetailDrawer({
               )}
             </div>
           </div>
+
+          <DetailSection title={t('pluginMetrics.title', { ns: 'common' })}>
+            <PluginMetrics
+              pluginId={detail.squad_id}
+              rating={detail.rating}
+              viewCount={detail.view_count}
+              installCount={detail.install_count}
+              downloadCount={detail.download_count}
+              canEditRating={canManage}
+              onRatingChanged={(rating) => {
+                setDetail((current) => current ? { ...current, rating } : current)
+                onChanged()
+              }}
+            />
+          </DetailSection>
 
           <DetailSection title={t('detail.leader')}>
             <Text>{detail.leader || '—'}</Text>

--- a/src/pages/ExpertMarket/SquadTab.tsx
+++ b/src/pages/ExpertMarket/SquadTab.tsx
@@ -17,6 +17,7 @@ import UploadModal from './UploadModal'
 import VisibilityTag from '../../components/VisibilityTag'
 import PluginRating from '../../components/PluginRating'
 import { useSpaceNameMap } from '../../hooks/useSpaceNameMap'
+import { mergeRatingOverrides, recordRatingOverride } from '../../utils/ratingOverrides'
 
 const PAGE_SIZE = 20
 
@@ -35,6 +36,7 @@ export default function SquadTab() {
   const [drawerId, setDrawerId] = useState<string | null>(null)
   const [uploadOpen, setUploadOpen] = useState(false)
   const loadSequence = useRef(0)
+  const ratingOverrides = useRef(new Map<string, number | null>())
 
   const load = async (nextPage = page, kw = keyword) => {
     const request = ++loadSequence.current
@@ -46,7 +48,7 @@ export default function SquadTab() {
         offset: (nextPage - 1) * PAGE_SIZE,
       })
       if (request !== loadSequence.current) return
-      setRows(resp.items)
+      setRows(mergeRatingOverrides(resp.items, ratingOverrides.current, (item) => item.squad_id))
       setTotal(resp.total)
       setPage(nextPage)
     } catch (err) {
@@ -140,6 +142,7 @@ export default function SquadTab() {
         render: (rating: number | null, record) => (
           <PluginRating compact pluginId={record.squad_id} rating={rating} canEdit={canWrite}
             onChanged={(next) => {
+              recordRatingOverride(ratingOverrides.current, record.squad_id, next)
               setRows((prev) => prev.map((row) =>
                 row.squad_id === record.squad_id ? { ...row, rating: next } : row
               ))
@@ -244,7 +247,15 @@ export default function SquadTab() {
         open={drawerId !== null}
         canManage={canWrite}
         onClose={() => setDrawerId(null)}
-        onChanged={() => load(page, keyword)}
+        onChanged={(ratingChange) => {
+          if (ratingChange) {
+            recordRatingOverride(ratingOverrides.current, ratingChange.id, ratingChange.rating)
+            setRows((prev) => prev.map((row) =>
+              row.squad_id === ratingChange.id ? { ...row, rating: ratingChange.rating } : row
+            ))
+          }
+          load(page, keyword)
+        }}
         onDeleted={handleDeleted}
       />
 

--- a/src/pages/ExpertMarket/SquadTab.tsx
+++ b/src/pages/ExpertMarket/SquadTab.tsx
@@ -17,7 +17,7 @@ import UploadModal from './UploadModal'
 import VisibilityTag from '../../components/VisibilityTag'
 import PluginRating from '../../components/PluginRating'
 import { useSpaceNameMap } from '../../hooks/useSpaceNameMap'
-import { mergeRatingOverrides, recordRatingOverride } from '../../utils/ratingOverrides'
+import { createRatingOverrideLedger, mergeRatingOverrides, ratingOverrideSequence, recordRatingOverride } from '../../utils/ratingOverrides'
 
 const PAGE_SIZE = 20
 
@@ -36,10 +36,11 @@ export default function SquadTab() {
   const [drawerId, setDrawerId] = useState<string | null>(null)
   const [uploadOpen, setUploadOpen] = useState(false)
   const loadSequence = useRef(0)
-  const ratingOverrides = useRef(new Map<string, number | null>())
+  const ratingOverrides = useRef(createRatingOverrideLedger())
 
   const load = async (nextPage = page, kw = keyword) => {
     const request = ++loadSequence.current
+    const seenRatingSequence = ratingOverrideSequence(ratingOverrides.current)
     setLoading(true)
     try {
       const resp = await listSystemSquads({
@@ -48,7 +49,7 @@ export default function SquadTab() {
         offset: (nextPage - 1) * PAGE_SIZE,
       })
       if (request !== loadSequence.current) return
-      setRows(mergeRatingOverrides(resp.items, ratingOverrides.current, (item) => item.squad_id))
+      setRows(mergeRatingOverrides(resp.items, ratingOverrides.current, seenRatingSequence, (item) => item.squad_id))
       setTotal(resp.total)
       setPage(nextPage)
     } catch (err) {

--- a/src/pages/ExpertMarket/SquadTab.tsx
+++ b/src/pages/ExpertMarket/SquadTab.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { Button, Input, Space as AntSpace, Table, Tag, message } from 'antd'
 import { PlusOutlined, ReloadOutlined, SearchOutlined } from '@ant-design/icons'
 import { useTranslation } from 'react-i18next'
@@ -15,6 +15,7 @@ import { useAuthStore } from '../../store/auth'
 import SquadDetailDrawer from './SquadDetailDrawer'
 import UploadModal from './UploadModal'
 import VisibilityTag from '../../components/VisibilityTag'
+import PluginRating from '../../components/PluginRating'
 import { useSpaceNameMap } from '../../hooks/useSpaceNameMap'
 
 const PAGE_SIZE = 20
@@ -33,8 +34,10 @@ export default function SquadTab() {
   const [categories, setCategories] = useState<ExpertCategory[]>([])
   const [drawerId, setDrawerId] = useState<string | null>(null)
   const [uploadOpen, setUploadOpen] = useState(false)
+  const loadSequence = useRef(0)
 
   const load = async (nextPage = page, kw = keyword) => {
+    const request = ++loadSequence.current
     setLoading(true)
     try {
       const resp = await listSystemSquads({
@@ -42,13 +45,16 @@ export default function SquadTab() {
         limit: PAGE_SIZE,
         offset: (nextPage - 1) * PAGE_SIZE,
       })
+      if (request !== loadSequence.current) return
       setRows(resp.items)
       setTotal(resp.total)
       setPage(nextPage)
     } catch (err) {
-      message.error(err instanceof ApiError ? err.message : t('loadFailed'))
+      if (request === loadSequence.current) {
+        message.error(err instanceof ApiError ? err.message : t('loadFailed'))
+      }
     } finally {
-      setLoading(false)
+      if (request === loadSequence.current) setLoading(false)
     }
   }
 
@@ -127,6 +133,35 @@ export default function SquadTab() {
         render: (v?: number) => <span className="mono">{v ?? 0}</span>,
       },
       {
+        title: t('pluginMetrics.rating', { ns: 'common' }),
+        dataIndex: 'rating',
+        key: 'rating',
+        width: 150,
+        render: (rating: number | null, record) => (
+          <PluginRating compact pluginId={record.squad_id} rating={rating} canEdit={canWrite}
+            onChanged={(next) => {
+              setRows((prev) => prev.map((row) =>
+                row.squad_id === record.squad_id ? { ...row, rating: next } : row
+              ))
+            }}
+          />
+        ),
+      },
+      {
+        title: t('pluginMetrics.views', { ns: 'common' }),
+        dataIndex: 'view_count',
+        key: 'views',
+        width: 90,
+        align: 'right',
+      },
+      {
+        title: t('pluginMetrics.installs', { ns: 'common' }),
+        dataIndex: 'install_count',
+        key: 'installs',
+        width: 90,
+        align: 'right',
+      },
+      {
         title: t('table.visibility', { ns: 'common' }),
         dataIndex: 'scope',
         key: 'scope',
@@ -149,7 +184,7 @@ export default function SquadTab() {
       },
     ],
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [t, nameOf]
+    [t, nameOf, canWrite]
   )
 
   return (

--- a/src/pages/ExpertMarket/UploadModal.tsx
+++ b/src/pages/ExpertMarket/UploadModal.tsx
@@ -286,7 +286,7 @@ export default function UploadModal({
             style={{ width: '100%' }}
             placeholder={t('list.categoryPlaceholder')}
             value={e.category}
-            disabled={submitting || e.status === 'done'}
+            disabled={submitting || e.status === 'done' || (e.status === 'rating_failed' && !!e.pluginId)}
             onChange={(v) => updateEntry(e.key, { category: v })}
             options={categories.map((c) => ({ value: c.name, label: c.name }))}
           />

--- a/src/pages/ExpertMarket/UploadModal.tsx
+++ b/src/pages/ExpertMarket/UploadModal.tsx
@@ -33,7 +33,7 @@ import {
   type ParsedSquad,
 } from './parseContainer'
 import { buildAiPrompt } from './aiPrompt'
-import { importThenRate } from './importRating'
+import { importResultNeedsReconcile, importThenRate } from './importRating'
 
 const { Dragger } = Upload
 const { Text, Paragraph } = Typography
@@ -175,6 +175,7 @@ export default function UploadModal({
     let created = 0
     let done = 0
     let fail = 0
+    let reconciledExisting = false
     let uncertain = false
     for (let i = 0; i < pending.length; i++) {
       const entry = pending[i]
@@ -201,6 +202,7 @@ export default function UploadModal({
           updatePluginRating,
         )
         if (result.imported) created += 1
+        else if (importResultNeedsReconcile(result)) reconciledExisting = true
         updateEntry(entry.key, { pluginId: result.pluginId })
         if (result.ratingFailed) {
           updateEntry(entry.key, {
@@ -229,7 +231,7 @@ export default function UploadModal({
     abortRef.current = null
     setSubmitting(false)
     setProgress(null)
-    if (created > 0 || uncertain) onImported()
+    if (created > 0 || reconciledExisting || uncertain) onImported()
     if (ctl.signal.aborted) {
       message.info(t('upload.cancelled'))
       return

--- a/src/pages/ExpertMarket/UploadModal.tsx
+++ b/src/pages/ExpertMarket/UploadModal.tsx
@@ -13,12 +13,13 @@
  */
 
 import { useRef, useState } from 'react'
-import { Alert, Button, message, Modal, Select, Table, Tag, Typography, Upload } from 'antd'
+import { Alert, Button, message, Modal, Rate, Select, Table, Tag, Typography, Upload } from 'antd'
 import { CopyOutlined, DeleteOutlined, InboxOutlined } from '@ant-design/icons'
 import { useTranslation } from 'react-i18next'
 import type { ColumnsType } from 'antd/es/table'
 import type { RcFile } from 'antd/es/upload'
 import { ApiError } from '../../api'
+import { updatePluginRating } from '../../api/plugin'
 import {
   importExpertContainer,
   type ExpertCategory,
@@ -32,11 +33,12 @@ import {
   type ParsedSquad,
 } from './parseContainer'
 import { buildAiPrompt } from './aiPrompt'
+import { importThenRate } from './importRating'
 
 const { Dragger } = Upload
 const { Text, Paragraph } = Typography
 
-type EntryStatus = 'parsing' | 'ready' | 'invalid' | 'saving' | 'done' | 'failed'
+type EntryStatus = 'parsing' | 'ready' | 'invalid' | 'saving' | 'done' | 'failed' | 'rating_failed' | 'uncertain'
 
 interface ImportEntry {
   key: string
@@ -49,6 +51,9 @@ interface ImportEntry {
   error: string | null
   /** Per-row category override, initialized from the manifest. */
   category?: string
+  rating: number | null
+  /** Persisted once import succeeds so a rating retry never imports twice. */
+  pluginId?: string
 }
 
 interface Props {
@@ -81,6 +86,8 @@ const STATUS_TAG: Record<EntryStatus, { color: string; key: string }> = {
   saving: { color: 'processing', key: 'list.statusSaving' },
   done: { color: 'green', key: 'list.statusDone' },
   failed: { color: 'red', key: 'list.statusFailed' },
+  rating_failed: { color: 'orange', key: 'list.statusRatingFailed' },
+  uncertain: { color: 'orange', key: 'list.statusUncertain' },
 }
 
 export default function UploadModal({
@@ -130,7 +137,7 @@ export default function UploadModal({
     const key = file.uid
     setEntries((prev) => [
       ...prev,
-      { key, fileName: file.name, file, parsed: null, status: 'parsing', error: null },
+      { key, fileName: file.name, file, parsed: null, status: 'parsing', error: null, rating: null },
     ])
     try {
       const parsed = await parseExpertContainer(file)
@@ -156,7 +163,7 @@ export default function UploadModal({
   const handleSubmit = async () => {
     const pending = entries.filter(
       (e): e is ImportEntry & { parsed: ParsedContainer } =>
-        (e.status === 'ready' || e.status === 'failed') && e.parsed !== null
+        (e.status === 'ready' || e.status === 'failed' || e.status === 'rating_failed') && e.parsed !== null
     )
     if (pending.length === 0) {
       message.error(t('upload.zipRequired'))
@@ -165,8 +172,10 @@ export default function UploadModal({
     setSubmitting(true)
     const ctl = new AbortController()
     abortRef.current = ctl
-    let ok = 0
+    let created = 0
+    let done = 0
     let fail = 0
+    let uncertain = false
     for (let i = 0; i < pending.length; i++) {
       const entry = pending[i]
       if (ctl.signal.aborted) break
@@ -179,23 +188,38 @@ export default function UploadModal({
         })
       )
       try {
-        // The whole container zip is uploaded to the server importer, which
-        // unzips it and mints the expert/team plugin + its bundled skills. The
-        // selected category (a name) is resolved to a unified category id in
-        // the client. Tags are NOT overridable here: the importer accepts only
-        // file + category_id and takes tags from the manifest inside the zip,
-        // so a per-row tags editor would be silently dropped.
-        await importExpertContainer(entry.file, {
-          kind: expectKind,
-          categoryName: entry.category,
-          signal: ctl.signal,
-        })
-        updateEntry(entry.key, { status: 'done' })
-        ok += 1
+        // A row whose import already succeeded retries only its rating. Keeping
+        // pluginId prevents a transient rating failure from creating a duplicate.
+        const result = await importThenRate(
+          entry.pluginId,
+          entry.rating,
+          () => importExpertContainer(entry.file, {
+            kind: expectKind,
+            categoryName: entry.category,
+            signal: ctl.signal,
+          }),
+          updatePluginRating,
+        )
+        if (result.imported) created += 1
+        updateEntry(entry.key, { pluginId: result.pluginId })
+        if (result.ratingFailed) {
+          updateEntry(entry.key, {
+            status: 'rating_failed',
+            pluginId: result.pluginId,
+            error: t('upload.ratingFailed'),
+          })
+          fail += 1
+          continue
+        }
+        updateEntry(entry.key, { status: 'done', pluginId: result.pluginId, error: null })
+        done += 1
       } catch (err) {
         if (ctl.signal.aborted) {
-          // Nothing was committed for this entry — put it back in line.
-          updateEntry(entry.key, { status: 'ready', error: null })
+          // The request may have reached the server before the client observed
+          // the abort. Keep this row non-retryable until the user verifies the
+          // refreshed list, avoiding an accidental duplicate import.
+          updateEntry(entry.key, { status: 'uncertain', error: t('upload.abortUncertain') })
+          uncertain = true
           break
         }
         updateEntry(entry.key, { status: 'failed', error: errText(err) })
@@ -205,22 +229,22 @@ export default function UploadModal({
     abortRef.current = null
     setSubmitting(false)
     setProgress(null)
-    if (ok > 0) onImported()
+    if (created > 0 || uncertain) onImported()
     if (ctl.signal.aborted) {
       message.info(t('upload.cancelled'))
       return
     }
     if (fail === 0) {
-      message.success(t('upload.successCount', { count: ok }))
+      message.success(t('upload.successCount', { count: done }))
       reset()
       onClose()
     } else {
-      message.warning(t('upload.partial', { ok, fail }))
+      message.warning(t('upload.partial', { ok: done, fail }))
     }
   }
 
   const importableCount = entries.filter(
-    (e) => e.status === 'ready' || e.status === 'failed'
+    (e) => e.status === 'ready' || e.status === 'failed' || e.status === 'rating_failed'
   ).length
   // Submitting while a file is still unzipping would silently drop it on the
   // all-success close path — hold the button until every parse settles.
@@ -265,6 +289,19 @@ export default function UploadModal({
             options={categories.map((c) => ({ value: c.name, label: c.name }))}
           />
         ),
+    },
+    {
+      title: t('common:pluginMetrics.rating'),
+      key: 'rating',
+      width: 150,
+      render: (_, e) => e.parsed && (
+        <Rate
+          value={e.rating ?? 0}
+          disabled={submitting || e.status === 'done'}
+          onChange={(value) => updateEntry(e.key, { rating: value || null })}
+          style={{ fontSize: 16 }}
+        />
+      ),
     },
     {
       title: t('list.status'),

--- a/src/pages/ExpertMarket/importRating.test.ts
+++ b/src/pages/ExpertMarket/importRating.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest'
+import { importThenRate } from './importRating'
+
+describe('importThenRate', () => {
+  it('imports then assigns the selected rating', async () => {
+    const importPlugin = vi.fn().mockResolvedValue({ plugin_id: 'expert-1' })
+    const setRating = vi.fn().mockResolvedValue(undefined)
+    await expect(importThenRate(undefined, 5, importPlugin, setRating)).resolves.toEqual({
+      pluginId: 'expert-1', imported: true, ratingFailed: false,
+    })
+    expect(setRating).toHaveBeenCalledWith('expert-1', 5)
+  })
+
+  it('reports partial success while retaining the created plugin id', async () => {
+    const importPlugin = vi.fn().mockResolvedValue({ plugin_id: 'expert-2' })
+    const setRating = vi.fn().mockRejectedValue(new Error('rating failed'))
+    await expect(importThenRate(undefined, 4, importPlugin, setRating)).resolves.toEqual({
+      pluginId: 'expert-2', imported: true, ratingFailed: true,
+    })
+  })
+
+  it('retries only rating when a previous import already succeeded', async () => {
+    const importPlugin = vi.fn()
+    const setRating = vi.fn().mockResolvedValue(undefined)
+    await expect(importThenRate('expert-2', 4, importPlugin, setRating)).resolves.toEqual({
+      pluginId: 'expert-2', imported: false, ratingFailed: false,
+    })
+    expect(importPlugin).not.toHaveBeenCalled()
+    expect(setRating).toHaveBeenCalledWith('expert-2', 4)
+  })
+})

--- a/src/pages/ExpertMarket/importRating.test.ts
+++ b/src/pages/ExpertMarket/importRating.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { importThenRate } from './importRating'
+import { importResultNeedsReconcile, importThenRate } from './importRating'
 
 describe('importThenRate', () => {
   it('imports then assigns the selected rating', async () => {
@@ -27,5 +27,18 @@ describe('importThenRate', () => {
     })
     expect(importPlugin).not.toHaveBeenCalled()
     expect(setRating).toHaveBeenCalledWith('expert-2', 4)
+  })
+
+  it('reconciles the list after a successful rating-only retry without counting a new import', async () => {
+    const result = await importThenRate('expert-2', 4, vi.fn(), vi.fn().mockResolvedValue(undefined))
+
+    expect(result.imported).toBe(false)
+    expect(importResultNeedsReconcile(result)).toBe(true)
+  })
+
+  it('does not reconcile a rating-only retry that still failed', async () => {
+    const result = await importThenRate('expert-2', 4, vi.fn(), vi.fn().mockRejectedValue(new Error('failed')))
+
+    expect(importResultNeedsReconcile(result)).toBe(false)
   })
 })

--- a/src/pages/ExpertMarket/importRating.ts
+++ b/src/pages/ExpertMarket/importRating.ts
@@ -1,0 +1,25 @@
+export interface ImportThenRateResult {
+  pluginId: string
+  imported: boolean
+  ratingFailed: boolean
+}
+
+/** Run a container import followed by its optional rating write. A retry passes
+ * the persisted plugin id, so only rating is retried and the plugin is never
+ * imported twice. */
+export async function importThenRate(
+  pluginId: string | undefined,
+  rating: number | null,
+  importPlugin: () => Promise<{ plugin_id: string }>,
+  setRating: (pluginId: string, rating: number) => Promise<void>,
+): Promise<ImportThenRateResult> {
+  const imported = pluginId === undefined
+  const id = pluginId ?? (await importPlugin()).plugin_id
+  if (rating === null) return { pluginId: id, imported, ratingFailed: false }
+  try {
+    await setRating(id, rating)
+    return { pluginId: id, imported, ratingFailed: false }
+  } catch {
+    return { pluginId: id, imported, ratingFailed: true }
+  }
+}

--- a/src/pages/ExpertMarket/importRating.ts
+++ b/src/pages/ExpertMarket/importRating.ts
@@ -4,6 +4,12 @@ export interface ImportThenRateResult {
   ratingFailed: boolean
 }
 
+/** A successful rating-only retry changed an existing row and therefore needs
+ * the same list reconciliation as a fresh import. */
+export function importResultNeedsReconcile(result: ImportThenRateResult): boolean {
+  return result.imported || !result.ratingFailed
+}
+
 /** Run a container import followed by its optional rating write. A retry passes
  * the persisted plugin id, so only rating is retried and the plugin is never
  * imported twice. */

--- a/src/pages/SkillMarket/SkillDetailDrawer.tsx
+++ b/src/pages/SkillMarket/SkillDetailDrawer.tsx
@@ -1,28 +1,36 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Descriptions, Drawer, Spin, Tag, Space, Button, message } from 'antd'
 import { DownloadOutlined } from '@ant-design/icons'
 import { useTranslation } from 'react-i18next'
 import { getAdminSkill, getAdminSkillMd, downloadAdminSkillPackage, type SkillDetail, type CategoryItem } from '../../api/skill'
+import PluginMetrics from '../../components/PluginMetrics'
 
 interface Props {
   open: boolean
   skillId: string | null
   categories: CategoryItem[]
+  canEditRating: boolean
+  onRatingChanged?: (rating: number | null) => void
   onClose: () => void
 }
 
-export default function SkillDetailDrawer({ open, skillId, categories, onClose }: Props) {
+export default function SkillDetailDrawer({ open, skillId, categories, canEditRating, onRatingChanged, onClose }: Props) {
   const { t } = useTranslation(['skillMarket'])
   const [detail, setDetail] = useState<SkillDetail | null>(null)
   const [skillMd, setSkillMd] = useState<string>('')
   const [loading, setLoading] = useState(false)
+  const requestSequence = useRef(0)
 
   useEffect(() => {
+    const request = ++requestSequence.current
     if (!open || !skillId) {
       setDetail(null)
       setSkillMd('')
+      setLoading(false)
       return
     }
+    setDetail(null)
+    setSkillMd('')
     setLoading(true)
     // SKILL.md preview comes from the ADMIN skill_md endpoint (token auth,
     // cross-Space, no X-Space-Id), which returns the authoritative raw markdown.
@@ -37,13 +45,16 @@ export default function SkillDetailDrawer({ open, skillId, categories, onClose }
       getAdminSkillMd(skillId).catch(() => null),
     ])
       .then(([d, md]) => {
+        if (request !== requestSequence.current) return
         setDetail(d)
         setSkillMd(md ?? d.readme_content ?? '')
       })
       .catch(() => {
-        message.error(t('skill.loadFailed'))
+        if (request === requestSequence.current) message.error(t('skill.loadFailed'))
       })
-      .finally(() => setLoading(false))
+      .finally(() => {
+        if (request === requestSequence.current) setLoading(false)
+      })
   }, [open, skillId, t])
 
   const getCategoryName = (catId: string) => {
@@ -77,6 +88,19 @@ export default function SkillDetailDrawer({ open, skillId, categories, onClose }
               <h3 style={{ margin: 0 }}>{detail.display_name || detail.name}</h3>
               <p style={{ margin: 0, color: '#666' }}>{detail.description}</p>
             </div>
+          </div>
+          <div style={{ marginBottom: 20 }}>
+            <PluginMetrics
+              pluginId={detail.skill_id}
+              rating={detail.rating}
+              viewCount={detail.view_count}
+              downloadCount={detail.download_count}
+              canEditRating={canEditRating}
+              onRatingChanged={(rating) => {
+                setDetail((current) => current ? { ...current, rating } : current)
+                onRatingChanged?.(rating)
+              }}
+            />
           </div>
           <Descriptions column={2} size="small" bordered style={{ marginBottom: 20 }}>
             <Descriptions.Item label={t('skill.detailDrawer.version')}>

--- a/src/pages/SkillMarket/SkillTab.tsx
+++ b/src/pages/SkillMarket/SkillTab.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { Button, Input, message, Popconfirm, Select, Space, Table, Tag } from 'antd'
 import { PlusOutlined, SearchOutlined } from '@ant-design/icons'
 import { useTranslation } from 'react-i18next'
@@ -20,6 +20,7 @@ import SkillDetailDrawer from './SkillDetailDrawer'
 import SkillFormModal from '../SystemSkill/SkillFormModal'
 import SkillUploadModal from './SkillUploadModal'
 import VisibilityTag from '../../components/VisibilityTag'
+import PluginRating from '../../components/PluginRating'
 import { useSpaceNameMap } from '../../hooks/useSpaceNameMap'
 
 const PAGE_SIZE = 20
@@ -46,9 +47,11 @@ export default function SkillTab() {
   const [editOpen, setEditOpen] = useState(false)
   const [editSkill, setEditSkill] = useState<SkillDetail | null>(null)
   const [uploadOpen, setUploadOpen] = useState(false)
+  const loadSequence = useRef(0)
 
   const load = useCallback(
     async (nextPage = page, kw = keyword, cat = categoryFilter, s = sort) => {
+      const request = ++loadSequence.current
       setLoading(true)
       try {
         const resp = await listAdminSkills({
@@ -58,13 +61,16 @@ export default function SkillTab() {
           page: nextPage,
           page_size: PAGE_SIZE,
         })
+        if (request !== loadSequence.current) return
         setRows(resp.items ?? [])
         setTotal(resp.total)
         setPage(nextPage)
       } catch (err) {
-        message.error(err instanceof ApiError ? err.message : t('skill.loadFailed'))
+        if (request === loadSequence.current) {
+          message.error(err instanceof ApiError ? err.message : t('skill.loadFailed'))
+        }
       } finally {
-        setLoading(false)
+        if (request === loadSequence.current) setLoading(false)
       }
     },
     [page, keyword, categoryFilter, sort, t]
@@ -157,12 +163,6 @@ export default function SkillTab() {
       ellipsis: true,
     },
     {
-      title: t('skill.table.description'),
-      dataIndex: 'description',
-      key: 'description',
-      ellipsis: true,
-    },
-    {
       title: t('skill.table.category'),
       dataIndex: 'category_id',
       key: 'category',
@@ -181,6 +181,25 @@ export default function SkillTab() {
           ))}
           {(tags ?? []).length > 3 && <Tag>+{tags.length - 3}</Tag>}
         </Space>
+      ),
+    },
+    {
+      title: t('common:pluginMetrics.rating'),
+      dataIndex: 'rating',
+      key: 'rating',
+      width: 150,
+      render: (rating: number | null, record) => (
+        <PluginRating
+          compact
+          pluginId={record.skill_id}
+          rating={rating}
+          canEdit={canWrite}
+          onChanged={(next) => {
+            setRows((prev) => prev.map((row) =>
+              row.skill_id === record.skill_id ? { ...row, rating: next } : row
+            ))
+          }}
+        />
       ),
     },
     {
@@ -319,6 +338,12 @@ export default function SkillTab() {
         open={drawerOpen}
         skillId={detailId}
         categories={categories}
+        canEditRating={canWrite}
+        onRatingChanged={(rating) => {
+          setRows((prev) => prev.map((row) =>
+            row.skill_id === detailId ? { ...row, rating } : row
+          ))
+        }}
         onClose={() => setDrawerOpen(false)}
       />
       <SkillFormModal

--- a/src/pages/SkillMarket/SkillTab.tsx
+++ b/src/pages/SkillMarket/SkillTab.tsx
@@ -22,7 +22,7 @@ import SkillUploadModal from './SkillUploadModal'
 import VisibilityTag from '../../components/VisibilityTag'
 import PluginRating from '../../components/PluginRating'
 import { useSpaceNameMap } from '../../hooks/useSpaceNameMap'
-import { mergeRatingOverrides, recordRatingOverride } from '../../utils/ratingOverrides'
+import { createRatingOverrideLedger, mergeRatingOverrides, ratingOverrideSequence, recordRatingOverride } from '../../utils/ratingOverrides'
 
 const PAGE_SIZE = 20
 
@@ -49,11 +49,12 @@ export default function SkillTab() {
   const [editSkill, setEditSkill] = useState<SkillDetail | null>(null)
   const [uploadOpen, setUploadOpen] = useState(false)
   const loadSequence = useRef(0)
-  const ratingOverrides = useRef(new Map<string, number | null>())
+  const ratingOverrides = useRef(createRatingOverrideLedger())
 
   const load = useCallback(
     async (nextPage = page, kw = keyword, cat = categoryFilter, s = sort) => {
       const request = ++loadSequence.current
+      const seenRatingSequence = ratingOverrideSequence(ratingOverrides.current)
       setLoading(true)
       try {
         const resp = await listAdminSkills({
@@ -64,7 +65,7 @@ export default function SkillTab() {
           page_size: PAGE_SIZE,
         })
         if (request !== loadSequence.current) return
-        setRows(mergeRatingOverrides(resp.items ?? [], ratingOverrides.current, (item) => item.skill_id))
+        setRows(mergeRatingOverrides(resp.items ?? [], ratingOverrides.current, seenRatingSequence, (item) => item.skill_id))
         setTotal(resp.total)
         setPage(nextPage)
       } catch (err) {

--- a/src/pages/SkillMarket/SkillTab.tsx
+++ b/src/pages/SkillMarket/SkillTab.tsx
@@ -22,6 +22,7 @@ import SkillUploadModal from './SkillUploadModal'
 import VisibilityTag from '../../components/VisibilityTag'
 import PluginRating from '../../components/PluginRating'
 import { useSpaceNameMap } from '../../hooks/useSpaceNameMap'
+import { mergeRatingOverrides, recordRatingOverride } from '../../utils/ratingOverrides'
 
 const PAGE_SIZE = 20
 
@@ -48,6 +49,7 @@ export default function SkillTab() {
   const [editSkill, setEditSkill] = useState<SkillDetail | null>(null)
   const [uploadOpen, setUploadOpen] = useState(false)
   const loadSequence = useRef(0)
+  const ratingOverrides = useRef(new Map<string, number | null>())
 
   const load = useCallback(
     async (nextPage = page, kw = keyword, cat = categoryFilter, s = sort) => {
@@ -62,7 +64,7 @@ export default function SkillTab() {
           page_size: PAGE_SIZE,
         })
         if (request !== loadSequence.current) return
-        setRows(resp.items ?? [])
+        setRows(mergeRatingOverrides(resp.items ?? [], ratingOverrides.current, (item) => item.skill_id))
         setTotal(resp.total)
         setPage(nextPage)
       } catch (err) {
@@ -195,6 +197,7 @@ export default function SkillTab() {
           rating={rating}
           canEdit={canWrite}
           onChanged={(next) => {
+            recordRatingOverride(ratingOverrides.current, record.skill_id, next)
             setRows((prev) => prev.map((row) =>
               row.skill_id === record.skill_id ? { ...row, rating: next } : row
             ))
@@ -340,6 +343,7 @@ export default function SkillTab() {
         categories={categories}
         canEditRating={canWrite}
         onRatingChanged={(rating) => {
+          if (detailId) recordRatingOverride(ratingOverrides.current, detailId, rating)
           setRows((prev) => prev.map((row) =>
             row.skill_id === detailId ? { ...row, rating } : row
           ))

--- a/src/pages/SkillMarket/SkillUploadModal.tsx
+++ b/src/pages/SkillMarket/SkillUploadModal.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Form, Input, message, Modal, Select, Upload } from 'antd'
+import { Form, Input, message, Modal, Rate, Select, Upload } from 'antd'
 import { InboxOutlined } from '@ant-design/icons'
 import { useTranslation } from 'react-i18next'
 import type { UploadFile } from 'antd'
@@ -9,6 +9,7 @@ import {
   type CategoryItem,
 } from '../../api/skill'
 import { ApiError } from '../../api'
+import { updatePluginRating } from '../../api/plugin'
 
 const { Dragger } = Upload
 
@@ -20,7 +21,7 @@ interface Props {
 }
 
 export default function SkillUploadModal({ open, categories, onClose, onSuccess }: Props) {
-  const { t } = useTranslation(['skillMarket'])
+  const { t } = useTranslation(['skillMarket', 'common'])
   const [form] = Form.useForm()
   const [submitting, setSubmitting] = useState(false)
   const [fileList, setFileList] = useState<UploadFile[]>([])
@@ -40,7 +41,7 @@ export default function SkillUploadModal({ open, categories, onClose, onSuccess 
       const { parseTaskId } = await uploadAndParseSkillZip(file)
 
       // Create skill with parse_task_id and user-provided metadata
-      await createAdminSkill({
+      const created = await createAdminSkill({
         parse_task_id: parseTaskId,
         name: values.name || undefined,
         description: values.description || undefined,
@@ -48,6 +49,17 @@ export default function SkillUploadModal({ open, categories, onClose, onSuccess 
         tags: values.tags?.length ? values.tags : undefined,
         version: values.version || undefined,
       })
+      if (values.rating != null) {
+        try {
+          await updatePluginRating(created.skill_id, values.rating)
+        } catch {
+          message.warning(t('common:pluginRating.partialSuccess'))
+          setFileList([])
+          form.resetFields()
+          onSuccess()
+          return
+        }
+      }
 
       message.success(t('skill.uploadModal.success'))
       setFileList([])
@@ -103,6 +115,9 @@ export default function SkillUploadModal({ open, categories, onClose, onSuccess 
         </Form.Item>
         <Form.Item name="version" label={t('skill.uploadModal.version')}>
           <Input placeholder={t('skill.uploadModal.versionDefault')} />
+        </Form.Item>
+        <Form.Item name="rating" label={t('common:pluginMetrics.rating')} extra={t('common:pluginRating.hint')}>
+          <Rate />
         </Form.Item>
         <Form.Item label={t('skill.uploadModal.zipFile')} required>
           <Dragger

--- a/src/pages/SkillMarket/SkillUploadModal.tsx
+++ b/src/pages/SkillMarket/SkillUploadModal.tsx
@@ -49,9 +49,10 @@ export default function SkillUploadModal({ open, categories, onClose, onSuccess 
         tags: values.tags?.length ? values.tags : undefined,
         version: values.version || undefined,
       })
-      if (values.rating != null) {
+      const rating = values.rating || null
+      if (rating !== null) {
         try {
-          await updatePluginRating(created.skill_id, values.rating)
+          await updatePluginRating(created.skill_id, rating)
         } catch {
           message.warning(t('common:pluginRating.partialSuccess'))
           setFileList([])
@@ -117,7 +118,7 @@ export default function SkillUploadModal({ open, categories, onClose, onSuccess 
           <Input placeholder={t('skill.uploadModal.versionDefault')} />
         </Form.Item>
         <Form.Item name="rating" label={t('common:pluginMetrics.rating')} extra={t('common:pluginRating.hint')}>
-          <Rate />
+          <Rate onChange={(value) => form.setFieldValue('rating', value || null)} />
         </Form.Item>
         <Form.Item label={t('skill.uploadModal.zipFile')} required>
           <Dragger

--- a/src/pages/SystemMcp/DetailDrawer.tsx
+++ b/src/pages/SystemMcp/DetailDrawer.tsx
@@ -12,6 +12,7 @@ import { Button, Drawer, Skeleton, Tag, Typography, message } from 'antd'
 import { DeleteOutlined, EditOutlined } from '@ant-design/icons'
 import { useTranslation } from 'react-i18next'
 import { ApiError } from '../../api'
+import PluginMetrics from '../../components/PluginMetrics'
 import {
   deleteSystemMcp,
   getSystemMcp,
@@ -26,6 +27,7 @@ interface Props {
   onClose: () => void
   canManage: boolean
   onEdit: (detail: McpDetail) => void
+  onRatingChanged: (id: string, rating: number | null) => void
   onDeleted: (id: string) => void
 }
 
@@ -35,6 +37,7 @@ export default function McpDetailDrawer({
   onClose,
   canManage,
   onEdit,
+  onRatingChanged,
   onDeleted,
 }: Props) {
   const { t } = useTranslation(['systemMcp', 'common'])
@@ -131,13 +134,28 @@ export default function McpDetailDrawer({
       {loading || !detail ? (
         <Skeleton active paragraph={{ rows: 6 }} />
       ) : (
-        <DetailBody detail={detail} />
+        <DetailBody
+          detail={detail}
+          canManage={canManage}
+          onRatingChanged={(rating) => {
+            setDetail((current) => current ? { ...current, rating } : current)
+            onRatingChanged(detail.mcp_id, rating)
+          }}
+        />
       )}
     </Drawer>
   )
 }
 
-function DetailBody({ detail }: { detail: McpDetail }) {
+function DetailBody({
+  detail,
+  canManage,
+  onRatingChanged,
+}: {
+  detail: McpDetail
+  canManage: boolean
+  onRatingChanged: (rating: number | null) => void
+}) {
   const { t } = useTranslation(['systemMcp'])
   const q = detail.quick_start
   const isRemote =
@@ -190,6 +208,18 @@ function DetailBody({ detail }: { detail: McpDetail }) {
           )}
         </div>
       </div>
+
+      <DetailSection title={t('pluginMetrics.title', { ns: 'common' })}>
+        <PluginMetrics
+          pluginId={detail.mcp_id}
+          rating={detail.rating}
+          viewCount={detail.view_count}
+          installCount={detail.install_count}
+          downloadCount={detail.download_count}
+          canEditRating={canManage}
+          onRatingChanged={onRatingChanged}
+        />
+      </DetailSection>
 
       <DetailSection title={t('detail.section.connection')}>
         <dl className="mcp-kv">

--- a/src/pages/SystemMcp/FormModal.tsx
+++ b/src/pages/SystemMcp/FormModal.tsx
@@ -25,6 +25,7 @@ import {
   Select,
   Steps,
   Switch,
+  Rate,
   message,
 } from 'antd'
 import {
@@ -50,6 +51,7 @@ import {
   type McpTransport,
   type PluginAttachmentWire,
 } from '../../api/mcp'
+import { updatePluginRating } from '../../api/plugin'
 import {
   buildProbeRequest,
   resolveProbeErrorMessage,
@@ -308,6 +310,7 @@ interface FormValues {
   usage_examples: string[]
   faqs: McpFaq[]
   notes: string[]
+  rating: number | null
 }
 
 const EMPTY: FormValues = {
@@ -333,6 +336,7 @@ const EMPTY: FormValues = {
   usage_examples: [],
   faqs: [],
   notes: [],
+  rating: null,
 }
 
 function isRemote(transport: McpTransport): boolean {
@@ -366,6 +370,7 @@ function detailToValues(d: McpDetail): FormValues {
     usage_examples: d.usage_examples || [],
     faqs: d.faqs || [],
     notes: d.notes || [],
+    rating: d.rating,
   }
 }
 
@@ -635,15 +640,22 @@ export default function McpFormModal({ open, editing, onClose, onSaved }: Props)
     const payload = buildPayload()
     setSubmitting(true)
     try {
-      if (isEdit && editing) {
-        const updated = await updateSystemMcp(editing.mcp_id, payload)
-        message.success(t('modal.updateSuccess'))
-        onSaved(updated)
-      } else {
-        const created = await createSystemMcp(payload)
-        message.success(t('modal.createSuccess'))
-        onSaved(created)
+      const saved = isEdit && editing
+        ? await updateSystemMcp(editing.mcp_id, payload)
+        : await createSystemMcp(payload)
+      if (form.rating !== saved.rating) {
+        try {
+          await updatePluginRating(saved.mcp_id, form.rating)
+          saved.rating = form.rating
+        } catch (ratingError) {
+          onSaved(saved)
+          message.warning(t('common:pluginRating.partialSuccess'))
+          onClose()
+          return
+        }
       }
+      message.success(t(isEdit ? 'modal.updateSuccess' : 'modal.createSuccess'))
+      onSaved(saved)
       onClose()
     } catch (e) {
       const fallback = isEdit
@@ -1120,6 +1132,18 @@ export default function McpFormModal({ open, editing, onClose, onSaved }: Props)
       {/* Step 3 — Docs (system MCPs skip visibility) */}
       {step === 2 && (
         <div className="mcp-form-step">
+          <div className="mcp-form-section">
+            <div className="mcp-form-section__body">
+              <Form.Item label={t('common:pluginMetrics.rating')} extra={t('common:pluginRating.hint')}>
+                <Rate value={form.rating ?? 0} onChange={(value) => update('rating', value || null)} />
+                {form.rating !== null && (
+                  <Button type="link" danger onClick={() => update('rating', null)}>
+                    {t('common:pluginRating.clear')}
+                  </Button>
+                )}
+              </Form.Item>
+            </div>
+          </div>
           <div className="mcp-form-section">
             <SimpleTextList
               title={t('detail.section.examples')}

--- a/src/pages/SystemMcp/FormModal.tsx
+++ b/src/pages/SystemMcp/FormModal.tsx
@@ -643,10 +643,11 @@ export default function McpFormModal({ open, editing, onClose, onSaved }: Props)
       const saved = isEdit && editing
         ? await updateSystemMcp(editing.mcp_id, payload)
         : await createSystemMcp(payload)
+      let completed = saved
       if (form.rating !== saved.rating) {
         try {
           await updatePluginRating(saved.mcp_id, form.rating)
-          saved.rating = form.rating
+          completed = { ...saved, rating: form.rating }
         } catch (ratingError) {
           onSaved(saved)
           message.warning(t('common:pluginRating.partialSuccess'))
@@ -655,7 +656,7 @@ export default function McpFormModal({ open, editing, onClose, onSaved }: Props)
         }
       }
       message.success(t(isEdit ? 'modal.updateSuccess' : 'modal.createSuccess'))
-      onSaved(saved)
+      onSaved(completed)
       onClose()
     } catch (e) {
       const fallback = isEdit

--- a/src/pages/SystemMcp/index.tsx
+++ b/src/pages/SystemMcp/index.tsx
@@ -21,6 +21,7 @@ import CategoryTab from './CategoryTab'
 import VisibilityTag from '../../components/VisibilityTag'
 import PluginRating from '../../components/PluginRating'
 import { useSpaceNameMap } from '../../hooks/useSpaceNameMap'
+import { mergeRatingOverrides, recordRatingOverride } from '../../utils/ratingOverrides'
 import './systemMcp.css'
 
 const PAGE_SIZE = 20
@@ -53,6 +54,7 @@ export default function SystemMcp() {
   const [formOpen, setFormOpen] = useState(false)
   const [editing, setEditing] = useState<McpDetail | null>(null)
   const loadSequence = useRef(0)
+  const ratingOverrides = useRef(new Map<string, number | null>())
 
   const load = async (nextPage = page, kw = keyword) => {
     const request = ++loadSequence.current
@@ -64,7 +66,7 @@ export default function SystemMcp() {
         offset: (nextPage - 1) * PAGE_SIZE,
       })
       if (request !== loadSequence.current) return
-      setRows(resp.items)
+      setRows(mergeRatingOverrides(resp.items, ratingOverrides.current, (item) => item.mcp_id))
       setTotal(resp.total)
       setPage(nextPage)
     } catch (err) {
@@ -117,6 +119,7 @@ export default function SystemMcp() {
     // payload (tools / quick_start / faqs / usage_examples / notes / …).
     const existingIdx = rows.findIndex((r) => r.mcp_id === updated.mcp_id)
     if (existingIdx !== -1) {
+      recordRatingOverride(ratingOverrides.current, updated.mcp_id, updated.rating)
       setRows((prev) =>
         prev.map((r) =>
           r.mcp_id === updated.mcp_id
@@ -226,6 +229,7 @@ export default function SystemMcp() {
             rating={rating}
             canEdit={canWrite}
             onChanged={(next) => {
+              recordRatingOverride(ratingOverrides.current, record.mcp_id, next)
               setRows((prev) => prev.map((row) =>
                 row.mcp_id === record.mcp_id ? { ...row, rating: next } : row
               ))
@@ -347,6 +351,7 @@ export default function SystemMcp() {
         canManage={canWrite}
         onEdit={openEdit}
         onRatingChanged={(id, rating) => {
+          recordRatingOverride(ratingOverrides.current, id, rating)
           setRows((prev) => prev.map((row) =>
             row.mcp_id === id ? { ...row, rating } : row
           ))

--- a/src/pages/SystemMcp/index.tsx
+++ b/src/pages/SystemMcp/index.tsx
@@ -21,7 +21,7 @@ import CategoryTab from './CategoryTab'
 import VisibilityTag from '../../components/VisibilityTag'
 import PluginRating from '../../components/PluginRating'
 import { useSpaceNameMap } from '../../hooks/useSpaceNameMap'
-import { mergeRatingOverrides, recordRatingOverride } from '../../utils/ratingOverrides'
+import { createRatingOverrideLedger, mergeRatingOverrides, ratingOverrideSequence, recordRatingOverride } from '../../utils/ratingOverrides'
 import './systemMcp.css'
 
 const PAGE_SIZE = 20
@@ -54,10 +54,11 @@ export default function SystemMcp() {
   const [formOpen, setFormOpen] = useState(false)
   const [editing, setEditing] = useState<McpDetail | null>(null)
   const loadSequence = useRef(0)
-  const ratingOverrides = useRef(new Map<string, number | null>())
+  const ratingOverrides = useRef(createRatingOverrideLedger())
 
   const load = async (nextPage = page, kw = keyword) => {
     const request = ++loadSequence.current
+    const seenRatingSequence = ratingOverrideSequence(ratingOverrides.current)
     setLoading(true)
     try {
       const resp = await listSystemMcps({
@@ -66,7 +67,7 @@ export default function SystemMcp() {
         offset: (nextPage - 1) * PAGE_SIZE,
       })
       if (request !== loadSequence.current) return
-      setRows(mergeRatingOverrides(resp.items, ratingOverrides.current, (item) => item.mcp_id))
+      setRows(mergeRatingOverrides(resp.items, ratingOverrides.current, seenRatingSequence, (item) => item.mcp_id))
       setTotal(resp.total)
       setPage(nextPage)
     } catch (err) {

--- a/src/pages/SystemMcp/index.tsx
+++ b/src/pages/SystemMcp/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { Button, Input, Space as AntSpace, Table, Tabs, Tag, message } from 'antd'
 import {
   PlusOutlined,
@@ -19,6 +19,7 @@ import McpDetailDrawer from './DetailDrawer'
 import McpFormModal from './FormModal'
 import CategoryTab from './CategoryTab'
 import VisibilityTag from '../../components/VisibilityTag'
+import PluginRating from '../../components/PluginRating'
 import { useSpaceNameMap } from '../../hooks/useSpaceNameMap'
 import './systemMcp.css'
 
@@ -51,8 +52,10 @@ export default function SystemMcp() {
   })
   const [formOpen, setFormOpen] = useState(false)
   const [editing, setEditing] = useState<McpDetail | null>(null)
+  const loadSequence = useRef(0)
 
   const load = async (nextPage = page, kw = keyword) => {
+    const request = ++loadSequence.current
     setLoading(true)
     try {
       const resp = await listSystemMcps({
@@ -60,13 +63,16 @@ export default function SystemMcp() {
         limit: PAGE_SIZE,
         offset: (nextPage - 1) * PAGE_SIZE,
       })
+      if (request !== loadSequence.current) return
       setRows(resp.items)
       setTotal(resp.total)
       setPage(nextPage)
     } catch (err) {
-      message.error(err instanceof ApiError ? err.message : t('loadFailed'))
+      if (request === loadSequence.current) {
+        message.error(err instanceof ApiError ? err.message : t('loadFailed'))
+      }
     } finally {
-      setLoading(false)
+      if (request === loadSequence.current) setLoading(false)
     }
   }
 
@@ -126,6 +132,10 @@ export default function SystemMcp() {
                 space_id: updated.space_id,
                 tags: updated.tags,
                 tool_count: updated.tool_count,
+                rating: updated.rating,
+                view_count: updated.view_count,
+                install_count: updated.install_count,
+                download_count: updated.download_count,
                 creator_name: updated.creator_name,
                 created_by_type: updated.created_by_type,
               }
@@ -205,6 +215,39 @@ export default function SystemMcp() {
         render: (v: number) => <span className="mono">{v}</span>,
       },
       {
+        title: t('pluginMetrics.rating', { ns: 'common' }),
+        dataIndex: 'rating',
+        key: 'rating',
+        width: 150,
+        render: (rating: number | null, record) => (
+          <PluginRating
+            compact
+            pluginId={record.mcp_id}
+            rating={rating}
+            canEdit={canWrite}
+            onChanged={(next) => {
+              setRows((prev) => prev.map((row) =>
+                row.mcp_id === record.mcp_id ? { ...row, rating: next } : row
+              ))
+            }}
+          />
+        ),
+      },
+      {
+        title: t('pluginMetrics.views', { ns: 'common' }),
+        dataIndex: 'view_count',
+        key: 'views',
+        width: 90,
+        align: 'right',
+      },
+      {
+        title: t('pluginMetrics.installs', { ns: 'common' }),
+        dataIndex: 'install_count',
+        key: 'installs',
+        width: 90,
+        align: 'right',
+      },
+      {
         title: t('table.visibility', { ns: 'common' }),
         dataIndex: 'scope',
         key: 'scope',
@@ -227,7 +270,7 @@ export default function SystemMcp() {
       },
     ],
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [t, nameOf]
+    [t, nameOf, canWrite]
   )
 
   return (
@@ -303,6 +346,11 @@ export default function SystemMcp() {
         onClose={closeDetail}
         canManage={canWrite}
         onEdit={openEdit}
+        onRatingChanged={(id, rating) => {
+          setRows((prev) => prev.map((row) =>
+            row.mcp_id === id ? { ...row, rating } : row
+          ))
+        }}
         onDeleted={handleDeleted}
       />
 

--- a/src/pages/SystemSkill/DetailDrawer.tsx
+++ b/src/pages/SystemSkill/DetailDrawer.tsx
@@ -3,6 +3,7 @@ import { Drawer, Descriptions, Tag, Button, Typography, Popconfirm, Avatar, mess
 import { useTranslation } from 'react-i18next'
 import { getSkill, deleteSkill, type SkillDetail } from '../../api/skill'
 import VisibilityTag from '../../components/VisibilityTag'
+import PluginMetrics from '../../components/PluginMetrics'
 
 interface Props {
   skillId: string | null
@@ -10,6 +11,7 @@ interface Props {
   onClose: () => void
   onDeleted: () => void
   onEdit: (skill: SkillDetail) => void
+  onRatingChanged?: (id: string, rating: number | null) => void
   canManage: boolean
 }
 
@@ -19,7 +21,7 @@ function formatFileSize(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
 }
 
-export default function DetailDrawer({ skillId, open, onClose, onDeleted, onEdit, canManage }: Props) {
+export default function DetailDrawer({ skillId, open, onClose, onDeleted, onEdit, onRatingChanged, canManage }: Props) {
   const { t } = useTranslation('systemSkill')
   const [skill, setSkill] = useState<SkillDetail | null>(null)
   const [loading, setLoading] = useState(false)
@@ -72,7 +74,20 @@ export default function DetailDrawer({ skillId, open, onClose, onDeleted, onEdit
             </div>
           </div>
 
-          <Descriptions column={1} size="small" bordered>
+          <PluginMetrics
+            pluginId={skill.id}
+            rating={skill.rating}
+            viewCount={skill.view_count}
+            installCount={skill.install_count}
+            downloadCount={skill.download_count}
+            canEditRating={canManage}
+            onRatingChanged={(rating) => {
+              setSkill((current) => current ? { ...current, rating } : current)
+              onRatingChanged?.(skill.id, rating)
+            }}
+          />
+
+          <Descriptions column={1} size="small" bordered style={{ marginTop: 20 }}>
             <Descriptions.Item label={t('detail.field.name')}>{skill.name}</Descriptions.Item>
             <Descriptions.Item label={t('detail.field.displayName')}>{skill.display_name}</Descriptions.Item>
             <Descriptions.Item label={t('detail.field.category')}>{skill.category_name || '—'}</Descriptions.Item>

--- a/src/pages/SystemSkill/SkillFormModal.tsx
+++ b/src/pages/SystemSkill/SkillFormModal.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react'
-import { Modal, Upload, Button, Form, Input, Select, Space, message, Progress, Alert, Typography } from 'antd'
+import { Modal, Upload, Button, Form, Input, Select, Space, message, Progress, Alert, Typography, Rate } from 'antd'
 import { UploadOutlined, InboxOutlined } from '@ant-design/icons'
 import { useTranslation } from 'react-i18next'
 import {
@@ -17,6 +17,7 @@ import {
   type ParseTaskStatus,
   type CategoryItem,
 } from '../../api/skill'
+import { updatePluginRating } from '../../api/plugin'
 
 interface Props {
   open: boolean
@@ -46,7 +47,7 @@ function validateSkillPackage(file: File, t: (key: string) => string): string | 
 }
 
 export default function SkillFormModal({ open, editSkill, onClose, onSuccess, canWrite }: Props) {
-  const { t } = useTranslation('systemSkill')
+  const { t } = useTranslation(['systemSkill', 'common'])
   const [uploading, setUploading] = useState(false)
   const [uploadProgress, setUploadProgress] = useState(0)
   const [parseStatus, setParseStatus] = useState<ParseTaskStatus | null>(null)
@@ -84,12 +85,13 @@ export default function SkillFormModal({ open, editSkill, onClose, onSuccess, ca
           visibility: editSkill.visibility || 'system',
           version: editSkill.version,
           changelog: t('upload.currentVersionChangelog'),
+          rating: editSkill.rating,
         })
         setIconUrl(editSkill.icon || '')
         setIconDisplayUrl(editSkill.icon_url || '')
       } else {
         setRenderEditSkill(null)
-        form.setFieldsValue({ visibility: 'system', version: DEFAULT_VERSION, changelog: '' })
+        form.setFieldsValue({ visibility: 'system', version: DEFAULT_VERSION, changelog: '', rating: null })
         setIconUrl('')
         setIconDisplayUrl('')
       }
@@ -232,6 +234,17 @@ export default function SkillFormModal({ open, editSkill, onClose, onSuccess, ca
             'system') as 'system' | 'space' | 'private',
           icon_url: iconUrl || undefined,
         })
+        const desiredRating = values.rating || null
+        if (desiredRating !== activeEditSkill.rating) {
+          try {
+            await updatePluginRating(activeEditSkill.id, desiredRating)
+          } catch {
+            message.warning(t('common:pluginRating.partialSuccess'))
+            onSuccess()
+            onClose()
+            return
+          }
+        }
         message.success(t('editModal.success'))
       } else {
         // The admin skill_import request accepts name/category/tags/version/
@@ -239,7 +252,7 @@ export default function SkillFormModal({ open, editSkill, onClose, onSuccess, ca
         // display_name and the uploaded icon can't ride the create — the form
         // hides them on create and edits them afterward via the edit path,
         // rather than collecting-and-discarding them here.
-        await createSkill({
+        const created = await createSkill({
           parse_task_id: parseTaskId,
           name: values.name,
           description: values.description,
@@ -249,6 +262,16 @@ export default function SkillFormModal({ open, editSkill, onClose, onSuccess, ca
           version: values.version,
           changelog: values.changelog,
         })
+        if (values.rating != null) {
+          try {
+            await updatePluginRating(created.skill_id, values.rating)
+          } catch {
+            message.warning(t('common:pluginRating.partialSuccess'))
+            onSuccess()
+            onClose()
+            return
+          }
+        }
         message.success(t('upload.success'))
       }
       onSuccess()
@@ -426,6 +449,9 @@ export default function SkillFormModal({ open, editSkill, onClose, onSuccess, ca
               placeholder={t('upload.form.tagsPlaceholder')}
               options={[]}
             />
+          </Form.Item>
+          <Form.Item name="rating" label={t('common:pluginMetrics.rating')} extra={t('common:pluginRating.hint')}>
+            <Rate />
           </Form.Item>
             {activeEditSkill && (
             <Form.Item label={t('upload.form.icon')}>

--- a/src/pages/SystemSkill/SkillFormModal.tsx
+++ b/src/pages/SystemSkill/SkillFormModal.tsx
@@ -262,9 +262,10 @@ export default function SkillFormModal({ open, editSkill, onClose, onSuccess, ca
           version: values.version,
           changelog: values.changelog,
         })
-        if (values.rating != null) {
+        const desiredRating = values.rating || null
+        if (desiredRating !== null) {
           try {
-            await updatePluginRating(created.skill_id, values.rating)
+            await updatePluginRating(created.skill_id, desiredRating)
           } catch {
             message.warning(t('common:pluginRating.partialSuccess'))
             onSuccess()
@@ -451,7 +452,7 @@ export default function SkillFormModal({ open, editSkill, onClose, onSuccess, ca
             />
           </Form.Item>
           <Form.Item name="rating" label={t('common:pluginMetrics.rating')} extra={t('common:pluginRating.hint')}>
-            <Rate />
+            <Rate onChange={(value) => form.setFieldValue('rating', value || null)} />
           </Form.Item>
             {activeEditSkill && (
             <Form.Item label={t('upload.form.icon')}>

--- a/src/pages/SystemSkill/SkillTable.tsx
+++ b/src/pages/SystemSkill/SkillTable.tsx
@@ -10,6 +10,7 @@ import {
   type CategoryItem,
 } from '../../api/skill'
 import VisibilityTag from '../../components/VisibilityTag'
+import PluginRating from '../../components/PluginRating'
 import { useSpaceNameMap } from '../../hooks/useSpaceNameMap'
 
 const LIMIT = 20
@@ -19,9 +20,10 @@ interface Props {
   onView: (id: string) => void
   onUpload: () => void
   canWrite: boolean
+  ratingUpdate?: { id: string; rating: number | null; sequence: number } | null
 }
 
-export default function SkillTable({ onView, onUpload, canWrite }: Props) {
+export default function SkillTable({ onView, onUpload, canWrite, ratingUpdate }: Props) {
   const { t } = useTranslation('systemSkill')
   const { nameOf } = useSpaceNameMap()
   const [data, setData] = useState<SkillListItem[]>([])
@@ -34,6 +36,7 @@ export default function SkillTable({ onView, onUpload, canWrite }: Props) {
   const [categories, setCategories] = useState<CategoryItem[]>([])
   const [loading, setLoading] = useState(false)
   const debounceRef = useRef<ReturnType<typeof setTimeout>>()
+  const requestSequence = useRef(0)
 
   useEffect(() => {
     listCategories().then(setCategories).catch(() => {})
@@ -49,6 +52,7 @@ export default function SkillTable({ onView, onUpload, canWrite }: Props) {
   }, [keyword])
 
   const fetchList = useCallback(async () => {
+    const request = ++requestSequence.current
     setLoading(true)
     try {
       const resp = await listSkills({
@@ -57,19 +61,27 @@ export default function SkillTable({ onView, onUpload, canWrite }: Props) {
         cursor: cursors[page],
         limit: LIMIT,
       })
+      if (request !== requestSequence.current) return
       setData(resp.items || [])
       setHasMore(!!resp.next_cursor)
       if (resp.next_cursor && !cursors[page + 1]) {
         setCursors((prev) => [...prev, resp.next_cursor!])
       }
     } catch (err) {
-      if (err instanceof Error) message.error(err.message)
+      if (request === requestSequence.current && err instanceof Error) message.error(err.message)
     } finally {
-      setLoading(false)
+      if (request === requestSequence.current) setLoading(false)
     }
   }, [page, cursors, debouncedKeyword, categoryFilter])
 
   useEffect(() => { fetchList() }, [fetchList])
+
+  useEffect(() => {
+    if (!ratingUpdate) return
+    setData((prev) => prev.map((row) =>
+      row.id === ratingUpdate.id ? { ...row, rating: ratingUpdate.rating } : row
+    ))
+  }, [ratingUpdate])
 
   const categoryOptions = [
     { value: '', label: t('list.categoryFilter') },
@@ -116,6 +128,36 @@ export default function SkillTable({ onView, onUpload, canWrite }: Props) {
       title: t('column.owner'),
       dataIndex: 'owner_name',
       width: 120,
+    },
+    {
+      title: t('pluginMetrics.rating', { ns: 'common' }),
+      dataIndex: 'rating',
+      width: 150,
+      render: (rating: number | null, record) => (
+        <PluginRating
+          compact
+          pluginId={record.id}
+          rating={rating}
+          canEdit={canWrite}
+          onChanged={(next) => {
+            setData((prev) => prev.map((row) =>
+              row.id === record.id ? { ...row, rating: next } : row
+            ))
+          }}
+        />
+      ),
+    },
+    {
+      title: t('pluginMetrics.views', { ns: 'common' }),
+      dataIndex: 'view_count',
+      width: 90,
+      align: 'right',
+    },
+    {
+      title: t('pluginMetrics.installs', { ns: 'common' }),
+      dataIndex: 'install_count',
+      width: 90,
+      align: 'right',
     },
     {
       title: t('table.visibility', { ns: 'common' }),

--- a/src/pages/SystemSkill/SkillTable.tsx
+++ b/src/pages/SystemSkill/SkillTable.tsx
@@ -12,7 +12,7 @@ import {
 import VisibilityTag from '../../components/VisibilityTag'
 import PluginRating from '../../components/PluginRating'
 import { useSpaceNameMap } from '../../hooks/useSpaceNameMap'
-import { mergeRatingOverrides, recordRatingOverride } from '../../utils/ratingOverrides'
+import { mergeRatingOverrides, ratingOverrideSequence, recordRatingOverride, type RatingOverrideLedger } from '../../utils/ratingOverrides'
 
 const LIMIT = 20
 const DEBOUNCE_MS = 300
@@ -21,10 +21,11 @@ interface Props {
   onView: (id: string) => void
   onUpload: () => void
   canWrite: boolean
-  ratingUpdate?: { id: string; rating: number | null; sequence: number } | null
+  refreshToken: number
+  ratingLedger: RatingOverrideLedger
 }
 
-export default function SkillTable({ onView, onUpload, canWrite, ratingUpdate }: Props) {
+export default function SkillTable({ onView, onUpload, canWrite, refreshToken, ratingLedger }: Props) {
   const { t } = useTranslation('systemSkill')
   const { nameOf } = useSpaceNameMap()
   const [data, setData] = useState<SkillListItem[]>([])
@@ -38,7 +39,6 @@ export default function SkillTable({ onView, onUpload, canWrite, ratingUpdate }:
   const [loading, setLoading] = useState(false)
   const debounceRef = useRef<ReturnType<typeof setTimeout>>()
   const requestSequence = useRef(0)
-  const ratingOverrides = useRef(new Map<string, number | null>())
 
   useEffect(() => {
     listCategories().then(setCategories).catch(() => {})
@@ -55,6 +55,7 @@ export default function SkillTable({ onView, onUpload, canWrite, ratingUpdate }:
 
   const fetchList = useCallback(async () => {
     const request = ++requestSequence.current
+    const seenRatingSequence = ratingOverrideSequence(ratingLedger)
     setLoading(true)
     try {
       const resp = await listSkills({
@@ -64,7 +65,7 @@ export default function SkillTable({ onView, onUpload, canWrite, ratingUpdate }:
         limit: LIMIT,
       })
       if (request !== requestSequence.current) return
-      setData(mergeRatingOverrides(resp.items || [], ratingOverrides.current, (item) => item.id))
+      setData(mergeRatingOverrides(resp.items || [], ratingLedger, seenRatingSequence, (item) => item.id))
       setHasMore(!!resp.next_cursor)
       if (resp.next_cursor && !cursors[page + 1]) {
         setCursors((prev) => [...prev, resp.next_cursor!])
@@ -74,17 +75,9 @@ export default function SkillTable({ onView, onUpload, canWrite, ratingUpdate }:
     } finally {
       if (request === requestSequence.current) setLoading(false)
     }
-  }, [page, cursors, debouncedKeyword, categoryFilter])
+  }, [page, cursors, debouncedKeyword, categoryFilter, ratingLedger])
 
-  useEffect(() => { fetchList() }, [fetchList])
-
-  useEffect(() => {
-    if (!ratingUpdate) return
-    recordRatingOverride(ratingOverrides.current, ratingUpdate.id, ratingUpdate.rating)
-    setData((prev) => prev.map((row) =>
-      row.id === ratingUpdate.id ? { ...row, rating: ratingUpdate.rating } : row
-    ))
-  }, [ratingUpdate])
+  useEffect(() => { fetchList() }, [fetchList, refreshToken])
 
   const categoryOptions = [
     { value: '', label: t('list.categoryFilter') },
@@ -143,7 +136,7 @@ export default function SkillTable({ onView, onUpload, canWrite, ratingUpdate }:
           rating={rating}
           canEdit={canWrite}
           onChanged={(next) => {
-            recordRatingOverride(ratingOverrides.current, record.id, next)
+            recordRatingOverride(ratingLedger, record.id, next)
             setData((prev) => prev.map((row) =>
               row.id === record.id ? { ...row, rating: next } : row
             ))
@@ -219,6 +212,7 @@ export default function SkillTable({ onView, onUpload, canWrite, ratingUpdate }:
         pagination={false}
         onRow={(record) => ({ onClick: () => onView(record.id), style: { cursor: 'pointer' } })}
         size="middle"
+        scroll={{ x: 'max-content' }}
       />
 
       {(page > 0 || hasMore) && (

--- a/src/pages/SystemSkill/SkillTable.tsx
+++ b/src/pages/SystemSkill/SkillTable.tsx
@@ -12,6 +12,7 @@ import {
 import VisibilityTag from '../../components/VisibilityTag'
 import PluginRating from '../../components/PluginRating'
 import { useSpaceNameMap } from '../../hooks/useSpaceNameMap'
+import { mergeRatingOverrides, recordRatingOverride } from '../../utils/ratingOverrides'
 
 const LIMIT = 20
 const DEBOUNCE_MS = 300
@@ -37,6 +38,7 @@ export default function SkillTable({ onView, onUpload, canWrite, ratingUpdate }:
   const [loading, setLoading] = useState(false)
   const debounceRef = useRef<ReturnType<typeof setTimeout>>()
   const requestSequence = useRef(0)
+  const ratingOverrides = useRef(new Map<string, number | null>())
 
   useEffect(() => {
     listCategories().then(setCategories).catch(() => {})
@@ -62,7 +64,7 @@ export default function SkillTable({ onView, onUpload, canWrite, ratingUpdate }:
         limit: LIMIT,
       })
       if (request !== requestSequence.current) return
-      setData(resp.items || [])
+      setData(mergeRatingOverrides(resp.items || [], ratingOverrides.current, (item) => item.id))
       setHasMore(!!resp.next_cursor)
       if (resp.next_cursor && !cursors[page + 1]) {
         setCursors((prev) => [...prev, resp.next_cursor!])
@@ -78,6 +80,7 @@ export default function SkillTable({ onView, onUpload, canWrite, ratingUpdate }:
 
   useEffect(() => {
     if (!ratingUpdate) return
+    recordRatingOverride(ratingOverrides.current, ratingUpdate.id, ratingUpdate.rating)
     setData((prev) => prev.map((row) =>
       row.id === ratingUpdate.id ? { ...row, rating: ratingUpdate.rating } : row
     ))
@@ -140,6 +143,7 @@ export default function SkillTable({ onView, onUpload, canWrite, ratingUpdate }:
           rating={rating}
           canEdit={canWrite}
           onChanged={(next) => {
+            recordRatingOverride(ratingOverrides.current, record.id, next)
             setData((prev) => prev.map((row) =>
               row.id === record.id ? { ...row, rating: next } : row
             ))

--- a/src/pages/SystemSkill/index.test.tsx
+++ b/src/pages/SystemSkill/index.test.tsx
@@ -1,65 +1,88 @@
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { recordRatingOverride, type RatingOverrideLedger } from '../../utils/ratingOverrides'
 
-let tableMounts = 0
+const mocks = vi.hoisted(() => ({
+  rating: null as number | null,
+  listSkills: vi.fn(),
+  listCategories: vi.fn(),
+}))
 
-vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }))
-vi.mock('../../store/auth', () => ({ useAuthStore: (select: (state: { managerCapabilities: string[] }) => unknown) => select({ managerCapabilities: ['skill.write'] }) }))
+vi.mock('react-i18next', async () => {
+  const actual = await vi.importActual<typeof import('react-i18next')>('react-i18next')
+  return { ...actual, useTranslation: () => ({ t: (key: string) => key }) }
+})
+vi.mock('../../store/auth', () => ({
+  useAuthStore: (select: (state: { managerCapabilities: string[] }) => unknown) =>
+    select({ managerCapabilities: ['skill.write'] }),
+}))
 vi.mock('../../auth/capabilities', () => ({ hasManagerCapability: () => true }))
-vi.mock('antd', async () => {
-  const React = await vi.importActual<typeof import('react')>('react')
+vi.mock('../../hooks/useSpaceNameMap', () => ({ useSpaceNameMap: () => ({ nameOf: () => '' }) }))
+vi.mock('../../api/skill', async () => {
+  const actual = await vi.importActual<typeof import('../../api/skill')>('../../api/skill')
   return {
-    Typography: { Title: ({ children }: { children?: React.ReactNode }) => React.createElement('h1', null, children) },
-    Tabs: ({ items }: { items: Array<{ key: string; children: React.ReactNode }> }) => React.createElement('div', null, items.map((item) => React.createElement('div', { key: item.key }, item.children))),
+    ...actual,
+    listCategories: mocks.listCategories,
+    listSkills: mocks.listSkills,
   }
 })
 vi.mock('./CategoryTab', () => ({ default: () => null }))
-vi.mock('./SkillTable', async () => {
-  const React = await vi.importActual<typeof import('react')>('react')
-  return {
-    default: ({ ratingLedger }: { ratingLedger: RatingOverrideLedger }) => {
-      React.useEffect(() => { tableMounts += 1 }, [])
-      const rating = ratingLedger.overrides.get('skill-1')?.rating ?? null
-      return React.createElement('div', null,
-        React.createElement('span', { 'data-testid': 'rating' }, String(rating)),
-        React.createElement('button', {
-          'data-testid': 'inline-five',
-          onClick: () => recordRatingOverride(ratingLedger, 'skill-1', 5),
-        }, 'inline five'),
-      )
-    },
-  }
-})
 vi.mock('./DetailDrawer', async () => {
   const React = await vi.importActual<typeof import('react')>('react')
   return {
-    default: ({ onRatingChanged }: { onRatingChanged: (id: string, rating: number) => void }) => React.createElement('button', {
-      'data-testid': 'drawer-three',
-      onClick: () => onRatingChanged('skill-1', 3),
-    }, 'drawer three'),
+    default: ({ onRatingChanged }: { onRatingChanged: (id: string, rating: number) => void }) =>
+      React.createElement('button', {
+        'data-testid': 'drawer-three',
+        onClick: () => {
+          mocks.rating = 3
+          onRatingChanged('skill-1', 3)
+        },
+      }, 'drawer three'),
   }
 })
-vi.mock('./SkillFormModal', async () => {
-  const React = await vi.importActual<typeof import('react')>('react')
-  return {
-    default: ({ onSuccess }: { onSuccess: () => void }) => React.createElement('button', {
-      'data-testid': 'refresh',
-      onClick: onSuccess,
-    }, 'refresh'),
-  }
-})
+vi.mock('./SkillFormModal', () => ({ default: () => null }))
 
 import SystemSkill from './index'
 
-describe('SystemSkill rating ledger', () => {
+describe('SystemSkill rating reconciliation', () => {
   let host: HTMLDivElement
   let root: Root
 
   beforeEach(() => {
     ;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
-    tableMounts = 0
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }))
+    mocks.rating = null
+    mocks.listCategories.mockReset().mockResolvedValue([])
+    mocks.listSkills.mockReset().mockImplementation(async () => ({
+      items: [{
+        id: 'skill-1',
+        name: 'skill-one',
+        display_name: 'Skill One',
+        description: '',
+        version: '1.0.0',
+        category_id: '',
+        category_name: '',
+        tags: [],
+        owner_name: 'Owner',
+        visibility: 'system',
+        rating: mocks.rating,
+        view_count: 0,
+        install_count: 0,
+        download_count: 0,
+        created_at: '',
+        updated_at: '',
+      }],
+      next_cursor: undefined,
+    }))
     host = document.createElement('div')
     document.body.appendChild(host)
     root = createRoot(host)
@@ -70,13 +93,22 @@ describe('SystemSkill rating ledger', () => {
     host.remove()
   })
 
-  it('keeps the newest inline rating across a refresh after a drawer update', async () => {
+  it('updates the real table row after a drawer rating without remounting the table', async () => {
     await act(async () => root.render(<SystemSkill />))
-    await act(async () => (host.querySelector('[data-testid="drawer-three"]') as HTMLButtonElement).click())
-    await act(async () => (host.querySelector('[data-testid="inline-five"]') as HTMLButtonElement).click())
-    await act(async () => (host.querySelector('[data-testid="refresh"]') as HTMLButtonElement).click())
+    await act(async () => {})
 
-    expect(host.querySelector('[data-testid="rating"]')?.textContent).toBe('5')
-    expect(tableMounts).toBe(1)
+    expect(host.textContent).toContain('pluginRating.unrated')
+    expect(mocks.listCategories).toHaveBeenCalledTimes(1)
+    expect(mocks.listSkills).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      ;(host.querySelector('[data-testid="drawer-three"]') as HTMLButtonElement).click()
+    })
+    await act(async () => {})
+
+    expect(mocks.listSkills).toHaveBeenCalledTimes(2)
+    expect(mocks.listCategories).toHaveBeenCalledTimes(1)
+    expect(host.textContent).not.toContain('pluginRating.unrated')
+    expect(host.querySelectorAll('.ant-rate-star-full')).toHaveLength(3)
   })
 })

--- a/src/pages/SystemSkill/index.test.tsx
+++ b/src/pages/SystemSkill/index.test.tsx
@@ -1,0 +1,82 @@
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { recordRatingOverride, type RatingOverrideLedger } from '../../utils/ratingOverrides'
+
+let tableMounts = 0
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }))
+vi.mock('../../store/auth', () => ({ useAuthStore: (select: (state: { managerCapabilities: string[] }) => unknown) => select({ managerCapabilities: ['skill.write'] }) }))
+vi.mock('../../auth/capabilities', () => ({ hasManagerCapability: () => true }))
+vi.mock('antd', async () => {
+  const React = await vi.importActual<typeof import('react')>('react')
+  return {
+    Typography: { Title: ({ children }: { children?: React.ReactNode }) => React.createElement('h1', null, children) },
+    Tabs: ({ items }: { items: Array<{ key: string; children: React.ReactNode }> }) => React.createElement('div', null, items.map((item) => React.createElement('div', { key: item.key }, item.children))),
+  }
+})
+vi.mock('./CategoryTab', () => ({ default: () => null }))
+vi.mock('./SkillTable', async () => {
+  const React = await vi.importActual<typeof import('react')>('react')
+  return {
+    default: ({ ratingLedger }: { ratingLedger: RatingOverrideLedger }) => {
+      React.useEffect(() => { tableMounts += 1 }, [])
+      const rating = ratingLedger.overrides.get('skill-1')?.rating ?? null
+      return React.createElement('div', null,
+        React.createElement('span', { 'data-testid': 'rating' }, String(rating)),
+        React.createElement('button', {
+          'data-testid': 'inline-five',
+          onClick: () => recordRatingOverride(ratingLedger, 'skill-1', 5),
+        }, 'inline five'),
+      )
+    },
+  }
+})
+vi.mock('./DetailDrawer', async () => {
+  const React = await vi.importActual<typeof import('react')>('react')
+  return {
+    default: ({ onRatingChanged }: { onRatingChanged: (id: string, rating: number) => void }) => React.createElement('button', {
+      'data-testid': 'drawer-three',
+      onClick: () => onRatingChanged('skill-1', 3),
+    }, 'drawer three'),
+  }
+})
+vi.mock('./SkillFormModal', async () => {
+  const React = await vi.importActual<typeof import('react')>('react')
+  return {
+    default: ({ onSuccess }: { onSuccess: () => void }) => React.createElement('button', {
+      'data-testid': 'refresh',
+      onClick: onSuccess,
+    }, 'refresh'),
+  }
+})
+
+import SystemSkill from './index'
+
+describe('SystemSkill rating ledger', () => {
+  let host: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    ;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+    tableMounts = 0
+    host = document.createElement('div')
+    document.body.appendChild(host)
+    root = createRoot(host)
+  })
+
+  afterEach(async () => {
+    await act(async () => root.unmount())
+    host.remove()
+  })
+
+  it('keeps the newest inline rating across a refresh after a drawer update', async () => {
+    await act(async () => root.render(<SystemSkill />))
+    await act(async () => (host.querySelector('[data-testid="drawer-three"]') as HTMLButtonElement).click())
+    await act(async () => (host.querySelector('[data-testid="inline-five"]') as HTMLButtonElement).click())
+    await act(async () => (host.querySelector('[data-testid="refresh"]') as HTMLButtonElement).click())
+
+    expect(host.querySelector('[data-testid="rating"]')?.textContent).toBe('5')
+    expect(tableMounts).toBe(1)
+  })
+})

--- a/src/pages/SystemSkill/index.tsx
+++ b/src/pages/SystemSkill/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react'
+import { useRef, useState, useCallback } from 'react'
 import { Typography, Tabs } from 'antd'
 import { useTranslation } from 'react-i18next'
 import SkillTable from './SkillTable'
@@ -6,6 +6,7 @@ import CategoryTab from './CategoryTab'
 import DetailDrawer from './DetailDrawer'
 import SkillFormModal from './SkillFormModal'
 import type { SkillDetail } from '../../api/skill'
+import { createRatingOverrideLedger, recordRatingOverride } from '../../utils/ratingOverrides'
 import { hasManagerCapability } from '../../auth/capabilities'
 import { useAuthStore } from '../../store/auth'
 
@@ -18,7 +19,7 @@ export default function SystemSkill() {
   const [uploadOpen, setUploadOpen] = useState(false)
   const [editSkill, setEditSkill] = useState<SkillDetail | null>(null)
   const [refreshKey, setRefreshKey] = useState(0)
-  const [ratingUpdate, setRatingUpdate] = useState<{ id: string; rating: number | null; sequence: number } | null>(null)
+  const ratingLedger = useRef(createRatingOverrideLedger()).current
 
   const refresh = useCallback(() => setRefreshKey((k) => k + 1), [])
 
@@ -36,13 +37,13 @@ export default function SystemSkill() {
             label: t('tabs.skills'),
             children: (
               <SkillTable
-                key={refreshKey}
+                refreshToken={refreshKey}
                 onView={(id) => setDetailId(id)}
                 onUpload={() => {
                   if (canWrite) setUploadOpen(true)
                 }}
                 canWrite={canWrite}
-                ratingUpdate={ratingUpdate}
+                ratingLedger={ratingLedger}
               />
             ),
           },
@@ -59,11 +60,7 @@ export default function SystemSkill() {
         open={!!detailId}
         onClose={() => setDetailId(null)}
         onDeleted={refresh}
-        onRatingChanged={(id, rating) => setRatingUpdate((current) => ({
-          id,
-          rating,
-          sequence: (current?.sequence ?? 0) + 1,
-        }))}
+        onRatingChanged={(id, rating) => recordRatingOverride(ratingLedger, id, rating)}
         onEdit={(skill) => {
           if (!canWrite) return
           setDetailId(null)

--- a/src/pages/SystemSkill/index.tsx
+++ b/src/pages/SystemSkill/index.tsx
@@ -18,6 +18,7 @@ export default function SystemSkill() {
   const [uploadOpen, setUploadOpen] = useState(false)
   const [editSkill, setEditSkill] = useState<SkillDetail | null>(null)
   const [refreshKey, setRefreshKey] = useState(0)
+  const [ratingUpdate, setRatingUpdate] = useState<{ id: string; rating: number | null; sequence: number } | null>(null)
 
   const refresh = useCallback(() => setRefreshKey((k) => k + 1), [])
 
@@ -41,6 +42,7 @@ export default function SystemSkill() {
                   if (canWrite) setUploadOpen(true)
                 }}
                 canWrite={canWrite}
+                ratingUpdate={ratingUpdate}
               />
             ),
           },
@@ -57,6 +59,11 @@ export default function SystemSkill() {
         open={!!detailId}
         onClose={() => setDetailId(null)}
         onDeleted={refresh}
+        onRatingChanged={(id, rating) => setRatingUpdate((current) => ({
+          id,
+          rating,
+          sequence: (current?.sequence ?? 0) + 1,
+        }))}
         onEdit={(skill) => {
           if (!canWrite) return
           setDetailId(null)

--- a/src/pages/SystemSkill/index.tsx
+++ b/src/pages/SystemSkill/index.tsx
@@ -60,7 +60,10 @@ export default function SystemSkill() {
         open={!!detailId}
         onClose={() => setDetailId(null)}
         onDeleted={refresh}
-        onRatingChanged={(id, rating) => recordRatingOverride(ratingLedger, id, rating)}
+        onRatingChanged={(id, rating) => {
+          recordRatingOverride(ratingLedger, id, rating)
+          refresh()
+        }}
         onEdit={(skill) => {
           if (!canWrite) return
           setDetailId(null)

--- a/src/utils/ratingOverrides.test.ts
+++ b/src/utils/ratingOverrides.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { mergeRatingOverrides, recordRatingOverride } from './ratingOverrides'
+
+type Row = { id: string; name: string; rating: number | null }
+
+describe('rating overrides', () => {
+  it('keeps a committed rating when an in-flight stale snapshot lands later', () => {
+    const overrides = new Map<string, number | null>()
+    recordRatingOverride(overrides, 'a', 5)
+
+    expect(mergeRatingOverrides<Row>([
+      { id: 'a', name: 'stale', rating: 2 },
+    ], overrides, (row) => row.id)).toEqual([
+      { id: 'a', name: 'stale', rating: 5 },
+    ])
+    expect(overrides.get('a')).toBe(5)
+  })
+
+  it('preserves search and pagination results instead of merging old rows', () => {
+    const overrides = new Map<string, number | null>([['a', 4]])
+    const page = [
+      { id: 'b', name: 'search result', rating: 3 },
+      { id: 'c', name: 'next page', rating: null },
+    ]
+
+    const merged = mergeRatingOverrides(page, overrides, (row) => row.id)
+
+    expect(merged).toEqual(page)
+    expect(merged).toHaveLength(2)
+    expect(overrides.get('a')).toBe(4)
+  })
+
+  it('drops an override after the server response confirms it', () => {
+    const overrides = new Map<string, number | null>([['a', null]])
+    const row = { id: 'a', name: 'confirmed', rating: null }
+
+    expect(mergeRatingOverrides([row], overrides, (item) => item.id)[0]).toBe(row)
+    expect(overrides.has('a')).toBe(false)
+  })
+})

--- a/src/utils/ratingOverrides.test.ts
+++ b/src/utils/ratingOverrides.test.ts
@@ -1,40 +1,60 @@
 import { describe, expect, it } from 'vitest'
-import { mergeRatingOverrides, recordRatingOverride } from './ratingOverrides'
+import {
+  createRatingOverrideLedger,
+  mergeRatingOverrides,
+  ratingOverrideSequence,
+  recordRatingOverride,
+} from './ratingOverrides'
 
 type Row = { id: string; name: string; rating: number | null }
 
 describe('rating overrides', () => {
-  it('keeps a committed rating when an in-flight stale snapshot lands later', () => {
-    const overrides = new Map<string, number | null>()
-    recordRatingOverride(overrides, 'a', 5)
+  it('keeps a committed rating when it was written after the request started', () => {
+    const ledger = createRatingOverrideLedger()
+    const seenSequence = ratingOverrideSequence(ledger)
+    recordRatingOverride(ledger, 'a', 5)
 
     expect(mergeRatingOverrides<Row>([
       { id: 'a', name: 'stale', rating: 2 },
-    ], overrides, (row) => row.id)).toEqual([
+    ], ledger, seenSequence, (row) => row.id)).toEqual([
       { id: 'a', name: 'stale', rating: 5 },
     ])
-    expect(overrides.get('a')).toBe(5)
+    expect(ledger.overrides.get('a')?.rating).toBe(5)
   })
 
-  it('preserves search and pagination results instead of merging old rows', () => {
-    const overrides = new Map<string, number | null>([['a', 4]])
-    const page = [
-      { id: 'b', name: 'search result', rating: 3 },
-      { id: 'c', name: 'next page', rating: null },
-    ]
+  it('trusts the server and clears an override written before the request', () => {
+    const ledger = createRatingOverrideLedger()
+    recordRatingOverride(ledger, 'a', 5)
+    const seenSequence = ratingOverrideSequence(ledger)
+    const row = { id: 'a', name: 'authoritative', rating: 2 }
 
-    const merged = mergeRatingOverrides(page, overrides, (row) => row.id)
-
-    expect(merged).toEqual(page)
-    expect(merged).toHaveLength(2)
-    expect(overrides.get('a')).toBe(4)
+    expect(mergeRatingOverrides([row], ledger, seenSequence, (item) => item.id)[0]).toBe(row)
+    expect(ledger.overrides.has('a')).toBe(false)
   })
 
-  it('drops an override after the server response confirms it', () => {
-    const overrides = new Map<string, number | null>([['a', null]])
-    const row = { id: 'a', name: 'confirmed', rating: null }
+  it('uses the newest write when multiple mutations race one response', () => {
+    const ledger = createRatingOverrideLedger()
+    recordRatingOverride(ledger, 'a', 3)
+    const seenSequence = ratingOverrideSequence(ledger)
+    recordRatingOverride(ledger, 'a', 4)
+    recordRatingOverride(ledger, 'a', 5)
 
-    expect(mergeRatingOverrides([row], overrides, (item) => item.id)[0]).toBe(row)
-    expect(overrides.has('a')).toBe(false)
+    const merged = mergeRatingOverrides(
+      [{ id: 'a', name: 'stale', rating: 3 }],
+      ledger,
+      seenSequence,
+      (row) => row.id,
+    )
+    expect(merged[0].rating).toBe(5)
+  })
+
+  it('preserves search results and unrelated overrides', () => {
+    const ledger = createRatingOverrideLedger()
+    recordRatingOverride(ledger, 'a', 4)
+    const seenSequence = ratingOverrideSequence(ledger)
+    const page = [{ id: 'b', name: 'search result', rating: 3 }]
+
+    expect(mergeRatingOverrides(page, ledger, seenSequence, (row) => row.id)).toEqual(page)
+    expect(ledger.overrides.get('a')?.rating).toBe(4)
   })
 })

--- a/src/utils/ratingOverrides.ts
+++ b/src/utils/ratingOverrides.ts
@@ -1,0 +1,40 @@
+export type RatingOverrideMap = Map<string, number | null>
+
+/**
+ * Record a locally committed rating before updating the visible rows. Keeping
+ * this separate from the current page means a later list response cannot
+ * restore a stale server snapshot.
+ */
+export function recordRatingOverride(
+  overrides: RatingOverrideMap,
+  id: string,
+  rating: number | null,
+): void {
+  overrides.set(id, rating)
+}
+
+/**
+ * Merge server-owned list results with locally committed rating mutations.
+ *
+ * An override is retained while the server still returns an older value and is
+ * removed once a response confirms the mutation. Only matching rows' ratings
+ * are changed: search and pagination results (including their order and all
+ * other fields) remain exactly as returned by the server.
+ */
+export function mergeRatingOverrides<T extends { rating: number | null }>(
+  items: T[],
+  overrides: RatingOverrideMap,
+  getId: (item: T) => string,
+): T[] {
+  return items.map((item) => {
+    const id = getId(item)
+    if (!overrides.has(id)) return item
+
+    const rating = overrides.get(id)!
+    if (item.rating === rating) {
+      overrides.delete(id)
+      return item
+    }
+    return { ...item, rating }
+  })
+}

--- a/src/utils/ratingOverrides.ts
+++ b/src/utils/ratingOverrides.ts
@@ -1,40 +1,52 @@
-export type RatingOverrideMap = Map<string, number | null>
+export interface RatingOverride {
+  rating: number | null
+  sequence: number
+}
 
-/**
- * Record a locally committed rating before updating the visible rows. Keeping
- * this separate from the current page means a later list response cannot
- * restore a stale server snapshot.
- */
+export interface RatingOverrideLedger {
+  sequence: number
+  overrides: Map<string, RatingOverride>
+}
+
+export function createRatingOverrideLedger(): RatingOverrideLedger {
+  return { sequence: 0, overrides: new Map() }
+}
+
+/** Record a locally committed rating with a process-local recency token. */
 export function recordRatingOverride(
-  overrides: RatingOverrideMap,
+  ledger: RatingOverrideLedger,
   id: string,
   rating: number | null,
 ): void {
-  overrides.set(id, rating)
+  ledger.sequence += 1
+  ledger.overrides.set(id, { rating, sequence: ledger.sequence })
+}
+
+/** Capture this immediately before starting a list request. */
+export function ratingOverrideSequence(ledger: RatingOverrideLedger): number {
+  return ledger.sequence
 }
 
 /**
- * Merge server-owned list results with locally committed rating mutations.
- *
- * An override is retained while the server still returns an older value and is
- * removed once a response confirms the mutation. Only matching rows' ratings
- * are changed: search and pagination results (including their order and all
- * other fields) remain exactly as returned by the server.
+ * Reconcile a server response against mutations made while that request was in
+ * flight. Overrides newer than the request win; older overrides are retired and
+ * the response is authoritative, even when its value differs.
  */
 export function mergeRatingOverrides<T extends { rating: number | null }>(
   items: T[],
-  overrides: RatingOverrideMap,
+  ledger: RatingOverrideLedger,
+  seenSequence: number,
   getId: (item: T) => string,
 ): T[] {
   return items.map((item) => {
     const id = getId(item)
-    if (!overrides.has(id)) return item
+    const override = ledger.overrides.get(id)
+    if (!override) return item
 
-    const rating = overrides.get(id)!
-    if (item.rating === rating) {
-      overrides.delete(id)
+    if (override.sequence <= seenSequence) {
+      ledger.overrides.delete(id)
       return item
     }
-    return { ...item, rating }
+    return item.rating === override.rating ? item : { ...item, rating: override.rating }
   })
 }


### PR DESCRIPTION
## Summary

- add reusable plugin rating and metrics UI for MCP, expert, squad, and skill administration
- support nullable 1–5 ratings in create/edit/upload flows with explicit partial-success handling
- show ratings, views, and relevant usage counters in list/detail views
- protect list/detail state from stale asynchronous responses and prevent rating controls from opening row details
- omit the Skill Market description and install-count columns per the latest product feedback

## Linked Spec / Issue

Fixes #153

Backend dependency: Mininglamp-OSS/octo-marketplace#79 (which is stacked on marketplace #77).

## Verification

- `npm test` — 30 files / 350 tests passed
- `npm run build`
- `git diff --check`

## COMPREHENSION

1. **Load-bearing behavior:** only users with each module's existing write capability see rating controls; display remains read-only for other users. The client uses the dedicated backend rating endpoint.
2. **Partial failure:** content creation/update may commit before rating. Rating failures are reported as partial success, refresh authoritative data, and never invite duplicate creation. Expert container retries retain the created plugin ID; ambiguous aborts are marked non-retryable until the list is reconciled.
3. **Async correctness:** stale detail/list responses cannot replace newer selections or searches. Rating updates patch the matching local row without cancelling legitimate in-flight filter/page requests.
